### PR TITLE
Fix FleetManager API calls and vehicle spawning

### DIFF
--- a/apps/simulator/src/__tests__/VehicleManager.test.ts
+++ b/apps/simulator/src/__tests__/VehicleManager.test.ts
@@ -401,6 +401,108 @@ describe("VehicleManager", () => {
     });
   });
 
+  // ─── Fleet assignment ────────────────────────────────────────────
+
+  describe("fleet assignment", () => {
+    it("should assign a vehicle to a fleet", () => {
+      const fleetManager = (manager as any).fleets as import("../modules/FleetManager").FleetManager;
+      const fleet = fleetManager.createFleet("TestFleet");
+      const vehicle = firstVehicle();
+
+      const result = manager.assignVehicleToFleet(vehicle.id, fleet.id);
+
+      expect(result).toBe(true);
+      expect(vehicle.fleetId).toBe(fleet.id);
+      expect(fleetManager.getVehicleFleetId(vehicle.id)).toBe(fleet.id);
+    });
+
+    it("should emit update event when assigning to fleet", () => {
+      const fleetManager = (manager as any).fleets as import("../modules/FleetManager").FleetManager;
+      const fleet = fleetManager.createFleet("TestFleet");
+      const vehicle = firstVehicle();
+      const listener = vi.fn();
+      manager.on("update", listener);
+
+      manager.assignVehicleToFleet(vehicle.id, fleet.id);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ id: vehicle.id }));
+    });
+
+    it("should return false when assigning non-existent vehicle", () => {
+      const fleetManager = (manager as any).fleets as import("../modules/FleetManager").FleetManager;
+      const fleet = fleetManager.createFleet("TestFleet");
+
+      const result = manager.assignVehicleToFleet("non-existent-id", fleet.id);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when assigning to non-existent fleet", () => {
+      const vehicle = firstVehicle();
+
+      const result = manager.assignVehicleToFleet(vehicle.id, "non-existent-fleet");
+
+      expect(result).toBe(false);
+    });
+
+    it("should unassign a vehicle from its fleet", () => {
+      const fleetManager = (manager as any).fleets as import("../modules/FleetManager").FleetManager;
+      const fleet = fleetManager.createFleet("TestFleet");
+      const vehicle = firstVehicle();
+      manager.assignVehicleToFleet(vehicle.id, fleet.id);
+
+      const result = manager.unassignVehicleFromFleet(vehicle.id);
+
+      expect(result).toBe(true);
+      expect(vehicle.fleetId).toBeUndefined();
+      expect(fleetManager.getVehicleFleetId(vehicle.id)).toBeUndefined();
+    });
+
+    it("should emit update event when unassigning from fleet", () => {
+      const fleetManager = (manager as any).fleets as import("../modules/FleetManager").FleetManager;
+      const fleet = fleetManager.createFleet("TestFleet");
+      const vehicle = firstVehicle();
+      manager.assignVehicleToFleet(vehicle.id, fleet.id);
+
+      const listener = vi.fn();
+      manager.on("update", listener);
+
+      manager.unassignVehicleFromFleet(vehicle.id);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ id: vehicle.id }));
+    });
+
+    it("should return false when unassigning non-existent vehicle", () => {
+      const result = manager.unassignVehicleFromFleet("non-existent-id");
+
+      expect(result).toBe(false);
+    });
+
+    it("should return false when unassigning vehicle not in any fleet", () => {
+      const vehicle = firstVehicle();
+
+      const result = manager.unassignVehicleFromFleet(vehicle.id);
+
+      expect(result).toBe(false);
+    });
+
+    it("should move vehicle between fleets", () => {
+      const fleetManager = (manager as any).fleets as import("../modules/FleetManager").FleetManager;
+      const fleetA = fleetManager.createFleet("FleetA");
+      const fleetB = fleetManager.createFleet("FleetB");
+      const vehicle = firstVehicle();
+
+      manager.assignVehicleToFleet(vehicle.id, fleetA.id);
+      expect(vehicle.fleetId).toBe(fleetA.id);
+
+      manager.assignVehicleToFleet(vehicle.id, fleetB.id);
+      expect(vehicle.fleetId).toBe(fleetB.id);
+      expect(fleetManager.getVehicleFleetId(vehicle.id)).toBe(fleetB.id);
+    });
+  });
+
   // ─── getNetwork ───────────────────────────────────────────────────
 
   describe("getNetwork", () => {

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -248,11 +248,8 @@ export class RoadNetwork extends EventEmitter {
   }
 
   public getRandomNode(): Node {
-    // Sample a random point in the bounding box and find the nearest node.
-    // This gives uniform spatial distribution regardless of road density.
-    const lat = this.bbox.minLat + Math.random() * (this.bbox.maxLat - this.bbox.minLat);
-    const lon = this.bbox.minLon + Math.random() * (this.bbox.maxLon - this.bbox.minLon);
-    return this.findNearestNode([lat, lon]);
+    const nodes = Array.from(this.nodes.values());
+    return nodes[Math.floor(Math.random() * nodes.length)];
   }
 
   /**

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -50,8 +50,9 @@ export class RoadNetwork extends EventEmitter {
   // Network bounding box for uniform spatial sampling
   private bbox = { minLat: Infinity, maxLat: -Infinity, minLon: Infinity, maxLon: -Infinity };
 
-  // Coarse geographic sectors for uniform spawn distribution
+  // Coarse geographic sectors for uniform spawn/destination distribution
   private sectorEdges: Edge[][] = [];
+  private sectorNodes: Node[][] = [];
 
   constructor(geojsonPath: string) {
     super();
@@ -92,29 +93,40 @@ export class RoadNetwork extends EventEmitter {
 
   private buildSectorIndex(): void {
     // Divide the bbox into a SECTORS_N × SECTORS_N coarse grid.
-    // Assign edges to sectors by their start node position.
-    // Sectors with any edges get one entry — so each geographic region
-    // has equal weight regardless of road density.
+    // Assign edges AND nodes to sectors by position.
+    // Each occupied sector gets equal weight regardless of road density,
+    // so both spawning and destination selection are geographically uniform.
     const SECTORS_N = 10;
     const { minLat, maxLat, minLon, maxLon } = this.bbox;
     const latStep = (maxLat - minLat) / SECTORS_N;
     const lonStep = (maxLon - minLon) / SECTORS_N;
 
-    const sectorMap = new Map<number, Edge[]>();
+    const edgeSectorMap = new Map<number, Edge[]>();
+    const nodeSectorMap = new Map<number, Node[]>();
+
     for (const edge of this.edges.values()) {
       if (edge.start.connections.length === 0) continue;
       const [lat, lon] = edge.start.coordinates;
       const row = Math.min(Math.floor((lat - minLat) / latStep), SECTORS_N - 1);
       const col = Math.min(Math.floor((lon - minLon) / lonStep), SECTORS_N - 1);
       const key = row * SECTORS_N + col;
-      let bucket = sectorMap.get(key);
-      if (!bucket) {
-        bucket = [];
-        sectorMap.set(key, bucket);
-      }
+      let bucket = edgeSectorMap.get(key);
+      if (!bucket) { bucket = []; edgeSectorMap.set(key, bucket); }
       bucket.push(edge);
     }
-    this.sectorEdges = Array.from(sectorMap.values());
+
+    for (const node of this.nodes.values()) {
+      const [lat, lon] = node.coordinates;
+      const row = Math.min(Math.floor((lat - minLat) / latStep), SECTORS_N - 1);
+      const col = Math.min(Math.floor((lon - minLon) / lonStep), SECTORS_N - 1);
+      const key = row * SECTORS_N + col;
+      let bucket = nodeSectorMap.get(key);
+      if (!bucket) { bucket = []; nodeSectorMap.set(key, bucket); }
+      bucket.push(node);
+    }
+
+    this.sectorEdges = Array.from(edgeSectorMap.values());
+    this.sectorNodes = Array.from(nodeSectorMap.values());
   }
 
   public getAllRoads(): Road[] {
@@ -278,9 +290,36 @@ export class RoadNetwork extends EventEmitter {
   }
 
   public getRandomNode(): Node {
-    // For destination picking: pick uniformly over all nodes.
-    const nodes = Array.from(this.nodes.values());
-    return nodes[Math.floor(Math.random() * nodes.length)];
+    // Sector-based: pick a random occupied sector, then a random node within it.
+    // Gives geographic coverage proportional to area, not road density.
+    const bucket = this.sectorNodes[Math.floor(Math.random() * this.sectorNodes.length)];
+    return bucket[Math.floor(Math.random() * bucket.length)];
+  }
+
+  public getRandomPOINode(): Node | null {
+    // Sector-based POI selection: pick a random sector that has POI nodes,
+    // then pick a random POI node from it — not biased by POI density.
+    const poiNodes = this.getPOINodes();
+    if (poiNodes.length === 0) return null;
+
+    // Bucket POI nodes by sector
+    const { minLat, maxLat, minLon, maxLon } = this.bbox;
+    const SECTORS_N = 10;
+    const latStep = (maxLat - minLat) / SECTORS_N;
+    const lonStep = (maxLon - minLon) / SECTORS_N;
+    const poiSectors = new Map<number, Node[]>();
+    for (const node of poiNodes) {
+      const [lat, lon] = node.coordinates;
+      const row = Math.min(Math.floor((lat - minLat) / latStep), SECTORS_N - 1);
+      const col = Math.min(Math.floor((lon - minLon) / lonStep), SECTORS_N - 1);
+      const key = row * SECTORS_N + col;
+      let bucket = poiSectors.get(key);
+      if (!bucket) { bucket = []; poiSectors.set(key, bucket); }
+      bucket.push(node);
+    }
+    const buckets = Array.from(poiSectors.values());
+    const bucket = buckets[Math.floor(Math.random() * buckets.length)];
+    return bucket[Math.floor(Math.random() * bucket.length)];
   }
 
   /**

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -50,12 +50,16 @@ export class RoadNetwork extends EventEmitter {
   // Network bounding box for uniform spatial sampling
   private bbox = { minLat: Infinity, maxLat: -Infinity, minLon: Infinity, maxLon: -Infinity };
 
+  // Coarse geographic sectors for uniform spawn distribution
+  private sectorEdges: Edge[][] = [];
+
   constructor(geojsonPath: string) {
     super();
     this.data = JSON.parse(fs.readFileSync(geojsonPath, "utf8")) as FeatureCollection;
     this.buildNetwork(this.data);
     this.computeBbox();
     this.buildSpatialIndex();
+    this.buildSectorIndex();
   }
 
   private computeBbox(): void {
@@ -84,6 +88,33 @@ export class RoadNetwork extends EventEmitter {
     const gx = Math.floor(lat / this.gridCellSize);
     const gy = Math.floor(lon / this.gridCellSize);
     return `${gx},${gy}`;
+  }
+
+  private buildSectorIndex(): void {
+    // Divide the bbox into a SECTORS_N × SECTORS_N coarse grid.
+    // Assign edges to sectors by their start node position.
+    // Sectors with any edges get one entry — so each geographic region
+    // has equal weight regardless of road density.
+    const SECTORS_N = 10;
+    const { minLat, maxLat, minLon, maxLon } = this.bbox;
+    const latStep = (maxLat - minLat) / SECTORS_N;
+    const lonStep = (maxLon - minLon) / SECTORS_N;
+
+    const sectorMap = new Map<number, Edge[]>();
+    for (const edge of this.edges.values()) {
+      if (edge.start.connections.length === 0) continue;
+      const [lat, lon] = edge.start.coordinates;
+      const row = Math.min(Math.floor((lat - minLat) / latStep), SECTORS_N - 1);
+      const col = Math.min(Math.floor((lon - minLon) / lonStep), SECTORS_N - 1);
+      const key = row * SECTORS_N + col;
+      let bucket = sectorMap.get(key);
+      if (!bucket) {
+        bucket = [];
+        sectorMap.set(key, bucket);
+      }
+      bucket.push(edge);
+    }
+    this.sectorEdges = Array.from(sectorMap.values());
   }
 
   public getAllRoads(): Road[] {
@@ -238,16 +269,16 @@ export class RoadNetwork extends EventEmitter {
   }
 
   public getRandomEdge(): Edge {
-    const node = this.getRandomNode();
-    if (node.connections.length > 0) {
-      return node.connections[Math.floor(Math.random() * node.connections.length)];
-    }
-    // Fallback: uniform random edge
-    const edges = Array.from(this.edges.values());
-    return edges[Math.floor(Math.random() * edges.length)];
+    // Geographic sector normalization: pick a random occupied sector
+    // (10×10 coarse grid over the bbox), then pick a random edge within it.
+    // Each geographic region of the map gets equal probability regardless
+    // of how many roads are in it.
+    const bucket = this.sectorEdges[Math.floor(Math.random() * this.sectorEdges.length)];
+    return bucket[Math.floor(Math.random() * bucket.length)];
   }
 
   public getRandomNode(): Node {
+    // For destination picking: pick uniformly over all nodes.
     const nodes = Array.from(this.nodes.values());
     return nodes[Math.floor(Math.random() * nodes.length)];
   }

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -628,23 +628,29 @@ export class VehicleManager extends EventEmitter {
   public assignVehicleToFleet(vehicleId: string, fleetId: string): boolean {
     const vehicle = this.vehicles.get(vehicleId);
     if (!vehicle) return false;
-    const result = this.fleets.assign(fleetId, vehicleId);
-    if (result) {
+    try {
+      this.fleets.assignVehicles(fleetId, [vehicleId]);
       vehicle.fleetId = fleetId;
       this.emit("update", serializeVehicle(vehicle));
+      return true;
+    } catch {
+      return false;
     }
-    return result;
   }
 
   public unassignVehicleFromFleet(vehicleId: string): boolean {
     const vehicle = this.vehicles.get(vehicleId);
     if (!vehicle) return false;
-    const result = this.fleets.unassign(vehicleId);
-    if (result) {
+    const fleetId = this.fleets.getVehicleFleetId(vehicleId);
+    if (!fleetId) return false;
+    try {
+      this.fleets.unassignVehicles(fleetId, [vehicleId]);
       vehicle.fleetId = undefined;
       this.emit("update", serializeVehicle(vehicle));
+      return true;
+    } catch {
+      return false;
     }
-    return result;
   }
 
   public getVehicles(): VehicleDTO[] {

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -182,10 +182,11 @@ export class VehicleManager extends EventEmitter {
   }
 
   private pickDestination(): Node {
-    const poiNodes = this.network.getPOINodes();
-    // 80% chance to pick a POI, 20% chance for random node
-    if (poiNodes.length > 0 && Math.random() < 0.8) {
-      return poiNodes[Math.floor(Math.random() * poiNodes.length)];
+    // 60% chance to pick a sector-normalized POI, 40% chance for a sector-normalized random node.
+    // Both use sector-based selection so destinations are spread across the whole map.
+    if (Math.random() < 0.6) {
+      const poiNode = this.network.getRandomPOINode();
+      if (poiNode) return poiNode;
     }
     return this.network.getRandomNode();
   }

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -6,7 +6,7 @@ import Vehicles from "./Controls/Vehicles";
 import Fleets from "./Controls/Fleets";
 import AdapterDrawer from "./Controls/Adapter/AdapterDrawer";
 import { useAdapterConfig } from "./Controls/Adapter/useAdapterConfig";
-import Map from "./Map/Map";
+import MapView from "./Map/Map";
 import FleetLegend from "./Map/FleetLegend";
 import SearchBar from "./SearchBar";
 import Zoom from "./Zoom/";
@@ -219,7 +219,7 @@ export default function App() {
               Disconnected — attempting to reconnect...
             </div>
           )}
-          <Map
+          <MapView
             animFreq={status.interval}
             vehicles={vehicles}
             filters={filters}

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -73,6 +73,7 @@ export default function Map({
       {modifiers.showVehicles &&
         vehicles
           ?.filter((vehicle) => {
+            if (vehicle.position[0] === 0 && vehicle.position[1] === 0) return false;
             const fleet = vehicleFleetMap.get(vehicle.id);
             return !fleet || !hiddenFleetIds.has(fleet.id);
           })


### PR DESCRIPTION
## Summary
- **Fix broken fleet assignment**: `VehicleManager` called non-existent `.assign()`/`.unassign()` methods on `FleetManager` — replaced with correct `.assignVehicles()`/`.unassignVehicles()` API (fixes CI lint+build failures)
- **Fix vehicle spawning distribution**: Sector-normalize spawn nodes and destinations so vehicles spread across the whole map instead of clustering
- **Fix UI Map naming conflict**: Rename `Map` import to `MapView` to avoid shadowing the built-in `Map` constructor
- **Hide vehicles until positioned**: Don't render vehicles before they have a real coordinate

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` succeeds
- [x] All 171 tests pass (9 new tests for fleet assign/unassign covering success, error, and edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)