### PR TITLE
feat: multi-stop waypoint routing with chained A* pathfinding

### DIFF
--- a/apps/simulator/package.json
+++ b/apps/simulator/package.json
@@ -2,6 +2,7 @@
   "name": "@moveet/simulator",
   "version": "0.0.3",
   "description": "Vehicle location simulator for fleet management systems using real road networks from OpenStreetMap",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",

--- a/apps/simulator/src/__tests__/waypoint-routing.test.ts
+++ b/apps/simulator/src/__tests__/waypoint-routing.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { VehicleManager } from "../modules/VehicleManager";
+import { FleetManager } from "../modules/FleetManager";
+import { SimulationController } from "../modules/SimulationController";
+import { RoadNetwork } from "../modules/RoadNetwork";
+import { config } from "../utils/config";
+import type { Waypoint } from "../types";
+import path from "path";
+
+vi.mock("../utils/logger", () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
+
+describe("Multi-stop waypoint routing", () => {
+  let network: RoadNetwork;
+  let manager: VehicleManager;
+  let controller: SimulationController;
+  let origAdapterURL: string;
+  let origVehicleCount: number;
+
+  function placeOnRoutableEdge(vehicleId: string): void {
+    const internalVehicle = (manager as any).vehicles.get(vehicleId);
+    const startNode = network.findNearestNode([45.502, -73.567]);
+    const startEdge = startNode.connections[0];
+    internalVehicle.currentEdge = startEdge;
+    internalVehicle.position = startEdge.start.coordinates;
+    internalVehicle.progress = 0;
+  }
+
+  beforeEach(() => {
+    origAdapterURL = config.adapterURL;
+    origVehicleCount = config.vehicleCount;
+    (config as any).vehicleCount = 3;
+    (config as any).adapterURL = "";
+
+    network = new RoadNetwork(FIXTURE_PATH);
+
+    const origProto = VehicleManager.prototype as any;
+    const origSetRandom = origProto.setRandomDestination;
+    origProto.setRandomDestination = function () {};
+
+    manager = new VehicleManager(network, new FleetManager());
+
+    origProto.setRandomDestination = origSetRandom;
+    controller = new SimulationController(manager);
+  });
+
+  afterEach(async () => {
+    const vehicles = manager.getVehicles();
+    for (const v of vehicles) {
+      manager.stopVehicleMovement(v.id);
+    }
+    manager.stopLocationUpdates();
+    await network.shutdownWorkers();
+    (config as any).adapterURL = origAdapterURL;
+    (config as any).vehicleCount = origVehicleCount;
+    vi.restoreAllMocks();
+  });
+
+  // ─── Single-destination backward compatibility ─────────────────────
+
+  describe("backward compatibility", () => {
+    it("should still work with single lat/lng destination (no waypoints)", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      const results = await controller.setDirections([
+        { id: vehicleId, lat: 45.5029, lng: -73.5661 },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("ok");
+      expect(results[0].route).toBeDefined();
+      expect(results[0].waypointCount).toBeUndefined();
+      expect(results[0].legs).toBeUndefined();
+    });
+
+    it("should ignore waypoints field when it is an empty array", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      const results = await controller.setDirections([
+        { id: vehicleId, lat: 45.5029, lng: -73.5661, waypoints: [] },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("ok");
+      expect(results[0].waypointCount).toBeUndefined();
+    });
+  });
+
+  // ─── Multi-waypoint dispatch ────────────────────────────────────────
+
+  describe("multi-waypoint dispatch", () => {
+    it("should return ok with waypointCount and legs for multi-stop route", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      const results = await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661, label: "Pickup" },
+            { lat: 45.5026, lng: -73.5664, label: "Delivery" },
+          ],
+        },
+      ]);
+
+      expect(results).toHaveLength(1);
+      const result = results[0];
+      expect(result.status).toBe("ok");
+      expect(result.waypointCount).toBe(2);
+      expect(result.legs).toHaveLength(2);
+      expect(result.legs![0].distance).toBeGreaterThan(0);
+      expect(result.legs![1].distance).toBeGreaterThan(0);
+      expect(result.route!.distance).toBe(result.legs![0].distance + result.legs![1].distance);
+    });
+
+    it("should set waypoint state on the vehicle", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661, label: "A" },
+            { lat: 45.5026, lng: -73.5664, label: "B" },
+          ],
+        },
+      ]);
+
+      const internalVehicle = (manager as any).vehicles.get(vehicleId);
+      expect(internalVehicle.waypoints).toHaveLength(2);
+      expect(internalVehicle.currentWaypointIndex).toBe(0);
+      expect(internalVehicle.waypoints[0].label).toBe("A");
+      expect(internalVehicle.waypoints[1].label).toBe("B");
+    });
+
+    it("should return error for non-existent vehicle", async () => {
+      const results = await controller.setDirections([
+        {
+          id: "nonexistent",
+          lat: 0,
+          lng: 0,
+          waypoints: [{ lat: 45.5029, lng: -73.5661 }],
+        },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("error");
+      expect(results[0].error).toContain("nonexistent");
+    });
+  });
+
+  // ─── Waypoint progression ──────────────────────────────────────────
+
+  describe("waypoint progression", () => {
+    it("should emit waypoint:reached when vehicle completes a leg", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661, label: "WP1", dwellTime: 1 },
+            { lat: 45.5026, lng: -73.5664, label: "WP2" },
+          ],
+        },
+      ]);
+
+      const waypointEvents: any[] = [];
+      const routeCompleteEvents: any[] = [];
+      manager.on("waypoint:reached", (data) => waypointEvents.push(data));
+      manager.on("route:completed", (data) => routeCompleteEvents.push(data));
+
+      // Simulate reaching the end of leg 0 by calling handleRouteCompleted directly
+      const vehicle = (manager as any).vehicles.get(vehicleId);
+      (manager as any).handleRouteCompleted(vehicle);
+
+      expect(waypointEvents).toHaveLength(1);
+      expect(waypointEvents[0].vehicleId).toBe(vehicleId);
+      expect(waypointEvents[0].waypointIndex).toBe(0);
+      expect(waypointEvents[0].waypointLabel).toBe("WP1");
+      expect(waypointEvents[0].remaining).toBe(1);
+
+      // Should set up the next leg
+      expect(vehicle.currentWaypointIndex).toBe(1);
+      expect(vehicle.dwellUntil).toBeDefined();
+    });
+
+    it("should emit route:completed when final waypoint is reached", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [{ lat: 45.5029, lng: -73.5661, label: "Only" }],
+        },
+      ]);
+
+      const routeCompleteEvents: any[] = [];
+      manager.on("route:completed", (data) => routeCompleteEvents.push(data));
+
+      const vehicle = (manager as any).vehicles.get(vehicleId);
+      (manager as any).handleRouteCompleted(vehicle);
+
+      expect(routeCompleteEvents).toHaveLength(1);
+      expect(routeCompleteEvents[0].vehicleId).toBe(vehicleId);
+
+      // Waypoint state should be cleared
+      expect(vehicle.waypoints).toBeUndefined();
+      expect(vehicle.currentWaypointIndex).toBeUndefined();
+    });
+
+    it("should use configured dwellTime at waypoints", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      const customDwell = 30; // 30 seconds
+      await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661, dwellTime: customDwell },
+            { lat: 45.5026, lng: -73.5664 },
+          ],
+        },
+      ]);
+
+      const vehicle = (manager as any).vehicles.get(vehicleId);
+      const beforeDwell = Date.now();
+      (manager as any).handleRouteCompleted(vehicle);
+
+      // dwellUntil should be approximately now + customDwell seconds
+      const dwellDelta = vehicle.dwellUntil! - beforeDwell;
+      expect(dwellDelta).toBeGreaterThanOrEqual(customDwell * 1000 - 100);
+      expect(dwellDelta).toBeLessThanOrEqual(customDwell * 1000 + 100);
+    });
+  });
+
+  // ─── getDirections with waypoint metadata ───────────────────────────
+
+  describe("getDirections with waypoint metadata", () => {
+    it("should include waypoints and currentWaypointIndex in directions", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661, label: "Stop1" },
+            { lat: 45.5026, lng: -73.5664, label: "Stop2" },
+          ],
+        },
+      ]);
+
+      const directions = manager.getDirections();
+      const dir = directions.find((d) => d.vehicleId === vehicleId);
+      expect(dir).toBeDefined();
+      expect(dir!.waypoints).toHaveLength(2);
+      expect(dir!.waypoints![0].label).toBe("Stop1");
+      expect(dir!.currentWaypointIndex).toBe(0);
+    });
+
+    it("should not include waypoint metadata for single-destination routes", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      await controller.setDirections([
+        { id: vehicleId, lat: 45.5029, lng: -73.5661 },
+      ]);
+
+      const directions = manager.getDirections();
+      const dir = directions.find((d) => d.vehicleId === vehicleId);
+      expect(dir).toBeDefined();
+      expect(dir!.waypoints).toBeUndefined();
+      expect(dir!.currentWaypointIndex).toBeUndefined();
+    });
+  });
+
+  // ─── Chained A* pathfinding ─────────────────────────────────────────
+
+  describe("chained A* pathfinding", () => {
+    it("should return error when one leg is unroutable", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      // Mock findRouteAsync to fail on the second call
+      let callCount = 0;
+      const origFindRoute = network.findRouteAsync.bind(network);
+      vi.spyOn(network, "findRouteAsync").mockImplementation(async (...args) => {
+        callCount++;
+        if (callCount === 2) return null; // fail second leg
+        return origFindRoute(...args);
+      });
+
+      const results = await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661 },
+            { lat: 45.5026, lng: -73.5664 },
+          ],
+        },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("error");
+      expect(results[0].error).toContain("leg");
+    });
+
+    it("should handle single waypoint (one leg)", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      const results = await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [{ lat: 45.5029, lng: -73.5661, label: "Only stop" }],
+        },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("ok");
+      expect(results[0].waypointCount).toBe(1);
+      expect(results[0].legs).toHaveLength(1);
+    });
+  });
+
+  // ─── Direction event emission ───────────────────────────────────────
+
+  describe("direction event", () => {
+    it("should emit direction event with waypoints and currentWaypointIndex", async () => {
+      const vehicles = manager.getVehicles();
+      const vehicleId = vehicles[0].id;
+      placeOnRoutableEdge(vehicleId);
+
+      const directionEvents: any[] = [];
+      manager.on("direction", (data) => directionEvents.push(data));
+
+      await controller.setDirections([
+        {
+          id: vehicleId,
+          lat: 0,
+          lng: 0,
+          waypoints: [
+            { lat: 45.5029, lng: -73.5661, label: "A" },
+            { lat: 45.5026, lng: -73.5664, label: "B" },
+          ],
+        },
+      ]);
+
+      // Find the direction event from waypoint routing (not from setRandomDestination)
+      const wpEvent = directionEvents.find((e) => e.waypoints);
+      expect(wpEvent).toBeDefined();
+      expect(wpEvent.vehicleId).toBe(vehicleId);
+      expect(wpEvent.waypoints).toHaveLength(2);
+      expect(wpEvent.currentWaypointIndex).toBe(0);
+      expect(wpEvent.eta).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/simulator/src/__tests__/waypoint-routing.test.ts
+++ b/apps/simulator/src/__tests__/waypoint-routing.test.ts
@@ -4,7 +4,6 @@ import { FleetManager } from "../modules/FleetManager";
 import { SimulationController } from "../modules/SimulationController";
 import { RoadNetwork } from "../modules/RoadNetwork";
 import { config } from "../utils/config";
-import type { Waypoint } from "../types";
 import path from "path";
 
 vi.mock("../utils/logger", () => ({
@@ -297,9 +296,7 @@ describe("Multi-stop waypoint routing", () => {
       const vehicleId = vehicles[0].id;
       placeOnRoutableEdge(vehicleId);
 
-      await controller.setDirections([
-        { id: vehicleId, lat: 45.5029, lng: -73.5661 },
-      ]);
+      await controller.setDirections([{ id: vehicleId, lat: 45.5029, lng: -73.5661 }]);
 
       const directions = manager.getDirections();
       const dir = directions.find((d) => d.vehicleId === vehicleId);

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -411,12 +411,8 @@ async function main() {
   // Non-vehicle events are broadcast immediately
   network.on("heatzones", (data) => broadcaster.broadcast("heatzones", data));
   vehicleManager.on("direction", (data) => broadcaster.broadcast("direction", data));
-  vehicleManager.on("waypoint:reached", (data) =>
-    broadcaster.broadcast("waypoint:reached", data)
-  );
-  vehicleManager.on("route:completed", (data) =>
-    broadcaster.broadcast("route:completed", data)
-  );
+  vehicleManager.on("waypoint:reached", (data) => broadcaster.broadcast("waypoint:reached", data));
+  vehicleManager.on("route:completed", (data) => broadcaster.broadcast("route:completed", data));
   vehicleManager.on("options", (data) => broadcaster.broadcast("options", data));
   simulationController.on("updateStatus", (data) => broadcaster.broadcast("status", data));
   simulationController.on("reset", (data) => broadcaster.broadcast("reset", data));

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -136,39 +136,63 @@ app.post(
         continue;
       }
 
-      // Validate lat/lng fields are numeric
-      if (typeof item.lat !== "number" || isNaN(item.lat)) {
-        errors.push(`[${i}]: 'lat' must be a valid number`);
-      }
-      if (typeof item.lng !== "number" || isNaN(item.lng)) {
-        errors.push(`[${i}]: 'lng' must be a valid number`);
-      }
-
-      // Skip further validation if lat/lng are not valid numbers
-      if (
-        typeof item.lat !== "number" ||
-        isNaN(item.lat) ||
-        typeof item.lng !== "number" ||
-        isNaN(item.lng)
-      ) {
-        continue;
-      }
-
       // Validate vehicle ID exists
       if (!vehicleManager.hasVehicle(item.id)) {
         errors.push(`[${i}]: vehicle '${item.id}' not found`);
+        continue;
       }
 
-      // Validate coordinates are within network bounds (with margin)
-      if (
-        item.lat < bbox.minLat - MARGIN ||
-        item.lat > bbox.maxLat + MARGIN ||
-        item.lng < bbox.minLon - MARGIN ||
-        item.lng > bbox.maxLon + MARGIN
-      ) {
-        errors.push(
-          `[${i}]: coordinates (${item.lat}, ${item.lng}) are outside the road network bounds`
-        );
+      if (Array.isArray(item.waypoints) && item.waypoints.length > 0) {
+        // Multi-stop waypoint validation
+        for (let j = 0; j < item.waypoints.length; j++) {
+          const wp = item.waypoints[j];
+          if (typeof wp.lat !== "number" || isNaN(wp.lat)) {
+            errors.push(`[${i}].waypoints[${j}]: 'lat' must be a valid number`);
+            continue;
+          }
+          if (typeof wp.lng !== "number" || isNaN(wp.lng)) {
+            errors.push(`[${i}].waypoints[${j}]: 'lng' must be a valid number`);
+            continue;
+          }
+          if (
+            wp.lat < bbox.minLat - MARGIN ||
+            wp.lat > bbox.maxLat + MARGIN ||
+            wp.lng < bbox.minLon - MARGIN ||
+            wp.lng > bbox.maxLon + MARGIN
+          ) {
+            errors.push(
+              `[${i}].waypoints[${j}]: coordinates (${wp.lat}, ${wp.lng}) are outside the road network bounds`
+            );
+          }
+        }
+      } else {
+        // Single-destination validation (backward compat)
+        if (typeof item.lat !== "number" || isNaN(item.lat)) {
+          errors.push(`[${i}]: 'lat' must be a valid number`);
+        }
+        if (typeof item.lng !== "number" || isNaN(item.lng)) {
+          errors.push(`[${i}]: 'lng' must be a valid number`);
+        }
+
+        if (
+          typeof item.lat !== "number" ||
+          isNaN(item.lat) ||
+          typeof item.lng !== "number" ||
+          isNaN(item.lng)
+        ) {
+          continue;
+        }
+
+        if (
+          item.lat < bbox.minLat - MARGIN ||
+          item.lat > bbox.maxLat + MARGIN ||
+          item.lng < bbox.minLon - MARGIN ||
+          item.lng > bbox.maxLon + MARGIN
+        ) {
+          errors.push(
+            `[${i}]: coordinates (${item.lat}, ${item.lng}) are outside the road network bounds`
+          );
+        }
       }
     }
 
@@ -387,6 +411,12 @@ async function main() {
   // Non-vehicle events are broadcast immediately
   network.on("heatzones", (data) => broadcaster.broadcast("heatzones", data));
   vehicleManager.on("direction", (data) => broadcaster.broadcast("direction", data));
+  vehicleManager.on("waypoint:reached", (data) =>
+    broadcaster.broadcast("waypoint:reached", data)
+  );
+  vehicleManager.on("route:completed", (data) =>
+    broadcaster.broadcast("route:completed", data)
+  );
   vehicleManager.on("options", (data) => broadcaster.broadcast("options", data));
   simulationController.on("updateStatus", (data) => broadcaster.broadcast("status", data));
   simulationController.on("reset", (data) => broadcaster.broadcast("reset", data));

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -147,9 +147,21 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
   async setDirections(requests: DirectionRequest[]): Promise<DirectionResult[]> {
     const results: DirectionResult[] = [];
     for (const request of requests) {
-      const { id, lat, lng } = request;
-      const result = await this.vehicleManager.findAndSetRoutes(id, [lat, lng]);
-      results.push(result);
+      const { id, lat, lng, waypoints } = request;
+      if (waypoints && waypoints.length > 0) {
+        // Multi-stop routing: convert WaypointRequest[] to Waypoint[]
+        const waypointPositions = waypoints.map((wp) => ({
+          position: [wp.lat, wp.lng] as [number, number],
+          dwellTime: wp.dwellTime,
+          label: wp.label,
+        }));
+        const result = await this.vehicleManager.findAndSetWaypointRoutes(id, waypointPositions);
+        results.push(result);
+      } else {
+        // Single-destination routing (backward compat)
+        const result = await this.vehicleManager.findAndSetRoutes(id, [lat, lng]);
+        results.push(result);
+      }
     }
     return results;
   }

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -701,7 +701,7 @@ export class VehicleManager extends EventEmitter {
 
       if (wpIndex < vehicle.waypoints.length - 1) {
         // More waypoints — dwell at this waypoint, then start next leg
-        const dwellSeconds = waypoint?.dwellTime ?? (10 + Math.random() * 50);
+        const dwellSeconds = waypoint?.dwellTime ?? 10 + Math.random() * 50;
         vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
         vehicle.speed = this.options.minSpeed;
 
@@ -717,7 +717,7 @@ export class VehicleManager extends EventEmitter {
         // Final waypoint reached
         this.emit("route:completed", { vehicleId: vehicle.id });
         this.clearWaypointState(vehicle);
-        const dwellSeconds = waypoint?.dwellTime ?? (10 + Math.random() * 50);
+        const dwellSeconds = waypoint?.dwellTime ?? 10 + Math.random() * 50;
         vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
         vehicle.speed = this.options.minSpeed;
         this.routes.delete(vehicle.id);

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -8,6 +8,8 @@ import type {
   Direction,
   DirectionResult,
   StartOptions,
+  Waypoint,
+  MultiStopRoute,
 } from "../types";
 import { VEHICLE_CONSTANTS } from "../constants";
 import type { RoadNetwork } from "./RoadNetwork";
@@ -25,6 +27,7 @@ export class VehicleManager extends EventEmitter {
   private vehicles: Map<string, Vehicle> = new Map();
   private visitedEdges: Map<string, CircularBuffer<string>> = new Map();
   private routes: Map<string, Route> = new Map();
+  private waypointRoutes: Map<string, MultiStopRoute> = new Map();
   private locationInterval: NodeJS.Timeout | null = null;
   private lastUpdateTimes: Map<string, number> = new Map();
   private lastPathfindAttempt: Map<string, number> = new Map();
@@ -140,6 +143,7 @@ export class VehicleManager extends EventEmitter {
     this.vehicles = new Map();
     this.visitedEdges = new Map();
     this.routes = new Map();
+    this.waypointRoutes = new Map();
     this.vehiclesByEdge = new Map();
     this.fleets.reset();
 
@@ -665,18 +669,77 @@ export class VehicleManager extends EventEmitter {
           edgeIndex: edgeIndex + 1,
         };
       } else {
-        // Reached destination — dwell before picking new route
-        const dwellSeconds = 10 + Math.random() * 50; // 10-60 seconds
-        vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
-        vehicle.speed = this.options.minSpeed;
-        this.routes.delete(vehicle.id);
-        return null;
+        // Reached end of current route segment
+        return this.handleRouteCompleted(vehicle);
       }
     } else {
       // Random movement
       const nextEdge = this.getNextEdge(vehicle);
       return { edge: nextEdge };
     }
+  }
+
+  /**
+   * Handles when a vehicle completes its current route segment.
+   * For multi-stop routes, advances to the next waypoint leg.
+   * For single-destination routes, dwells and picks a new random destination.
+   */
+  private handleRouteCompleted(vehicle: Vehicle): null {
+    const multiRoute = this.waypointRoutes.get(vehicle.id);
+
+    if (multiRoute && vehicle.waypoints && vehicle.currentWaypointIndex !== undefined) {
+      const wpIndex = vehicle.currentWaypointIndex;
+      const waypoint = vehicle.waypoints[wpIndex];
+      const remaining = vehicle.waypoints.length - wpIndex - 1;
+
+      this.emit("waypoint:reached", {
+        vehicleId: vehicle.id,
+        waypointIndex: wpIndex,
+        waypointLabel: waypoint?.label,
+        remaining,
+      });
+
+      if (wpIndex < vehicle.waypoints.length - 1) {
+        // More waypoints — dwell at this waypoint, then start next leg
+        const dwellSeconds = waypoint?.dwellTime ?? (10 + Math.random() * 50);
+        vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
+        vehicle.speed = this.options.minSpeed;
+
+        // Set up the next leg route so updateVehicle picks it up after dwell
+        const nextLeg = multiRoute.legs[wpIndex + 1];
+        if (nextLeg) {
+          this.routes.set(vehicle.id, { edges: nextLeg.edges, distance: nextLeg.distance });
+          vehicle.currentWaypointIndex = wpIndex + 1;
+          vehicle.edgeIndex = -1;
+        }
+        return null;
+      } else {
+        // Final waypoint reached
+        this.emit("route:completed", { vehicleId: vehicle.id });
+        this.clearWaypointState(vehicle);
+        const dwellSeconds = waypoint?.dwellTime ?? (10 + Math.random() * 50);
+        vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
+        vehicle.speed = this.options.minSpeed;
+        this.routes.delete(vehicle.id);
+        return null;
+      }
+    }
+
+    // Single-destination route: dwell before picking new route
+    const dwellSeconds = 10 + Math.random() * 50;
+    vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
+    vehicle.speed = this.options.minSpeed;
+    this.routes.delete(vehicle.id);
+    return null;
+  }
+
+  /**
+   * Clears all waypoint-related state for a vehicle.
+   */
+  private clearWaypointState(vehicle: Vehicle): void {
+    vehicle.waypoints = undefined;
+    vehicle.currentWaypointIndex = undefined;
+    this.waypointRoutes.delete(vehicle.id);
   }
 
   /**
@@ -769,15 +832,110 @@ export class VehicleManager extends EventEmitter {
   }
 
   /**
-   * Gets all vehicles with their current state as DTOs for external consumption.
-   * Converts internal vehicle representation to simplified transfer objects.
-   *
-   * @returns Array of vehicle DTOs containing position, speed, and heading
-   *
-   * @example
-   * const vehicles = vehicleManager.getVehicles();
-   * vehicles.forEach(v => console.log(`${v.name}: ${v.speed}km/h at [${v.position}]`));
+   * Calculates and sets a multi-stop route through waypoints.
+   * Computes A* routes between consecutive waypoints (current position → wp1 → wp2 → ...).
+   * Emits 'direction' event with the full stitched route and waypoint metadata.
    */
+  public async findAndSetWaypointRoutes(
+    vehicleId: string,
+    waypoints: Waypoint[]
+  ): Promise<DirectionResult> {
+    const vehicle = this.vehicles.get(vehicleId);
+    if (!vehicle) {
+      return { vehicleId, status: "error", error: `Vehicle ${vehicleId} not found` };
+    }
+
+    if (waypoints.length === 0) {
+      return { vehicleId, status: "error", error: "No waypoints provided" };
+    }
+
+    // Build ordered positions: [current position, wp1, wp2, ...]
+    const positions: [number, number][] = [vehicle.position, ...waypoints.map((wp) => wp.position)];
+    const legs: { edges: Edge[]; distance: number; waypointIndex: number }[] = [];
+    const legResults: { start: [number, number]; end: [number, number]; distance: number }[] = [];
+
+    // Compute A* for each consecutive pair
+    for (let i = 0; i < positions.length - 1; i++) {
+      const startNode = this.network.findNearestNode(positions[i]);
+      const endNode = this.network.findNearestNode(positions[i + 1]);
+
+      if (startNode.connections.length === 0 || endNode.connections.length === 0) {
+        return {
+          vehicleId,
+          status: "error",
+          error: `Waypoint ${i} has no connected road nearby`,
+          snappedTo: endNode.coordinates,
+        };
+      }
+
+      const route = await this.network.findRouteAsync(startNode, endNode);
+      if (!route || route.edges.length === 0) {
+        return {
+          vehicleId,
+          status: "error",
+          error: `No route found for leg ${i} (waypoint ${i} → ${i + 1})`,
+          snappedTo: endNode.coordinates,
+        };
+      }
+
+      legs.push({ edges: route.edges, distance: route.distance, waypointIndex: i });
+      legResults.push({
+        start: startNode.coordinates,
+        end: endNode.coordinates,
+        distance: route.distance,
+      });
+    }
+
+    const totalDistance = legs.reduce((sum, leg) => sum + leg.distance, 0);
+    const allEdges = legs.flatMap((leg) => leg.edges);
+
+    // Store multi-stop route state
+    const multiRoute: MultiStopRoute = { legs, totalDistance };
+    this.waypointRoutes.set(vehicleId, multiRoute);
+
+    // Set waypoint state on vehicle
+    vehicle.waypoints = waypoints;
+    vehicle.currentWaypointIndex = 0;
+
+    // Set the first leg as the active route
+    const firstLeg = legs[0];
+    const stitchedRoute: Route = { edges: allEdges, distance: totalDistance };
+    this.routes.set(vehicleId, { edges: firstLeg.edges, distance: firstLeg.distance });
+
+    // Snap vehicle to start of first leg
+    const previousEdgeId = vehicle.currentEdge.id;
+    this.traffic.leave(previousEdgeId);
+    vehicle.currentEdge = firstLeg.edges[0];
+    this.traffic.enter(vehicle.currentEdge.id);
+    this.moveInEdgeIndex(vehicleId, previousEdgeId, vehicle.currentEdge.id);
+    vehicle.progress = 0;
+    vehicle.edgeIndex = 0;
+
+    const eta = utils.estimateRouteDuration(stitchedRoute, vehicle.speed);
+
+    this.emit("direction", {
+      vehicleId,
+      route: utils.nonCircularRouteEdges(stitchedRoute),
+      eta,
+      waypoints,
+      currentWaypointIndex: 0,
+    });
+
+    return {
+      vehicleId,
+      status: "ok",
+      route: {
+        start: legResults[0].start,
+        end: legResults[legResults.length - 1].end,
+        distance: totalDistance,
+      },
+      eta,
+      snappedTo: legResults[legResults.length - 1].end,
+      waypointCount: waypoints.length,
+      legs: legResults,
+    };
+  }
+
   public assignVehicleToFleet(vehicleId: string, fleetId: string): boolean {
     const vehicle = this.vehicles.get(vehicleId);
     if (!vehicle) return false;
@@ -832,11 +990,19 @@ export class VehicleManager extends EventEmitter {
    * console.log(`${directions.length} vehicles have active routes`);
    */
   public getDirections(): Direction[] {
-    return Array.from(this.routes.entries()).map(([id, route]) => ({
-      vehicleId: id,
-      route: utils.nonCircularRouteEdges(route),
-      eta: utils.estimateRouteDuration(route, this.vehicles.get(id)!.speed),
-    }));
+    return Array.from(this.routes.entries()).map(([id, route]) => {
+      const vehicle = this.vehicles.get(id)!;
+      const direction: Direction = {
+        vehicleId: id,
+        route: utils.nonCircularRouteEdges(route),
+        eta: utils.estimateRouteDuration(route, vehicle.speed),
+      };
+      if (vehicle.waypoints) {
+        direction.waypoints = vehicle.waypoints;
+        direction.currentWaypointIndex = vehicle.currentWaypointIndex;
+      }
+      return direction;
+    });
   }
 
   /**

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -134,6 +134,7 @@ export interface Waypoint {
 export interface Direction {
   vehicleId: string;
   route: Route;
+  eta?: number;
   waypoints?: Waypoint[];
   currentWaypointIndex?: number;
 }

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -52,6 +52,8 @@ export interface Vehicle {
   dwellUntil?: number; // timestamp (ms) when vehicle should resume moving
   targetSpeed?: number; // desired speed, changes every few seconds
   fleetId?: string;
+  waypoints?: Waypoint[]; // ordered waypoint sequence for multi-stop routing
+  currentWaypointIndex?: number; // index of current target waypoint in waypoints[]
 }
 
 export interface VehicleDTO {
@@ -87,6 +89,17 @@ export interface Route {
   distance: number;
 }
 
+export interface RouteLeg {
+  edges: Edge[];
+  distance: number;
+  waypointIndex: number; // which waypoint this leg leads to
+}
+
+export interface MultiStopRoute {
+  legs: RouteLeg[];
+  totalDistance: number;
+}
+
 export interface StartOptions {
   minSpeed: number;
   maxSpeed: number;
@@ -98,15 +111,31 @@ export interface StartOptions {
   updateInterval: number;
 }
 
+export interface WaypointRequest {
+  lat: number;
+  lng: number;
+  dwellTime?: number; // seconds to dwell at this waypoint (default: 10-60s random)
+  label?: string;
+}
+
 export interface DirectionRequest {
   id: string;
   lat: number;
   lng: number;
+  waypoints?: WaypointRequest[]; // if provided, lat/lng is ignored and waypoints are used
+}
+
+export interface Waypoint {
+  position: [number, number];
+  dwellTime?: number;
+  label?: string;
 }
 
 export interface Direction {
   vehicleId: string;
   route: Route;
+  waypoints?: Waypoint[];
+  currentWaypointIndex?: number;
 }
 
 export interface BoundingBox {
@@ -127,6 +156,8 @@ export interface DirectionResult {
   };
   eta?: number;
   snappedTo?: [number, number];
+  waypointCount?: number;
+  legs?: { start: [number, number]; end: [number, number]; distance: number }[];
 }
 
 export interface HeatZoneProperties {

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -19,6 +19,7 @@ import type {
   Position,
   Road,
   SimulationStatus,
+  Waypoint,
 } from "./types";
 import styles from "./App.module.css";
 import { useVehicles } from "./hooks/useVehicles";
@@ -100,30 +101,67 @@ export default function App() {
   const onMapClick = useCallback(
     (_event?: React.MouseEvent, position?: Position) => {
       if (dispatchMode && position && selectedForDispatch.length > 0) {
-        const waypoint = { position: [position[1], position[0]] as [number, number] };
-        const newAssignments: DispatchAssignment[] = selectedForDispatch
-          .filter((id) => !assignments.some((a) => a.vehicleId === id))
-          .map((id) => {
-            const vehicle = vehicles.find((v) => v.id === id);
-            return {
-              vehicleId: id,
-              vehicleName: vehicle?.name ?? id,
-              waypoints: [waypoint],
-            };
+        const newWaypoint: Waypoint = { position: [position[1], position[0]] };
+
+        setAssignments((prev) => {
+          // Append waypoint to existing assignments for selected vehicles
+          const updated = prev.map((a) => {
+            if (!selectedForDispatch.includes(a.vehicleId)) return a;
+            return { ...a, waypoints: [...a.waypoints, newWaypoint] };
           });
-        if (newAssignments.length > 0) {
-          setAssignments((prev) => [...prev, ...newAssignments]);
-        }
-        setSelectedForDispatch([]);
+
+          // Create new assignments for vehicles not yet assigned
+          const existingIds = new Set(updated.map((a) => a.vehicleId));
+          const newAssignments: DispatchAssignment[] = selectedForDispatch
+            .filter((id) => !existingIds.has(id))
+            .map((id) => {
+              const vehicle = vehicles.find((v) => v.id === id);
+              return {
+                vehicleId: id,
+                vehicleName: vehicle?.name ?? id,
+                waypoints: [newWaypoint],
+              };
+            });
+
+          return [...updated, ...newAssignments];
+        });
+        // Do NOT clear selectedForDispatch — user can keep adding waypoints
         return;
       }
       clearMap();
     },
-    [clearMap, dispatchMode, selectedForDispatch, assignments, vehicles]
+    [clearMap, dispatchMode, selectedForDispatch, vehicles]
   );
 
   const onRemoveAssignment = useCallback((vehicleId: string) => {
     setAssignments((prev) => prev.filter((a) => a.vehicleId !== vehicleId));
+  }, []);
+
+  const onAddWaypoint = useCallback((vehicleId: string, position: Position) => {
+    const newWaypoint: Waypoint = { position: [position[1], position[0]] };
+    setAssignments((prev) =>
+      prev.map((a) => {
+        if (a.vehicleId !== vehicleId) return a;
+        return { ...a, waypoints: [...a.waypoints, newWaypoint] };
+      })
+    );
+  }, []);
+  void onAddWaypoint; // Will be wired to context menu in a follow-up
+
+  const onRemoveWaypoint = useCallback((vehicleId: string, waypointIndex: number) => {
+    setAssignments((prev) => {
+      const result: DispatchAssignment[] = [];
+      for (const a of prev) {
+        if (a.vehicleId !== vehicleId) {
+          result.push(a);
+          continue;
+        }
+        const waypoints = a.waypoints.filter((_, i) => i !== waypointIndex);
+        if (waypoints.length === 0) continue; // Remove entire assignment
+        result.push({ ...a, waypoints });
+      }
+      return result;
+    });
   }, []);
 
   const onClearAllAssignments = useCallback(() => {
@@ -338,6 +376,7 @@ export default function App() {
                 <BatchDispatch
                   assignments={assignments}
                   onRemoveAssignment={onRemoveAssignment}
+                  onRemoveWaypoint={onRemoveWaypoint}
                   onClearAll={onClearAllAssignments}
                   onClose={onToggleDispatchPanel}
                   vehicles={vehicles}

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -146,7 +146,35 @@ export default function App() {
       })
     );
   }, []);
-  void onAddWaypoint; // Will be wired to context menu in a follow-up
+
+  const onContextMenuAddWaypoint = useCallback(() => {
+    if (!destination) return;
+    const assignedIds = new Set(assignments.map((a) => a.vehicleId));
+
+    for (const id of selectedForDispatch) {
+      if (assignedIds.has(id)) {
+        onAddWaypoint(id, destination);
+      }
+    }
+
+    const newAssignments: DispatchAssignment[] = selectedForDispatch
+      .filter((id) => !assignedIds.has(id))
+      .map((id) => {
+        const vehicle = vehicles.find((v) => v.id === id);
+        const newWaypoint: Waypoint = { position: [destination[1], destination[0]] };
+        return {
+          vehicleId: id,
+          vehicleName: vehicle?.name ?? id,
+          waypoints: [newWaypoint],
+        };
+      });
+
+    if (newAssignments.length > 0) {
+      setAssignments((prev) => [...prev, ...newAssignments]);
+    }
+
+    closeContextMenu();
+  }, [destination, selectedForDispatch, assignments, vehicles, onAddWaypoint, closeContextMenu]);
 
   const onRemoveWaypoint = useCallback((vehicleId: string, waypointIndex: number) => {
     setAssignments((prev) => {
@@ -419,6 +447,9 @@ export default function App() {
             <Button onClick={onFindRoadClick}>Identify closest road</Button>
             {filters.selected && (
               <Button onClick={onPointDestinationSingleClick}>Send selected vehicle here</Button>
+            )}
+            {dispatchMode && selectedForDispatch.length > 0 && (
+              <Button onClick={onContextMenuAddWaypoint}>Add waypoint here</Button>
             )}
           </div>
         </ContextMenu>

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -100,6 +100,7 @@ export default function App() {
   const onMapClick = useCallback(
     (_event?: React.MouseEvent, position?: Position) => {
       if (dispatchMode && position && selectedForDispatch.length > 0) {
+        const waypoint = { position: [position[1], position[0]] as [number, number] };
         const newAssignments: DispatchAssignment[] = selectedForDispatch
           .filter((id) => !assignments.some((a) => a.vehicleId === id))
           .map((id) => {
@@ -107,7 +108,7 @@ export default function App() {
             return {
               vehicleId: id,
               vehicleName: vehicle?.name ?? id,
-              destination: [position[1], position[0]] as [number, number],
+              waypoints: [waypoint],
             };
           });
         if (newAssignments.length > 0) {

--- a/apps/ui/src/Controls/BatchDispatch.module.css
+++ b/apps/ui/src/Controls/BatchDispatch.module.css
@@ -359,3 +359,117 @@
   font-size: var(--text-xs);
   color: var(--color-gray-light);
 }
+
+.doneButton {
+  display: block;
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-3);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  font-weight: 500;
+  color: var(--color-white);
+  background: rgba(57, 153, 255, 0.15);
+  border: 1px solid rgba(57, 153, 255, 0.3);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.doneButton:hover {
+  background: rgba(57, 153, 255, 0.25);
+  border-color: rgba(57, 153, 255, 0.5);
+}
+
+.assignmentGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.waypointBadge {
+  background: rgba(57, 153, 255, 0.2);
+  border: 1px solid rgba(57, 153, 255, 0.3);
+  border-radius: var(--radius-xs);
+  color: rgba(57, 153, 255, 0.9);
+  font-size: var(--text-xs);
+  font-family: inherit;
+  padding: 1px var(--space-2);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1.4;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.waypointBadge:hover {
+  background: rgba(57, 153, 255, 0.3);
+  color: var(--color-white);
+}
+
+.waypointList {
+  display: flex;
+  flex-direction: column;
+  margin-left: var(--space-4);
+  padding: var(--space-1) 0;
+  border-left: 1px solid rgba(57, 153, 255, 0.15);
+}
+
+.waypointRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-gray-light);
+}
+
+.waypointRow:hover {
+  background: var(--surface-bg-hover);
+}
+
+.waypointIndex {
+  width: 16px;
+  text-align: center;
+  color: var(--color-gray);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.waypointCoords {
+  font-variant-numeric: tabular-nums;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.waypointLabel {
+  color: rgba(57, 153, 255, 0.7);
+  font-size: var(--text-xs);
+  flex-shrink: 0;
+}
+
+.waypointRemove {
+  background: none;
+  border: none;
+  color: var(--color-gray);
+  cursor: pointer;
+  padding: 0 var(--space-1);
+  font-size: var(--text-xs);
+  line-height: 1;
+  border-radius: var(--radius-xs);
+  flex-shrink: 0;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.waypointRemove:hover {
+  color: #f44;
+  background: rgba(255, 68, 68, 0.1);
+}

--- a/apps/ui/src/Controls/BatchDispatch.module.css
+++ b/apps/ui/src/Controls/BatchDispatch.module.css
@@ -473,3 +473,27 @@
   color: #f44;
   background: rgba(255, 68, 68, 0.1);
 }
+
+.resultExpandable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.resultExpandable:hover {
+  filter: brightness(1.15);
+}
+
+.legList {
+  display: flex;
+  flex-direction: column;
+  padding-left: var(--space-6, 24px);
+  margin-top: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+
+.legRow {
+  font-size: var(--text-xs);
+  color: var(--color-gray-light);
+  padding: var(--space-1) var(--space-2);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}

--- a/apps/ui/src/Controls/BatchDispatch.tsx
+++ b/apps/ui/src/Controls/BatchDispatch.tsx
@@ -7,6 +7,7 @@ import styles from "./BatchDispatch.module.css";
 interface BatchDispatchProps {
   assignments: DispatchAssignment[];
   onRemoveAssignment: (vehicleId: string) => void;
+  onRemoveWaypoint: (vehicleId: string, waypointIndex: number) => void;
   onClearAll: () => void;
   onClose: () => void;
   vehicles: Vehicle[];
@@ -21,6 +22,7 @@ interface BatchDispatchProps {
 export default function BatchDispatch({
   assignments,
   onRemoveAssignment,
+  onRemoveWaypoint,
   onClearAll,
   onClose,
   vehicles,
@@ -34,6 +36,19 @@ export default function BatchDispatch({
   const [results, setResults] = useState<DirectionResult[]>([]);
   const [dispatching, setDispatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [expandedAssignments, setExpandedAssignments] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((vehicleId: string) => {
+    setExpandedAssignments((prev) => {
+      const next = new Set(prev);
+      if (next.has(vehicleId)) {
+        next.delete(vehicleId);
+      } else {
+        next.add(vehicleId);
+      }
+      return next;
+    });
+  }, []);
 
   const handleDispatch = useCallback(async () => {
     if (assignments.length === 0) return;
@@ -104,6 +119,12 @@ export default function BatchDispatch({
         </span>
       </button>
 
+      {isDispatchMode && assignments.length > 0 && (
+        <button type="button" className={styles.doneButton} onClick={onToggleDispatchMode}>
+          Done adding waypoints
+        </button>
+      )}
+
       {isDispatchMode && availableVehicles.length > 0 && (
         <div className={styles.vehiclePicker}>
           <div className={styles.vehiclePickerHeader}>
@@ -167,23 +188,59 @@ export default function BatchDispatch({
         ) : (
           assignments.map((assignment) => {
             const dest = assignment.waypoints[assignment.waypoints.length - 1];
+            const waypointCount = assignment.waypoints.length;
+            const isExpanded = expandedAssignments.has(assignment.vehicleId);
+
             return (
-              <div key={assignment.vehicleId} className={styles.assignment}>
-                <span className={styles.assignmentName}>{assignment.vehicleName}</span>
-                <span className={styles.assignmentArrow}>&rarr;</span>
-                <span className={styles.assignmentCoords}>
-                  {assignment.waypoints.length > 1
-                    ? `${assignment.waypoints.length} stops`
-                    : `${dest.position[0].toFixed(4)}, ${dest.position[1].toFixed(4)}`}
-                </span>
-                <button
-                  className={styles.removeButton}
-                  onClick={() => onRemoveAssignment(assignment.vehicleId)}
-                  type="button"
-                  title="Remove assignment"
-                >
-                  x
-                </button>
+              <div key={assignment.vehicleId} className={styles.assignmentGroup}>
+                <div className={styles.assignment}>
+                  <span className={styles.assignmentName}>{assignment.vehicleName}</span>
+                  <span className={styles.assignmentArrow}>&rarr;</span>
+                  <span className={styles.assignmentCoords}>
+                    {waypointCount > 1
+                      ? `${waypointCount} stops`
+                      : `${dest.position[0].toFixed(4)}, ${dest.position[1].toFixed(4)}`}
+                  </span>
+                  {waypointCount > 1 && (
+                    <button
+                      type="button"
+                      className={styles.waypointBadge}
+                      onClick={() => toggleExpanded(assignment.vehicleId)}
+                      title={isExpanded ? "Collapse waypoints" : "Expand waypoints"}
+                    >
+                      {waypointCount} pts
+                    </button>
+                  )}
+                  <button
+                    className={styles.removeButton}
+                    onClick={() => onRemoveAssignment(assignment.vehicleId)}
+                    type="button"
+                    title="Remove assignment"
+                  >
+                    x
+                  </button>
+                </div>
+                {waypointCount > 1 && isExpanded && (
+                  <div className={styles.waypointList}>
+                    {assignment.waypoints.map((wp, i) => (
+                      <div key={i} className={styles.waypointRow}>
+                        <span className={styles.waypointIndex}>{i + 1}</span>
+                        <span className={styles.waypointCoords}>
+                          {wp.position[0].toFixed(4)}, {wp.position[1].toFixed(4)}
+                        </span>
+                        {wp.label && <span className={styles.waypointLabel}>{wp.label}</span>}
+                        <button
+                          type="button"
+                          className={styles.waypointRemove}
+                          onClick={() => onRemoveWaypoint(assignment.vehicleId, i)}
+                          title={`Remove waypoint ${i + 1}`}
+                        >
+                          x
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             );
           })

--- a/apps/ui/src/Controls/BatchDispatch.tsx
+++ b/apps/ui/src/Controls/BatchDispatch.tsx
@@ -41,11 +41,24 @@ export default function BatchDispatch({
     setResults([]);
     setError(null);
 
-    const body = assignments.map((a) => ({
-      id: a.vehicleId,
-      lat: a.destination[0],
-      lng: a.destination[1],
-    }));
+    const body = assignments.map((a) => {
+      const dest = a.waypoints[a.waypoints.length - 1];
+      return {
+        id: a.vehicleId,
+        lat: dest.position[0],
+        lng: dest.position[1],
+        ...(a.waypoints.length > 1
+          ? {
+              waypoints: a.waypoints.map((wp) => ({
+                lat: wp.position[0],
+                lng: wp.position[1],
+                ...(wp.label ? { label: wp.label } : {}),
+                ...(wp.dwellTime != null ? { dwellTime: wp.dwellTime } : {}),
+              })),
+            }
+          : {}),
+      };
+    });
 
     const response = await client.batchDirection(body);
     setDispatching(false);
@@ -152,23 +165,28 @@ export default function BatchDispatch({
               : "No pending assignments"}
           </div>
         ) : (
-          assignments.map((assignment) => (
-            <div key={assignment.vehicleId} className={styles.assignment}>
-              <span className={styles.assignmentName}>{assignment.vehicleName}</span>
-              <span className={styles.assignmentArrow}>&rarr;</span>
-              <span className={styles.assignmentCoords}>
-                {assignment.destination[0].toFixed(4)}, {assignment.destination[1].toFixed(4)}
-              </span>
-              <button
-                className={styles.removeButton}
-                onClick={() => onRemoveAssignment(assignment.vehicleId)}
-                type="button"
-                title="Remove assignment"
-              >
-                x
-              </button>
-            </div>
-          ))
+          assignments.map((assignment) => {
+            const dest = assignment.waypoints[assignment.waypoints.length - 1];
+            return (
+              <div key={assignment.vehicleId} className={styles.assignment}>
+                <span className={styles.assignmentName}>{assignment.vehicleName}</span>
+                <span className={styles.assignmentArrow}>&rarr;</span>
+                <span className={styles.assignmentCoords}>
+                  {assignment.waypoints.length > 1
+                    ? `${assignment.waypoints.length} stops`
+                    : `${dest.position[0].toFixed(4)}, ${dest.position[1].toFixed(4)}`}
+                </span>
+                <button
+                  className={styles.removeButton}
+                  onClick={() => onRemoveAssignment(assignment.vehicleId)}
+                  type="button"
+                  title="Remove assignment"
+                >
+                  x
+                </button>
+              </div>
+            );
+          })
         )}
       </div>
 

--- a/apps/ui/src/Controls/BatchDispatch.tsx
+++ b/apps/ui/src/Controls/BatchDispatch.tsx
@@ -37,9 +37,22 @@ export default function BatchDispatch({
   const [dispatching, setDispatching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expandedAssignments, setExpandedAssignments] = useState<Set<string>>(new Set());
+  const [expandedResults, setExpandedResults] = useState<Set<string>>(new Set());
 
   const toggleExpanded = useCallback((vehicleId: string) => {
     setExpandedAssignments((prev) => {
+      const next = new Set(prev);
+      if (next.has(vehicleId)) {
+        next.delete(vehicleId);
+      } else {
+        next.add(vehicleId);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleResultExpanded = useCallback((vehicleId: string) => {
+    setExpandedResults((prev) => {
       const next = new Set(prev);
       if (next.has(vehicleId)) {
         next.delete(vehicleId);
@@ -257,22 +270,55 @@ export default function BatchDispatch({
         <div className={styles.results}>
           {results.map((result) => {
             const vehicle = vehicles.find((v) => v.id === result.vehicleId);
+            const hasLegs = result.legs != null && result.legs.length > 0;
+            const isExpanded = expandedResults.has(result.vehicleId);
+            const totalDistance =
+              result.waypointCount != null && result.route?.distance != null
+                ? (result.route.distance / 1000).toFixed(1)
+                : null;
+
+            const buildDetail = () => {
+              if (result.status !== "ok") return result.error ?? "Failed";
+              const parts: string[] = [];
+              if (result.waypointCount != null) {
+                parts.push(
+                  `${result.waypointCount} stop${result.waypointCount !== 1 ? "s" : ""}${totalDistance != null ? `, ${totalDistance} km` : ""}`
+                );
+              }
+              if (result.eta != null) {
+                parts.push(`ETA ${result.eta.toFixed(0)}s`);
+              }
+              if (parts.length > 0) return parts.join(" \u00B7 ");
+              return "Dispatched";
+            };
+
             return (
-              <div
-                key={result.vehicleId}
-                className={classNames(styles.resultRow, {
-                  [styles.resultOk]: result.status === "ok",
-                  [styles.resultError]: result.status === "error",
-                })}
-              >
-                <span className={styles.resultName}>{vehicle?.name ?? result.vehicleId}</span>
-                <span className={styles.resultDetail}>
-                  {result.status === "ok"
-                    ? result.eta != null
-                      ? `ETA ${result.eta.toFixed(0)}s`
-                      : "Dispatched"
-                    : (result.error ?? "Failed")}
-                </span>
+              <div key={result.vehicleId}>
+                <div
+                  className={classNames(styles.resultRow, {
+                    [styles.resultOk]: result.status === "ok",
+                    [styles.resultError]: result.status === "error",
+                    [styles.resultExpandable]: hasLegs,
+                  })}
+                  onClick={hasLegs ? () => toggleResultExpanded(result.vehicleId) : undefined}
+                >
+                  <span className={styles.resultName}>{vehicle?.name ?? result.vehicleId}</span>
+                  <span className={styles.resultDetail}>{buildDetail()}</span>
+                  {hasLegs && (
+                    <span className={styles.resultDetail}>
+                      {isExpanded ? "\u25B4" : "\u25BE"}
+                    </span>
+                  )}
+                </div>
+                {hasLegs && isExpanded && (
+                  <div className={styles.legList}>
+                    {result.legs!.map((leg, i) => (
+                      <div key={i} className={styles.legRow}>
+                        Leg {i + 1}: {(leg.distance / 1000).toFixed(1)} km
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             );
           })}

--- a/apps/ui/src/Controls/Vehicles.test.tsx
+++ b/apps/ui/src/Controls/Vehicles.test.tsx
@@ -121,7 +121,7 @@ describe("VehicleList", () => {
           },
           roads: [],
           pois: [],
-          directions: new Map([["v1", route]]),
+          directions: new Map([["v1", { route }]]),
           heatzones: [],
           network: { type: "FeatureCollection", features: [] },
           setOptions: vi.fn(),

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -85,7 +85,7 @@ export default function VehicleList({
           </div>
         ) : (
           visibleVehicles.map((vehicle) => {
-            const routeDistance = directions.get(vehicle.id)?.distance;
+            const routeDistance = directions.get(vehicle.id)?.route.distance;
             const vehicleFleet = fleets.find((f) => f.vehicleIds.includes(vehicle.id));
 
             return (

--- a/apps/ui/src/Controls/__tests__/BatchDispatch.test.tsx
+++ b/apps/ui/src/Controls/__tests__/BatchDispatch.test.tsx
@@ -33,6 +33,7 @@ describe("BatchDispatch", () => {
   const defaultProps = {
     assignments: [] as DispatchAssignment[],
     onRemoveAssignment: vi.fn(),
+    onRemoveWaypoint: vi.fn(),
     onClearAll: vi.fn(),
     onClose: vi.fn(),
     vehicles: defaultVehicles,
@@ -476,5 +477,149 @@ describe("BatchDispatch", () => {
 
     // Button should be disabled again
     expect(screen.getByText("Dispatch All (0)")).toBeDisabled();
+  });
+
+  it("shows waypoint count badge for multi-waypoint assignments", () => {
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        vehicleName: "Truck Alpha",
+        waypoints: [
+          { position: [-1.29, 36.82] },
+          { position: [-1.30, 36.83] },
+          { position: [-1.31, 36.84] },
+        ],
+      }),
+    ];
+
+    render(<BatchDispatch {...defaultProps} assignments={assignments} />);
+
+    expect(screen.getByText("3 stops")).toBeInTheDocument();
+    expect(screen.getByText("3 pts")).toBeInTheDocument();
+  });
+
+  it("expands waypoint list when badge is clicked", async () => {
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        vehicleName: "Truck Alpha",
+        waypoints: [
+          { position: [-1.29, 36.82] },
+          { position: [-1.30, 36.83] },
+          { position: [-1.31, 36.84] },
+        ],
+      }),
+    ];
+    const user = userEvent.setup();
+
+    render(<BatchDispatch {...defaultProps} assignments={assignments} />);
+
+    await user.click(screen.getByText("3 pts"));
+
+    // Individual waypoint coordinates should now be visible
+    expect(screen.getByText("-1.2900, 36.8200")).toBeInTheDocument();
+    expect(screen.getByText("-1.3000, 36.8300")).toBeInTheDocument();
+    expect(screen.getByText("-1.3100, 36.8400")).toBeInTheDocument();
+  });
+
+  it("calls onRemoveWaypoint when waypoint remove button clicked", async () => {
+    const onRemoveWaypoint = vi.fn();
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        vehicleName: "Truck Alpha",
+        waypoints: [
+          { position: [-1.29, 36.82] },
+          { position: [-1.30, 36.83] },
+          { position: [-1.31, 36.84] },
+        ],
+      }),
+    ];
+    const user = userEvent.setup();
+
+    render(
+      <BatchDispatch
+        {...defaultProps}
+        assignments={assignments}
+        onRemoveWaypoint={onRemoveWaypoint}
+      />
+    );
+
+    // Expand waypoints first
+    await user.click(screen.getByText("3 pts"));
+
+    // Click remove button on waypoint 2 (index 1)
+    const removeButton = screen.getByTitle("Remove waypoint 2");
+    await user.click(removeButton);
+
+    expect(onRemoveWaypoint).toHaveBeenCalledWith("v1", 1);
+  });
+
+  it("shows done button when dispatch mode active with assignments", () => {
+    const assignments = [makeAssignment()];
+
+    render(
+      <BatchDispatch {...defaultProps} assignments={assignments} isDispatchMode={true} />
+    );
+
+    expect(screen.getByText("Done adding waypoints")).toBeInTheDocument();
+  });
+
+  it("calls batchDirection with waypoints for multi-stop assignments", async () => {
+    mockedBatchDirection.mockResolvedValue({
+      data: { status: "ok", results: [] },
+    });
+
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        waypoints: [
+          { position: [-1.29, 36.82] },
+          { position: [-1.30, 36.83] },
+          { position: [-1.31, 36.84] },
+        ],
+      }),
+    ];
+    const user = userEvent.setup();
+
+    render(<BatchDispatch {...defaultProps} assignments={assignments} />);
+
+    await user.click(screen.getByText("Dispatch All (1)"));
+
+    expect(mockedBatchDirection).toHaveBeenCalledWith([
+      {
+        id: "v1",
+        lat: -1.31,
+        lng: 36.84,
+        waypoints: [
+          { lat: -1.29, lng: 36.82 },
+          { lat: -1.30, lng: 36.83 },
+          { lat: -1.31, lng: 36.84 },
+        ],
+      },
+    ]);
+  });
+
+  it("single-waypoint assignment sends flat format without waypoints field", async () => {
+    mockedBatchDirection.mockResolvedValue({
+      data: { status: "ok", results: [] },
+    });
+
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        waypoints: [{ position: [-1.2921, 36.8219] }],
+      }),
+    ];
+    const user = userEvent.setup();
+
+    render(<BatchDispatch {...defaultProps} assignments={assignments} />);
+
+    await user.click(screen.getByText("Dispatch All (1)"));
+
+    const call = mockedBatchDirection.mock.calls[0][0];
+    expect(call).toEqual([{ id: "v1", lat: -1.2921, lng: 36.8219 }]);
+    // Ensure there is no waypoints field on the payload
+    expect(call[0]).not.toHaveProperty("waypoints");
   });
 });

--- a/apps/ui/src/Controls/__tests__/BatchDispatch.test.tsx
+++ b/apps/ui/src/Controls/__tests__/BatchDispatch.test.tsx
@@ -19,7 +19,7 @@ function makeAssignment(overrides: Partial<DispatchAssignment> = {}): DispatchAs
   return {
     vehicleId: "v1",
     vehicleName: "Truck Alpha",
-    destination: [-1.2921, 36.8219],
+    waypoints: [{ position: [-1.2921, 36.8219] }],
     ...overrides,
   };
 }
@@ -63,9 +63,13 @@ describe("BatchDispatch", () => {
       makeAssignment({
         vehicleId: "v1",
         vehicleName: "Truck Alpha",
-        destination: [-1.2921, 36.8219],
+        waypoints: [{ position: [-1.2921, 36.8219] }],
       }),
-      makeAssignment({ vehicleId: "v2", vehicleName: "Van Beta", destination: [-1.3, 36.85] }),
+      makeAssignment({
+        vehicleId: "v2",
+        vehicleName: "Van Beta",
+        waypoints: [{ position: [-1.3, 36.85] }],
+      }),
     ];
 
     render(<BatchDispatch {...defaultProps} assignments={assignments} />);
@@ -127,8 +131,14 @@ describe("BatchDispatch", () => {
     });
 
     const assignments = [
-      makeAssignment({ vehicleId: "v1", destination: [-1.2921, 36.8219] }),
-      makeAssignment({ vehicleId: "v2", destination: [-1.3, 36.85] }),
+      makeAssignment({
+        vehicleId: "v1",
+        waypoints: [{ position: [-1.2921, 36.8219] }],
+      }),
+      makeAssignment({
+        vehicleId: "v2",
+        waypoints: [{ position: [-1.3, 36.85] }],
+      }),
     ];
     const user = userEvent.setup();
 

--- a/apps/ui/src/Map/Direction.tsx
+++ b/apps/ui/src/Map/Direction.tsx
@@ -1,25 +1,108 @@
 import { useEffect, useState, memo } from "react";
-import type { Route } from "@/types";
+import type { Waypoint, Position } from "@/types";
 import { useDirections, type DirectionState } from "@/hooks/useDirections";
 import { Polyline } from "@/components/Map/components/Polyline";
 import { invertLatLng } from "@/utils/coordinates";
+import { useMapContext } from "@/components/Map/hooks";
 import Label from "@/components/Map/components/Label";
 
+interface WaypointMarkersProps {
+  waypoints: Waypoint[];
+  currentWaypointIndex: number;
+  color: string;
+}
+
+const WaypointMarkers = memo(function WaypointMarkers({
+  waypoints,
+  currentWaypointIndex,
+  color,
+}: WaypointMarkersProps) {
+  const { projection, transform } = useMapContext();
+  const k = transform?.k ?? 1;
+  const radius = 10 / k;
+  const fontSize = 10 / k;
+  const strokeWidth = 1.5 / k;
+
+  const remaining = waypoints.length - currentWaypointIndex;
+
+  return (
+    <>
+      {waypoints.map((wp, i) => {
+        const projected = projection
+          ? (projection(invertLatLng(wp.position) as Position) as Position | null)
+          : null;
+        if (!projected) return null;
+
+        const isCurrent = i === currentWaypointIndex;
+        const isCompleted = i < currentWaypointIndex;
+
+        const dotRadius = isCurrent ? radius * 1.3 : radius;
+        const opacity = isCompleted ? 0.4 : 1;
+        const fillColor = isCurrent ? color : "rgba(0,0,0,0.7)";
+        const strokeColor = isCurrent ? "#fff" : color;
+
+        return (
+          <g key={i} opacity={opacity}>
+            <circle
+              cx={projected[0]}
+              cy={projected[1]}
+              r={dotRadius}
+              fill={fillColor}
+              stroke={strokeColor}
+              strokeWidth={strokeWidth}
+            />
+            <text
+              x={projected[0]}
+              y={projected[1]}
+              textAnchor="middle"
+              dominantBaseline="central"
+              fill={isCurrent ? "#fff" : color}
+              fontSize={fontSize}
+              fontWeight={isCurrent ? "bold" : "normal"}
+              style={{ pointerEvents: "none" }}
+            >
+              {i + 1}
+            </text>
+          </g>
+        );
+      })}
+      {remaining > 0 && (
+        <Label
+          label={`${remaining} stop${remaining === 1 ? "" : "s"} left`}
+          coordinates={invertLatLng(waypoints[waypoints.length - 1].position) as Position}
+          color={color}
+        />
+      )}
+    </>
+  );
+});
+
 interface DirectionLineProps {
-  direction: Route;
+  direction: DirectionState;
   color: string;
 }
 
 const DirectionLine = memo(function DirectionLine({ direction, color }: DirectionLineProps) {
-  const distance = `${direction.distance.toFixed(1)} km`;
-  const coordinates = direction.edges.map((edge) => edge.start.coordinates).map(invertLatLng);
+  const { route, waypoints, currentWaypointIndex } = direction;
+  const distance = `${route.distance.toFixed(1)} km`;
+  const coordinates = route.edges.map((edge) => edge.start.coordinates).map(invertLatLng);
+  const showWaypoints = waypoints && waypoints.length > 1;
+
   return (
     <>
       <Polyline coordinates={coordinates} color={color} />
       <Label label={distance} coordinates={coordinates} color={color} />
+      {showWaypoints && (
+        <WaypointMarkers
+          waypoints={waypoints}
+          currentWaypointIndex={currentWaypointIndex ?? 0}
+          color={color}
+        />
+      )}
     </>
   );
 });
+
 interface DirectionProps {
   selected?: string;
   hovered?: string;
@@ -29,6 +112,7 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
   const directions = useDirections();
   const [selectedDirection, setSelectedDirection] = useState<DirectionState | null>(null);
   const [hoveredDirection, setHoveredDirection] = useState<DirectionState | null>(null);
+
   useEffect(() => {
     if (selected && directions.size > 0) {
       setSelectedDirection(directions.get(selected) ?? null);
@@ -48,15 +132,11 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
   return (
     <>
       {hoveredDirection && (
-        <DirectionLine
-          direction={hoveredDirection.route}
-          key={`${hovered}--hovered`}
-          color={"#f93"}
-        />
+        <DirectionLine direction={hoveredDirection} key={`${hovered}--hovered`} color={"#f93"} />
       )}
       {selectedDirection && (
         <DirectionLine
-          direction={selectedDirection.route}
+          direction={selectedDirection}
           key={`${selected}--selected`}
           color={"#39f"}
         />

--- a/apps/ui/src/Map/Direction.tsx
+++ b/apps/ui/src/Map/Direction.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, memo } from "react";
 import type { Route } from "@/types";
-import { useDirections } from "@/hooks/useDirections";
+import { useDirections, type DirectionState } from "@/hooks/useDirections";
 import { Polyline } from "@/components/Map/components/Polyline";
 import { invertLatLng } from "@/utils/coordinates";
 import Label from "@/components/Map/components/Label";
@@ -27,8 +27,8 @@ interface DirectionProps {
 
 export default function DirectionMap({ selected, hovered }: DirectionProps) {
   const directions = useDirections();
-  const [selectedDirection, setSelectedDirection] = useState<Route | null>(null);
-  const [hoveredDirection, setHoveredDirection] = useState<Route | null>(null);
+  const [selectedDirection, setSelectedDirection] = useState<DirectionState | null>(null);
+  const [hoveredDirection, setHoveredDirection] = useState<DirectionState | null>(null);
   useEffect(() => {
     if (selected && directions.size > 0) {
       setSelectedDirection(directions.get(selected) ?? null);
@@ -48,10 +48,18 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
   return (
     <>
       {hoveredDirection && (
-        <DirectionLine direction={hoveredDirection} key={`${hovered}--hovered`} color={"#f93"} />
+        <DirectionLine
+          direction={hoveredDirection.route}
+          key={`${hovered}--hovered`}
+          color={"#f93"}
+        />
       )}
       {selectedDirection && (
-        <DirectionLine direction={selectedDirection} key={`${selected}--selected`} color={"#39f"} />
+        <DirectionLine
+          direction={selectedDirection.route}
+          key={`${selected}--selected`}
+          color={"#39f"}
+        />
       )}
     </>
   );

--- a/apps/ui/src/Map/PendingDispatch.tsx
+++ b/apps/ui/src/Map/PendingDispatch.tsx
@@ -22,13 +22,91 @@ export default memo(function PendingDispatch({ assignments, vehicles }: PendingD
     <g className="pending-dispatch">
       {assignments.map((assignment) => {
         const vehicle = vehicleMap.get(assignment.vehicleId);
-        if (!vehicle) return null;
+        if (!vehicle || assignment.waypoints.length === 0) return null;
 
-        if (assignment.waypoints.length === 0) return null;
+        const isMultiStop = assignment.waypoints.length > 1;
 
-        // Use last waypoint as primary destination for backward compat
-        const dest = assignment.waypoints[assignment.waypoints.length - 1];
-        // Waypoint position is [lat, lng], projection expects [lng, lat]
+        if (isMultiStop) {
+          // --- Multi-waypoint rendering ---
+          const projected = assignment.waypoints.map(
+            (wp) => projection([wp.position[1], wp.position[0]]) as Position | undefined
+          );
+
+          if (projected.some((p) => !p || !isFinite(p[0]) || !isFinite(p[1]))) return null;
+
+          const pts = projected as Position[];
+          const r = 6 / k;
+          const stroke = 1.5 / k;
+          const fontSize = 8 / k;
+          const labelFontSize = 10 / k;
+          const gap = 3 / k;
+
+          return (
+            <g key={assignment.vehicleId}>
+              {/* Dashed connecting lines between consecutive waypoints */}
+              {pts.map((pt, i) => {
+                if (i === 0) return null;
+                const prev = pts[i - 1];
+                return (
+                  <line
+                    key={`line-${i}`}
+                    x1={prev[0]}
+                    y1={prev[1]}
+                    x2={pt[0]}
+                    y2={pt[1]}
+                    stroke={COLOR}
+                    strokeWidth={stroke}
+                    strokeDasharray={`${4 / k} ${3 / k}`}
+                  />
+                );
+              })}
+
+              {/* Numbered circle markers at each waypoint */}
+              {pts.map((pt, i) => (
+                <g key={`wp-${i}`}>
+                  <circle
+                    cx={pt[0]}
+                    cy={pt[1]}
+                    r={r}
+                    fill={COLOR_SOLID}
+                    stroke="white"
+                    strokeWidth={stroke}
+                  />
+                  <text
+                    x={pt[0]}
+                    y={pt[1]}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fill="white"
+                    fontSize={fontSize}
+                    fontFamily="inherit"
+                    fontWeight={700}
+                    style={{ pointerEvents: "none" }}
+                  >
+                    {i + 1}
+                  </text>
+                </g>
+              ))}
+
+              {/* Vehicle name label at the first waypoint */}
+              <text
+                x={pts[0][0]}
+                y={pts[0][1] - r - gap}
+                textAnchor="middle"
+                fill={COLOR}
+                fontSize={labelFontSize}
+                fontFamily="inherit"
+                fontWeight={500}
+                style={{ pointerEvents: "none" }}
+              >
+                {assignment.vehicleName}
+              </text>
+            </g>
+          );
+        }
+
+        // --- Single waypoint rendering ---
+        const dest = assignment.waypoints[0];
         const destPos = projection([dest.position[1], dest.position[0]]) as Position | undefined;
 
         if (!destPos || !isFinite(destPos[0]) || !isFinite(destPos[1])) return null;

--- a/apps/ui/src/Map/PendingDispatch.tsx
+++ b/apps/ui/src/Map/PendingDispatch.tsx
@@ -24,10 +24,12 @@ export default memo(function PendingDispatch({ assignments, vehicles }: PendingD
         const vehicle = vehicleMap.get(assignment.vehicleId);
         if (!vehicle) return null;
 
-        // Destination is [lat, lng], projection expects [lng, lat]
-        const destPos = projection([assignment.destination[1], assignment.destination[0]]) as
-          | Position
-          | undefined;
+        if (assignment.waypoints.length === 0) return null;
+
+        // Use last waypoint as primary destination for backward compat
+        const dest = assignment.waypoints[assignment.waypoints.length - 1];
+        // Waypoint position is [lat, lng], projection expects [lng, lat]
+        const destPos = projection([dest.position[1], dest.position[0]]) as Position | undefined;
 
         if (!destPos || !isFinite(destPos[0]) || !isFinite(destPos[1])) return null;
 

--- a/apps/ui/src/Map/__tests__/PendingDispatch.test.tsx
+++ b/apps/ui/src/Map/__tests__/PendingDispatch.test.tsx
@@ -26,7 +26,7 @@ function makeAssignment(overrides: Partial<DispatchAssignment> = {}): DispatchAs
   return {
     vehicleId: "v1",
     vehicleName: "Truck Alpha",
-    destination: [-1.2921, 36.8219],
+    waypoints: [{ position: [-1.2921, 36.8219] }],
     ...overrides,
   };
 }
@@ -53,7 +53,7 @@ describe("PendingDispatch", () => {
       makeAssignment({
         vehicleId: "v1",
         vehicleName: "Truck Alpha",
-        destination: [-1.2921, 36.8219],
+        waypoints: [{ position: [-1.2921, 36.8219] }],
       }),
     ];
 
@@ -81,9 +81,13 @@ describe("PendingDispatch", () => {
       makeAssignment({
         vehicleId: "v1",
         vehicleName: "Truck Alpha",
-        destination: [-1.2921, 36.8219],
+        waypoints: [{ position: [-1.2921, 36.8219] }],
       }),
-      makeAssignment({ vehicleId: "v2", vehicleName: "Van Beta", destination: [-1.3, 36.85] }),
+      makeAssignment({
+        vehicleId: "v2",
+        vehicleName: "Van Beta",
+        waypoints: [{ position: [-1.3, 36.85] }],
+      }),
     ];
 
     const { container } = render(

--- a/apps/ui/src/Map/__tests__/PendingDispatch.test.tsx
+++ b/apps/ui/src/Map/__tests__/PendingDispatch.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import type { DispatchAssignment, Vehicle, Position } from "@/types";
 import { createVehicle } from "@/test/mocks/types";
@@ -36,6 +36,13 @@ describe("PendingDispatch", () => {
     createVehicle({ id: "v1", name: "Truck Alpha", position: [36.8219, -1.2921] as Position }),
     createVehicle({ id: "v2", name: "Van Beta", position: [36.85, -1.3] as Position }),
   ];
+
+  beforeEach(() => {
+    mockProjection.mockReset();
+    mockProjection.mockImplementation(
+      (pos: Position) => [pos[0] * 10, pos[1] * 10] as [number, number]
+    );
+  });
 
   it("returns null with empty assignments", () => {
     const { container } = render(
@@ -150,5 +157,106 @@ describe("PendingDispatch", () => {
     );
 
     expect(container.querySelector(".pending-dispatch")).toBeNull();
+  });
+
+  it("renders numbered markers for multi-waypoint assignments", () => {
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        vehicleName: "Truck Alpha",
+        waypoints: [
+          { position: [-1.29, 36.82] },
+          { position: [-1.30, 36.83] },
+          { position: [-1.31, 36.84] },
+        ],
+      }),
+    ];
+
+    const { container } = render(
+      <svg>
+        <PendingDispatch assignments={assignments} vehicles={defaultVehicles} />
+      </svg>
+    );
+
+    const group = container.querySelector(".pending-dispatch");
+    expect(group).not.toBeNull();
+
+    // Multi-stop renders numbered circles: one filled circle per waypoint
+    const circles = group!.querySelectorAll("circle");
+    expect(circles.length).toBe(3);
+
+    // Each waypoint has a number label text ("1", "2", "3") plus the vehicle name label
+    const texts = group!.querySelectorAll("text");
+    const textContents = Array.from(texts).map((t) => t.textContent);
+    expect(textContents).toContain("1");
+    expect(textContents).toContain("2");
+    expect(textContents).toContain("3");
+  });
+
+  it("renders dashed connecting lines between waypoints", () => {
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        vehicleName: "Truck Alpha",
+        waypoints: [
+          { position: [-1.29, 36.82] },
+          { position: [-1.30, 36.83] },
+          { position: [-1.31, 36.84] },
+        ],
+      }),
+    ];
+
+    const { container } = render(
+      <svg>
+        <PendingDispatch assignments={assignments} vehicles={defaultVehicles} />
+      </svg>
+    );
+
+    const group = container.querySelector(".pending-dispatch");
+    expect(group).not.toBeNull();
+
+    // 3 waypoints => 2 connecting lines
+    const lines = group!.querySelectorAll("line");
+    expect(lines.length).toBe(2);
+
+    // Lines should have dashed stroke
+    lines.forEach((line) => {
+      expect(line.getAttribute("stroke-dasharray")).toBeTruthy();
+    });
+  });
+
+  it("renders single-waypoint assignment with original circle style", () => {
+    const assignments = [
+      makeAssignment({
+        vehicleId: "v1",
+        vehicleName: "Truck Alpha",
+        waypoints: [{ position: [-1.2921, 36.8219] }],
+      }),
+    ];
+
+    const { container } = render(
+      <svg>
+        <PendingDispatch assignments={assignments} vehicles={defaultVehicles} />
+      </svg>
+    );
+
+    const group = container.querySelector(".pending-dispatch");
+    expect(group).not.toBeNull();
+
+    // Single-waypoint uses target circle style: outer ring (fill="none") + center dot = 2 circles
+    const circles = group!.querySelectorAll("circle");
+    expect(circles.length).toBe(2);
+
+    // The outer ring has fill="none"
+    expect(circles[0].getAttribute("fill")).toBe("none");
+
+    // No connecting lines for single waypoint
+    const lines = group!.querySelectorAll("line");
+    expect(lines.length).toBe(0);
+
+    // No numbered labels — only the vehicle name text
+    const texts = group!.querySelectorAll("text");
+    expect(texts.length).toBe(1);
+    expect(texts[0].textContent).toBe("Truck Alpha");
   });
 });

--- a/apps/ui/src/data/context.ts
+++ b/apps/ui/src/data/context.ts
@@ -1,8 +1,9 @@
 import React from "react";
-import type { Road, Route, Heatzone, StartOptions, RoadNetwork, POI } from "@/types";
+import type { Road, Heatzone, StartOptions, RoadNetwork, POI } from "@/types";
+import type { DirectionState } from "@/hooks/useDirections";
 import { DEFAULT_START_OPTIONS } from "./constants";
 
-export type DirectionMap = Map<string, Route>;
+export type DirectionMap = Map<string, DirectionState>;
 
 interface ClientData {
   options: StartOptions;

--- a/apps/ui/src/hooks/useDirections.test.ts
+++ b/apps/ui/src/hooks/useDirections.test.ts
@@ -148,4 +148,73 @@ describe("useDirections", () => {
     expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
+
+  it("handles waypoint:reached by updating currentWaypointIndex", async () => {
+    const route = createRoute({ distance: 300 });
+    vi.mocked(client.getDirections).mockResolvedValue({
+      data: [
+        {
+          vehicleId: "v1",
+          route,
+          eta: 60,
+          waypoints: [
+            { position: [-1.29, 36.82] },
+            { position: [-1.30, 36.83] },
+          ],
+          currentWaypointIndex: 0,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useDirections(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await vi.mocked(client.getDirections).mock.results[0].value;
+    });
+
+    expect(result.current.get("v1")?.currentWaypointIndex).toBe(0);
+
+    // Grab the onWaypointReached handler that the hook registered
+    const onWaypointReachedMock = vi.mocked(client.onWaypointReached);
+    expect(onWaypointReachedMock).toHaveBeenCalledOnce();
+    const handler = onWaypointReachedMock.mock.calls[0][0];
+
+    act(() => {
+      handler({ vehicleId: "v1", waypointIndex: 1 });
+    });
+
+    expect(result.current.get("v1")?.currentWaypointIndex).toBe(1);
+  });
+
+  it("handles route:completed by removing the direction", async () => {
+    const route = createRoute({ distance: 200 });
+    vi.mocked(client.getDirections).mockResolvedValue({
+      data: [{ vehicleId: "v1", route, eta: 45 }],
+    });
+
+    const { result } = renderHook(() => useDirections(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await vi.mocked(client.getDirections).mock.results[0].value;
+    });
+
+    expect(result.current.size).toBe(1);
+    expect(result.current.has("v1")).toBe(true);
+
+    // Grab the onRouteCompleted handler that the hook registered
+    const onRouteCompletedMock = vi.mocked(client.onRouteCompleted);
+    expect(onRouteCompletedMock).toHaveBeenCalledOnce();
+    const handler = onRouteCompletedMock.mock.calls[0][0];
+
+    act(() => {
+      handler({ vehicleId: "v1" });
+    });
+
+    expect(result.current.size).toBe(0);
+    expect(result.current.has("v1")).toBe(false);
+  });
 });

--- a/apps/ui/src/hooks/useDirections.test.ts
+++ b/apps/ui/src/hooks/useDirections.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/utils/client", () => ({
     onDirection: vi.fn(),
     onConnect: vi.fn(),
     onReset: vi.fn(),
+    onWaypointReached: vi.fn(),
+    onRouteCompleted: vi.fn(),
   },
 }));
 
@@ -88,8 +90,8 @@ describe("useDirections", () => {
 
     expect(client.getDirections).toHaveBeenCalledOnce();
     expect(result.current.size).toBe(2);
-    expect(result.current.get("v1")).toBe(route1);
-    expect(result.current.get("v2")).toBe(route2);
+    expect(result.current.get("v1")?.route).toBe(route1);
+    expect(result.current.get("v2")?.route).toBe(route2);
   });
 
   it("handles WS direction updates via onDirection callback", async () => {
@@ -116,7 +118,7 @@ describe("useDirections", () => {
     });
 
     expect(result.current.size).toBe(1);
-    expect(result.current.get("ws-v1")).toBe(wsRoute);
+    expect(result.current.get("ws-v1")?.route).toBe(wsRoute);
 
     // Verify a second WS update adds to the map without removing the first
     const wsRoute2 = createRoute({ distance: 750 });
@@ -126,8 +128,8 @@ describe("useDirections", () => {
     });
 
     expect(result.current.size).toBe(2);
-    expect(result.current.get("ws-v1")).toBe(wsRoute);
-    expect(result.current.get("ws-v2")).toBe(wsRoute2);
+    expect(result.current.get("ws-v1")?.route).toBe(wsRoute);
+    expect(result.current.get("ws-v2")?.route).toBe(wsRoute2);
   });
 
   it("handles getDirections returning no data gracefully", async () => {

--- a/apps/ui/src/hooks/useDirections.ts
+++ b/apps/ui/src/hooks/useDirections.ts
@@ -3,10 +3,20 @@ import type { Route, VehicleDirection } from "@/types";
 import client from "@/utils/client";
 import { useCallback, useEffect } from "react";
 
-function buildDirectionMap(directions: VehicleDirection[]): Map<string, Route> {
-  const directionMap = new Map<string, Route>();
+export interface DirectionState {
+  route: Route;
+  waypoints?: VehicleDirection["waypoints"];
+  currentWaypointIndex?: number;
+}
+
+function buildDirectionMap(directions: VehicleDirection[]): Map<string, DirectionState> {
+  const directionMap = new Map<string, DirectionState>();
   for (const direction of directions) {
-    directionMap.set(direction.vehicleId, direction.route);
+    directionMap.set(direction.vehicleId, {
+      route: direction.route,
+      waypoints: direction.waypoints,
+      currentWaypointIndex: direction.currentWaypointIndex,
+    });
   }
   return directionMap;
 }
@@ -33,8 +43,34 @@ export function useDirections() {
 
     client.onDirection((direction) => {
       setDirections((prev) => {
-        const updated = new Map<string, Route>(prev);
-        updated.set(direction.vehicleId, direction.route);
+        const updated = new Map(prev);
+        updated.set(direction.vehicleId, {
+          route: direction.route,
+          waypoints: direction.waypoints,
+          currentWaypointIndex: direction.currentWaypointIndex,
+        });
+        return updated;
+      });
+    });
+
+    client.onWaypointReached((data) => {
+      setDirections((prev) => {
+        const existing = prev.get(data.vehicleId);
+        if (!existing) return prev;
+        const updated = new Map(prev);
+        updated.set(data.vehicleId, {
+          ...existing,
+          currentWaypointIndex: data.waypointIndex,
+        });
+        return updated;
+      });
+    });
+
+    client.onRouteCompleted((data) => {
+      setDirections((prev) => {
+        if (!prev.has(data.vehicleId)) return prev;
+        const updated = new Map(prev);
+        updated.delete(data.vehicleId);
         return updated;
       });
     });

--- a/apps/ui/src/hooks/useResetSync.test.ts
+++ b/apps/ui/src/hooks/useResetSync.test.ts
@@ -34,6 +34,8 @@ vi.mock("@/utils/client", () => ({
     onDirection: vi.fn((h: DirectionHandler) => {
       directionHandlers.push(h);
     }),
+    onWaypointReached: vi.fn(),
+    onRouteCompleted: vi.fn(),
     getVehicles: vi.fn().mockResolvedValue({ data: [] }),
     getDirections: vi.fn().mockResolvedValue({ data: [] }),
   },
@@ -222,7 +224,7 @@ describe("reset WS event: full directions replacement", () => {
 
     expect(result.current.get("stale-dir")).toBeUndefined();
     expect(result.current.get("new-dir")).toBeDefined();
-    expect(result.current.get("new-dir")!.distance).toBe(200);
+    expect(result.current.get("new-dir")!.route.distance).toBe(200);
   });
 });
 
@@ -255,6 +257,6 @@ describe("reconnect: re-fetch directions from REST", () => {
     // getDirections called at least twice: once on mount, once on reconnect
     expect(vi.mocked(client.getDirections).mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(result.current.get("reconnect-v")).toBeDefined();
-    expect(result.current.get("reconnect-v")!.distance).toBe(999);
+    expect(result.current.get("reconnect-v")!.route.distance).toBe(999);
   });
 });

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -98,10 +98,18 @@ export interface Edge {
   bearing: number;
 }
 
+export interface Waypoint {
+  position: [number, number]; // [lat, lng]
+  label?: string;
+  dwellTime?: number;
+}
+
 export interface VehicleDirection {
   vehicleId: string;
   route: Route;
   eta: number;
+  waypoints?: Waypoint[];
+  currentWaypointIndex?: number;
 }
 
 export interface Road {
@@ -138,6 +146,8 @@ export interface DirectionResult {
   route?: { start: [number, number]; end: [number, number]; distance: number };
   eta?: number;
   snappedTo?: [number, number];
+  waypointCount?: number;
+  legs?: { start: [number, number]; end: [number, number]; distance: number }[];
 }
 
 export interface DirectionResponse {
@@ -148,5 +158,5 @@ export interface DirectionResponse {
 export interface DispatchAssignment {
   vehicleId: string;
   vehicleName: string;
-  destination: [number, number]; // [lat, lng]
+  waypoints: Waypoint[];
 }

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -14,7 +14,7 @@ import type {
   Fleet,
   DirectionResponse,
 } from "@/types";
-import type { ResetPayload } from "./wsTypes";
+import type { ResetPayload, WaypointReachedPayload, RouteCompletedPayload } from "./wsTypes";
 
 class SimulationService {
   constructor(
@@ -54,6 +54,8 @@ class SimulationService {
     this.onFleetCreated = this.onFleetCreated.bind(this);
     this.onFleetDeleted = this.onFleetDeleted.bind(this);
     this.onFleetAssigned = this.onFleetAssigned.bind(this);
+    this.onWaypointReached = this.onWaypointReached.bind(this);
+    this.onRouteCompleted = this.onRouteCompleted.bind(this);
   }
 
   connectWebSocket(): void {
@@ -204,6 +206,14 @@ class SimulationService {
 
   onFleetAssigned(handler: (data: { fleetId: string | null; vehicleIds: string[] }) => void): void {
     this.ws.on("fleet:assigned", handler);
+  }
+
+  onWaypointReached(handler: (data: WaypointReachedPayload) => void): void {
+    this.ws.on("waypoint:reached", handler);
+  }
+
+  onRouteCompleted(handler: (data: RouteCompletedPayload) => void): void {
+    this.ws.on("route:completed", handler);
   }
 }
 

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -119,7 +119,12 @@ class SimulationService {
   }
 
   async batchDirection(
-    assignments: { id: string; lat: number; lng: number }[]
+    assignments: {
+      id: string;
+      lat: number;
+      lng: number;
+      waypoints?: { lat: number; lng: number; dwellTime?: number; label?: string }[];
+    }[]
   ): Promise<ApiResponse<DirectionResponse>> {
     return this.http.post("/direction", assignments);
   }

--- a/apps/ui/src/utils/wsTypes.ts
+++ b/apps/ui/src/utils/wsTypes.ts
@@ -12,6 +12,17 @@ export interface ResetPayload {
   directions: VehicleDirection[];
 }
 
+export interface WaypointReachedPayload {
+  vehicleId: string;
+  waypointIndex: number;
+  waypointLabel?: string;
+  remaining: number;
+}
+
+export interface RouteCompletedPayload {
+  vehicleId: string;
+}
+
 // Discriminated union for WebSocket messages
 export type WebSocketMessage =
   | { type: "connect" }
@@ -25,7 +36,9 @@ export type WebSocketMessage =
   | { type: "reset"; data: ResetPayload }
   | { type: "fleet:created"; data: Fleet }
   | { type: "fleet:deleted"; data: { id: string } }
-  | { type: "fleet:assigned"; data: { fleetId: string | null; vehicleIds: string[] } };
+  | { type: "fleet:assigned"; data: { fleetId: string | null; vehicleIds: string[] } }
+  | { type: "waypoint:reached"; data: WaypointReachedPayload }
+  | { type: "route:completed"; data: RouteCompletedPayload };
 
 /**
  * Type guard to validate WebSocket message structure
@@ -53,6 +66,8 @@ export function isValidMessage(msg: unknown): msg is WebSocketMessage {
     case "fleet:created":
     case "fleet:deleted":
     case "fleet:assigned":
+    case "waypoint:reached":
+    case "route:completed":
       return "data" in message;
     default:
       return false;

--- a/docs/plans/2026-03-14-dispatch-ux-redesign.md
+++ b/docs/plans/2026-03-14-dispatch-ux-redesign.md
@@ -1,0 +1,238 @@
+# Dispatch UX Redesign: Integrated Vehicle List with State Machine
+
+**Date:** 2026-03-14
+**Status:** Approved
+**Branch:** feat/multi-stop-routing
+
+## Problem
+
+The current multi-stop dispatch UI is confusing:
+
+1. **Two disconnected vehicle lists** — the sidebar has a full vehicle list; the dispatch panel has a second mini vehicle picker with checkboxes. Users must mentally switch contexts.
+2. **Cramped overlay panel** — the dispatch panel is a small bottom-right overlay trying to fit mode toggle, vehicle picker, assignment list (expandable waypoints), done button, dispatch button, results (expandable legs), and errors.
+3. **No step-based guidance** — everything is visible simultaneously. Users have no sense of "what do I do next?"
+4. **"Selected" means three different things** — vehicle selection (blue highlight for route viewing), `selectedForDispatch` (checkboxes), and `assignments` (vehicles with waypoints).
+5. **Overlapping context menu options** — "Find Directions To Here" (all vehicles), "Send selected vehicle here" (left-panel-selected), and "Add waypoint here" (dispatch-panel-selected) feel random.
+
+## Solution
+
+Merge dispatch into the existing vehicle list sidebar. Dispatch becomes a **mode** of the vehicle list, not a separate panel. A state machine governs what the sidebar, map, and footer show.
+
+## State Machine
+
+```
+BROWSE ──→ SELECT ──→ ROUTE ──→ DISPATCH ──→ RESULTS
+  ↑           ↑         │          │            │
+  └───────────┴─────────←┘          └──→ ROUTE ←─┘
+```
+
+The state is **derived**, not stored explicitly. It is computed from existing state:
+
+| Condition | State |
+|-----------|-------|
+| `!dispatchMode` | BROWSE |
+| `dispatchMode && selectedForDispatch.length === 0` | SELECT |
+| `dispatchMode && selectedForDispatch.length > 0 && !dispatching && results.length === 0` | ROUTE |
+| `dispatching` | DISPATCH |
+| `!dispatching && results.length > 0` | RESULTS |
+
+---
+
+## State 1: BROWSE (default)
+
+### Sidebar
+- Normal vehicle list: search, filter, hover, select, fleet dropdown
+- "Dispatch" toggle button at top (inactive, subtle)
+- Clicking a vehicle row selects it (blue highlight, shows route on map)
+
+### Map
+- Vehicles rendered as dots (canvas layer)
+- Selected vehicle: blue route polyline + distance label
+- Hovered vehicle: orange route polyline
+- Right-click: context menu (Find Directions, Find Road, Send Vehicle)
+- Left-click on empty space: deselects everything
+- Cursor: `default`
+
+### Footer
+Hidden.
+
+### Transitions
+| Trigger | Next State |
+|---------|-----------|
+| Click "Dispatch" toggle | SELECT |
+
+---
+
+## State 2: SELECT
+
+### Sidebar
+- Vehicle rows show **checkbox** on the left (replaces fleet dropdown)
+- Clicking a row toggles the checkbox (not the old select behavior)
+- Hover still works (orange route preview on map)
+- Search/filter still works
+- "All / None" buttons at top of list
+- "Dispatch" toggle button is active (blue)
+
+### Map
+- Vehicles rendered normally
+- Hover preview works (orange polyline)
+- Map clicks do nothing
+- Checked vehicles get a subtle ring around their dot
+- Right-click: reduced context menu (only "Find Road")
+- Cursor: `default`
+
+### Footer
+Sticky bar at bottom of sidebar:
+- `"Select vehicles to dispatch"` when 0 checked
+- `"3 selected — click map to add stops"` when >= 1 checked
+- [Clear] button → exits back to BROWSE
+
+### Transitions
+| Trigger | Next State |
+|---------|-----------|
+| Check >= 1 vehicle | ROUTE (automatic) |
+| Click "Dispatch" toggle off | BROWSE |
+| Click [Clear] | BROWSE |
+
+---
+
+## State 3: ROUTE
+
+### Sidebar
+- Same as SELECT (checkboxes visible, checked vehicles highlighted)
+- Checked vehicles with waypoints show inline badge: `"2 stops"`
+- Clicking badge expands inline waypoint list under vehicle row (numbered, with x remove buttons)
+- Unchecking a vehicle with waypoints removes its assignment
+- Hover still works for route preview
+
+### Map
+- **Cursor: `crosshair`**
+- Clicking map adds waypoint for all checked vehicles
+- PendingDispatch layer: numbered circle markers (1, 2, 3), dashed connecting lines between waypoints
+- Checked vehicles with no waypoints: subtle ring on dot
+- Right-click: context menu shows "Add waypoint here"
+- Hover preview still works
+
+### Footer
+- `"3 vehicles, 2 stops"` — counts update live
+- [Dispatch] button (primary, blue) — enabled when >= 1 assignment with >= 1 waypoint
+- [Clear] button — clears all waypoints and unchecks vehicles → SELECT
+
+### Transitions
+| Trigger | Next State |
+|---------|-----------|
+| Click [Dispatch] | DISPATCH |
+| Uncheck all vehicles | SELECT |
+| Click "Dispatch" toggle off | BROWSE (clears everything) |
+| Remove all waypoints | stays in ROUTE (footer shows hint) |
+
+---
+
+## State 4: DISPATCH (transient)
+
+### Sidebar
+- Vehicle list dimmed / non-interactive (pointer-events: none, opacity: 0.6)
+- Checkboxes and badges remain visible but frozen
+
+### Map
+- PendingDispatch markers remain visible
+- Cursor: `wait`
+- Map clicks disabled
+- Optional: pulse animation on waypoint markers
+
+### Footer
+- `"Dispatching 3 vehicles..."` with spinner
+- No interactive buttons
+
+### Transitions
+| Trigger | Next State |
+|---------|-----------|
+| API resolves (success or error) | RESULTS |
+
+---
+
+## State 5: RESULTS
+
+### Sidebar
+- Checkboxes hidden
+- Each dispatched vehicle row shows inline result badge:
+  - Green: `"ETA 120s"` for success
+  - Red: `"No route"` for error
+  - Multi-stop: `"3 stops, 12.4 km"` (clickable to expand legs)
+- Non-dispatched vehicles show normally
+- Hover still works (now shows computed route from Direction, not pending markers)
+
+### Map
+- PendingDispatch markers removed
+- Direction polylines appear for successful dispatches
+- Waypoint progress dots on multi-stop routes (WaypointMarkers in Direction.tsx)
+- Failed vehicles: no route shown
+- Cursor: `default`
+- Map clicks: back to normal (deselect)
+
+### Footer
+- Summary: `"2 dispatched, 1 failed"`
+- [Done] button → BROWSE (clears results, exits dispatch)
+- [Retry Failed] button (if failures) → ROUTE (re-checks failed vehicles with their waypoints)
+
+### Transitions
+| Trigger | Next State |
+|---------|-----------|
+| Click [Done] | BROWSE |
+| Click [Retry Failed] | ROUTE |
+
+---
+
+## What Gets Deleted
+
+- `Controls/BatchDispatch.tsx` — replaced by dispatch mode in Vehicles.tsx
+- `Controls/BatchDispatch.module.css` — all styles
+- `Controls/__tests__/BatchDispatch.test.tsx` — rewritten as dispatch mode tests
+- `App.module.css` `.dispatchPanel*` styles — no separate panel
+- ControlPanel "dispatch" toggle button — moves into vehicle list header
+- `isDispatchPanelOpen` state in App.tsx — no panel to open
+
+## What Gets Modified
+
+- `Controls/Vehicles.tsx` — gains dispatch mode: checkboxes, waypoint badges, result badges, footer
+- `Controls/Vehicles.module.css` — new styles for checkbox, badge, footer
+- `App.tsx` — dispatch state management simplified, no separate panel rendering
+- `Controls/Controls.tsx` — remove dispatch panel toggle button
+- `Map/PendingDispatch.tsx` — no changes (already works with assignments)
+- `Map/Direction.tsx` — no changes (already shows waypoint progress)
+- Context menu in App.tsx — simplify: remove "Add waypoint here" (map click covers it), keep "Find Road" and "Send Vehicle"
+
+## What Gets Created
+
+- `Controls/DispatchFooter.tsx` — the sticky footer bar (state-aware)
+- `Controls/DispatchFooter.module.css` — footer styles
+- `hooks/useDispatchState.ts` — derived state computation hook, returns current state enum + helpers
+
+## Component Structure (after)
+
+```
+App.tsx
+├── ControlPanel (top bar — no dispatch button)
+├── Sidebar (left)
+│   ├── Fleets
+│   ├── DispatchToggle (new, top of vehicle list)
+│   ├── Vehicles (with conditional checkboxes + badges)
+│   └── DispatchFooter (sticky bottom, state-aware)
+├── Map
+│   ├── VehiclesLayer (canvas)
+│   ├── PendingDispatch (SVG markers — unchanged)
+│   ├── Direction (SVG routes — unchanged)
+│   └── ... (roads, POIs, heatzones)
+└── ContextMenu (simplified)
+```
+
+## Implementation Order
+
+1. **useDispatchState hook** — derive state from existing signals
+2. **Vehicles.tsx** — add checkbox mode, waypoint badges, result badges
+3. **DispatchFooter** — new component, sticky footer bar
+4. **App.tsx** — remove BatchDispatch panel, wire dispatch state to sidebar + map
+5. **Map cursor/interaction** — crosshair in ROUTE, disabled in DISPATCH
+6. **Context menu** — simplify options per state
+7. **Delete** BatchDispatch.tsx, clean up Controls.tsx
+8. **Tests** — rewrite dispatch tests for new integrated UX


### PR DESCRIPTION
## Summary
- Add ordered waypoint sequences to the direction API (`POST /direction` now accepts `waypoints[]` per vehicle)
- Chained A* pathfinding computes independent legs between consecutive waypoints, returning per-leg distance/ETA
- Vehicles progress through waypoints automatically with configurable dwell times at each stop
- WebSocket broadcasts `waypoint:reached` and `route:completed` events for real-time tracking
- `GET /directions` includes waypoint metadata (current index, waypoint list) for state reconstruction on reconnect
- Full backward compatibility — single `{lat, lng}` requests work unchanged

## API usage
```json
POST /direction
[{
  "id": "vehicle-1",
  "waypoints": [
    {"lat": -1.28, "lng": 36.81, "label": "Pickup", "dwellTime": 30},
    {"lat": -1.29, "lng": 36.82, "label": "Delivery"},
    {"lat": -1.27, "lng": 36.80, "label": "Depot"}
  ]
}]
```

## Test plan
- [x] 13 new tests in `waypoint-routing.test.ts`
- [x] Single-destination backward compat (no waypoints field, empty waypoints array)
- [x] Multi-waypoint dispatch returns `waypointCount` and `legs[]`
- [x] Waypoint state set on vehicle (`waypoints`, `currentWaypointIndex`)
- [x] `waypoint:reached` event emitted with correct index, label, remaining count
- [x] `route:completed` event emitted and waypoint state cleared at final stop
- [x] Configurable `dwellTime` respected at waypoints
- [x] `getDirections()` includes waypoint metadata for multi-stop, excludes for single
- [x] Partial failure: error returned when one leg is unroutable
- [x] Direction event includes waypoints and currentWaypointIndex
- [x] All 338 existing tests still pass (351 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)