### PR TITLE
feat: recording & replay for simulation sessions

### DIFF
--- a/apps/simulator/src/__tests__/RecordingReplay.test.ts
+++ b/apps/simulator/src/__tests__/RecordingReplay.test.ts
@@ -1,0 +1,568 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { RecordingManager } from "../modules/RecordingManager";
+import { ReplayManager } from "../modules/ReplayManager";
+import type {
+  StartOptions,
+  VehicleDTO,
+  RecordingHeader,
+  RecordingEvent,
+} from "../types";
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "moveet-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function tmpFile(name: string): string {
+  return path.join(tmpDir, name);
+}
+
+function writeTestRecording(
+  filePath: string,
+  header: RecordingHeader,
+  events: RecordingEvent[],
+): void {
+  const lines = [
+    JSON.stringify(header),
+    ...events.map((e) => JSON.stringify(e)),
+  ];
+  fs.writeFileSync(filePath, lines.join("\n") + "\n");
+}
+
+function makeVehicle(
+  id: string,
+  lat: number,
+  lng: number,
+  overrides?: Partial<VehicleDTO>,
+): VehicleDTO {
+  return {
+    id,
+    name: `Vehicle ${id}`,
+    position: [lat, lng],
+    speed: 45,
+    heading: 90,
+    ...overrides,
+  };
+}
+
+const defaultOptions: StartOptions = {
+  minSpeed: 20,
+  maxSpeed: 60,
+  speedVariation: 0.1,
+  acceleration: 10,
+  deceleration: 15,
+  turnThreshold: 45,
+  heatZoneSpeedFactor: 0.6,
+  updateInterval: 1000,
+};
+
+function makeHeader(overrides?: Partial<RecordingHeader>): RecordingHeader {
+  return {
+    format: "moveet-recording",
+    version: 1,
+    startTime: new Date().toISOString(),
+    vehicleCount: 3,
+    options: defaultOptions,
+    ...overrides,
+  };
+}
+
+// ─── RecordingManager ───────────────────────────────────────────────
+
+describe("RecordingManager", () => {
+  let rm: RecordingManager;
+
+  beforeEach(() => {
+    rm = new RecordingManager();
+  });
+
+  afterEach(() => {
+    if (rm.isRecording()) {
+      rm.stopRecording();
+    }
+  });
+
+  // ─── NDJSON format write/read roundtrip ───────────────────────
+
+  describe("NDJSON format write/read roundtrip", () => {
+    it("should write a valid NDJSON file with header and events", () => {
+      const filePath = tmpFile("roundtrip.ndjson");
+      rm.startRecording(defaultOptions, 2, filePath);
+
+      rm.recordEvent("direction", { vehicleId: "v1", dest: [1, 2] });
+      rm.recordEvent("incident", { id: "inc1", type: "closure" });
+
+      rm.stopRecording();
+
+      const content = fs.readFileSync(filePath, "utf-8").trim();
+      const lines = content.split("\n");
+
+      // At least header + 2 events
+      expect(lines.length).toBeGreaterThanOrEqual(3);
+
+      // Verify each line is valid JSON
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+
+      // Verify header
+      const header = JSON.parse(lines[0]) as RecordingHeader;
+      expect(header.format).toBe("moveet-recording");
+      expect(header.version).toBe(1);
+      expect(header.vehicleCount).toBe(2);
+
+      // Verify events have correct structure
+      const event1 = JSON.parse(lines[1]) as RecordingEvent;
+      expect(event1.type).toBe("direction");
+      expect(event1.timestamp).toBeGreaterThanOrEqual(0);
+
+      const event2 = JSON.parse(lines[2]) as RecordingEvent;
+      expect(event2.type).toBe("incident");
+    });
+  });
+
+  // ─── Delta dedup for vehicle snapshots ────────────────────────
+
+  describe("captureVehicleSnapshot with delta dedup", () => {
+    it("should record only changed positions beyond threshold", () => {
+      const filePath = tmpFile("dedup.ndjson");
+      rm.startRecording(defaultOptions, 2, filePath);
+
+      const v1 = makeVehicle("v1", 45.5, -73.5);
+      const v2 = makeVehicle("v2", 45.6, -73.6);
+
+      // First snapshot — both should be recorded (no previous positions)
+      rm.captureVehicleSnapshot([v1, v2]);
+
+      // Same positions — nothing should be recorded
+      rm.captureVehicleSnapshot([v1, v2]);
+
+      // Tiny change below threshold (0.000005 < 0.00001)
+      const v1Tiny = makeVehicle("v1", 45.5 + 0.000005, -73.5);
+      rm.captureVehicleSnapshot([v1Tiny, v2]);
+
+      // Significant change above threshold
+      const v1Moved = makeVehicle("v1", 45.5 + 0.001, -73.5);
+      rm.captureVehicleSnapshot([v1Moved, v2]);
+
+      rm.stopRecording();
+
+      const content = fs.readFileSync(filePath, "utf-8").trim();
+      const lines = content.split("\n");
+      // header + 2 snapshot events (first snapshot with both, then v1 moved)
+      const eventLines = lines.slice(1);
+      expect(eventLines.length).toBe(2);
+
+      // First snapshot should contain both vehicles
+      const snap1 = JSON.parse(eventLines[0]) as RecordingEvent;
+      expect(snap1.type).toBe("vehicle");
+      const snap1Data = snap1.data as { vehicles: unknown[] };
+      expect(snap1Data.vehicles.length).toBe(2);
+
+      // Second snapshot should only contain v1 (only one that moved enough)
+      const snap2 = JSON.parse(eventLines[1]) as RecordingEvent;
+      expect(snap2.type).toBe("vehicle");
+      const snap2Data = snap2.data as { vehicles: { id: string }[] };
+      expect(snap2Data.vehicles.length).toBe(1);
+      expect(snap2Data.vehicles[0].id).toBe("v1");
+    });
+  });
+
+  // ─── Discrete events ──────────────────────────────────────────
+
+  describe("recordEvent captures discrete events", () => {
+    it("should record direction, incident, and heatzone events", () => {
+      const filePath = tmpFile("discrete.ndjson");
+      rm.startRecording(defaultOptions, 1, filePath);
+
+      rm.recordEvent("direction", { vehicleId: "v1" });
+      rm.recordEvent("incident", { id: "inc1", type: "accident" });
+      rm.recordEvent("heatzone", { zones: [] });
+
+      rm.stopRecording();
+
+      const content = fs.readFileSync(filePath, "utf-8").trim();
+      const lines = content.split("\n");
+      const events = lines.slice(1).map((l) => JSON.parse(l) as RecordingEvent);
+
+      expect(events).toHaveLength(3);
+      expect(events[0].type).toBe("direction");
+      expect(events[1].type).toBe("incident");
+      expect(events[2].type).toBe("heatzone");
+    });
+  });
+
+  // ─── startRecording throws if already recording ───────────────
+
+  describe("startRecording throws if already recording", () => {
+    it("should throw Error when called twice", () => {
+      const filePath = tmpFile("double-start.ndjson");
+      rm.startRecording(defaultOptions, 1, filePath);
+
+      expect(() =>
+        rm.startRecording(defaultOptions, 1, tmpFile("second.ndjson")),
+      ).toThrow("Recording already in progress");
+    });
+  });
+
+  // ─── stopRecording returns correct metadata ───────────────────
+
+  describe("stopRecording returns correct metadata", () => {
+    it("should return filePath, duration, eventCount, vehicleCount", () => {
+      const filePath = tmpFile("metadata.ndjson");
+      rm.startRecording(defaultOptions, 5, filePath);
+
+      rm.recordEvent("direction", {});
+      rm.recordEvent("incident", {});
+      rm.recordEvent("heatzone", {});
+
+      const meta = rm.stopRecording();
+
+      expect(meta.filePath).toBe(filePath);
+      expect(meta.duration).toBeGreaterThanOrEqual(0);
+      expect(meta.eventCount).toBe(3);
+      expect(meta.vehicleCount).toBe(5);
+    });
+  });
+
+  // ─── Auto-generated file path ─────────────────────────────────
+
+  describe("auto-generated file path", () => {
+    it("should match pattern moveet-{date}-{count}v.ndjson", () => {
+      const filePath = rm.startRecording(defaultOptions, 7);
+
+      expect(filePath).toMatch(/moveet-.*-7v\.ndjson$/);
+
+      rm.stopRecording();
+
+      // Clean up the auto-generated file
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    });
+  });
+
+  // ─── Buffer flush on count threshold ──────────────────────────
+
+  describe("buffer flush on count threshold", () => {
+    it("should flush to disk when buffer exceeds 1000 events", () => {
+      const filePath = tmpFile("flush.ndjson");
+      rm.startRecording(defaultOptions, 1, filePath);
+
+      // Write 1001 events to trigger the flush threshold
+      for (let i = 0; i < 1001; i++) {
+        rm.recordEvent("direction", { i });
+      }
+
+      // Before stopping, the file should already have data from the flush
+      const content = fs.readFileSync(filePath, "utf-8");
+      const lines = content.trim().split("\n");
+      // Header + at least 1000 flushed events (the remaining 1 may still be buffered)
+      expect(lines.length).toBeGreaterThanOrEqual(1001);
+
+      rm.stopRecording();
+    });
+  });
+
+  // ─── isRecording and getElapsedMs ─────────────────────────────
+
+  describe("isRecording and getElapsedMs", () => {
+    it("should track recording state correctly", () => {
+      expect(rm.isRecording()).toBe(false);
+      expect(rm.getElapsedMs()).toBe(0);
+
+      const filePath = tmpFile("state.ndjson");
+      rm.startRecording(defaultOptions, 1, filePath);
+
+      expect(rm.isRecording()).toBe(true);
+      expect(rm.getElapsedMs()).toBeGreaterThanOrEqual(0);
+
+      rm.stopRecording();
+
+      expect(rm.isRecording()).toBe(false);
+      expect(rm.getElapsedMs()).toBe(0);
+    });
+  });
+});
+
+// ─── ReplayManager ──────────────────────────────────────────────────
+
+describe("ReplayManager", () => {
+  let rp: ReplayManager;
+
+  beforeEach(() => {
+    rp = new ReplayManager();
+  });
+
+  afterEach(() => {
+    rp.stopReplay();
+  });
+
+  // ─── Replay emits events at correct timestamps ────────────────
+
+  describe("replay emits events in order", () => {
+    it("should emit events via individual event channels", async () => {
+      vi.useFakeTimers();
+
+      const filePath = tmpFile("replay-order.ndjson");
+      const header = makeHeader();
+      const events: RecordingEvent[] = [
+        { timestamp: 100, type: "vehicle", data: { vehicles: [] } },
+        { timestamp: 200, type: "direction", data: { vehicleId: "v2" } },
+        { timestamp: 300, type: "incident", data: { action: "created", id: "inc1" } },
+      ];
+      writeTestRecording(filePath, header, events);
+
+      await rp.loadRecording(filePath);
+
+      const vehicleEvents: unknown[] = [];
+      const directionEvents: unknown[] = [];
+      const incidentEvents: unknown[] = [];
+      rp.on("vehicle", (data) => vehicleEvents.push(data));
+      rp.on("direction", (data) => directionEvents.push(data));
+      rp.on("incident:created", (data) => incidentEvents.push(data));
+
+      rp.startReplay(1);
+
+      // At t=0, no events yet
+      expect(vehicleEvents).toHaveLength(0);
+
+      // Advance to t=100 — vehicle event fires
+      vi.advanceTimersByTime(100);
+      expect(vehicleEvents).toHaveLength(1);
+
+      // Advance to t=200 — direction event fires
+      vi.advanceTimersByTime(100);
+      expect(directionEvents).toHaveLength(1);
+
+      // Advance to t=300 — incident event fires
+      vi.advanceTimersByTime(100);
+      expect(incidentEvents).toHaveLength(1);
+
+      vi.useRealTimers();
+    });
+  });
+
+  // ─── Replay speed multiplier ──────────────────────────────────
+
+  describe("replay speed multiplier", () => {
+    it("should emit events faster when speed=2", async () => {
+      vi.useFakeTimers();
+
+      const filePath = tmpFile("replay-speed.ndjson");
+      const header = makeHeader();
+      // Events spaced 400ms apart — at 2x, should arrive 200ms apart in wall time
+      const events: RecordingEvent[] = [
+        { timestamp: 0, type: "vehicle", data: {} },
+        { timestamp: 400, type: "direction", data: {} },
+      ];
+      writeTestRecording(filePath, header, events);
+
+      await rp.loadRecording(filePath);
+
+      const received: unknown[] = [];
+      rp.on("vehicle", (data) => received.push(data));
+      rp.on("direction", (data) => received.push(data));
+
+      rp.startReplay(2);
+
+      // First event at ts=0 fires immediately
+      vi.advanceTimersByTime(1);
+      expect(received).toHaveLength(1);
+
+      // At 2x speed, ts=400 should fire at real-time ~200ms
+      vi.advanceTimersByTime(199);
+      expect(received).toHaveLength(2);
+
+      vi.useRealTimers();
+    });
+  });
+
+  // ─── Pause and resume ─────────────────────────────────────────
+
+  describe("pause and resume", () => {
+    it("should stop emitting when paused and resume after", async () => {
+      vi.useFakeTimers();
+
+      const filePath = tmpFile("replay-pause.ndjson");
+      const header = makeHeader();
+      const events: RecordingEvent[] = [
+        { timestamp: 100, type: "vehicle", data: {} },
+        { timestamp: 500, type: "direction", data: {} },
+      ];
+      writeTestRecording(filePath, header, events);
+
+      await rp.loadRecording(filePath);
+
+      const received: unknown[] = [];
+      rp.on("vehicle", (data) => received.push(data));
+      rp.on("direction", (data) => received.push(data));
+
+      rp.startReplay(1);
+
+      // First event at 100ms
+      vi.advanceTimersByTime(100);
+      expect(received).toHaveLength(1);
+
+      // Pause
+      rp.pauseReplay();
+      expect(rp.getStatus().paused).toBe(true);
+
+      // Advance time while paused — no new events
+      vi.advanceTimersByTime(1000);
+      expect(received).toHaveLength(1);
+
+      // Resume
+      rp.resumeReplay();
+      expect(rp.getStatus().paused).toBe(false);
+
+      // The second event should fire after its remaining delay
+      vi.advanceTimersByTime(400);
+      expect(received).toHaveLength(2);
+
+      vi.useRealTimers();
+    });
+  });
+
+  // ─── seekTo ───────────────────────────────────────────────────
+
+  describe("seekTo", () => {
+    it("should seek to the correct position in the recording", async () => {
+      const filePath = tmpFile("replay-seek.ndjson");
+      const header = makeHeader();
+      const events: RecordingEvent[] = [
+        { timestamp: 100, type: "vehicle", data: {} },
+        { timestamp: 200, type: "direction", data: {} },
+        { timestamp: 300, type: "incident", data: { action: "created" } },
+        { timestamp: 400, type: "heatzone", data: {} },
+      ];
+      writeTestRecording(filePath, header, events);
+
+      await rp.loadRecording(filePath);
+
+      // Seek to t=250 — progress should be between first and second thirds
+      rp.seekTo(250);
+      const status = rp.getStatus();
+      expect(status.mode).toBe("replay");
+      // currentTime should be at or near 200 (the event at/before 250)
+      expect(status.currentTime).toBeDefined();
+    });
+  });
+
+  // ─── stopReplay resets state ──────────────────────────────────
+
+  describe("stopReplay resets state", () => {
+    it("should return mode 'live' after stop", async () => {
+      const filePath = tmpFile("replay-stop.ndjson");
+      const header = makeHeader();
+      const events: RecordingEvent[] = [
+        { timestamp: 100, type: "vehicle", data: {} },
+      ];
+      writeTestRecording(filePath, header, events);
+
+      await rp.loadRecording(filePath);
+      expect(rp.getStatus().mode).toBe("replay");
+
+      rp.stopReplay();
+
+      const status = rp.getStatus();
+      expect(status.mode).toBe("live");
+    });
+  });
+
+  // ─── loadRecording validates format ───────────────────────────
+
+  describe("loadRecording validates format", () => {
+    it("should throw on header with wrong format", async () => {
+      const filePath = tmpFile("wrong-format.ndjson");
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({ format: "wrong", version: 1 }) + "\n",
+      );
+
+      await expect(rp.loadRecording(filePath)).rejects.toThrow(
+        "Invalid recording format",
+      );
+    });
+
+    it("should throw on header with wrong version", async () => {
+      const filePath = tmpFile("wrong-version.ndjson");
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({ format: "moveet-recording", version: 99 }) + "\n",
+      );
+
+      await expect(rp.loadRecording(filePath)).rejects.toThrow(
+        "Invalid recording format",
+      );
+    });
+  });
+
+  // ─── loadRecording validates empty file ───────────────────────
+
+  describe("loadRecording validates empty file", () => {
+    it("should throw on empty file", async () => {
+      const filePath = tmpFile("empty.ndjson");
+      fs.writeFileSync(filePath, "");
+
+      await expect(rp.loadRecording(filePath)).rejects.toThrow(
+        "empty or missing header",
+      );
+    });
+
+    it("should throw on whitespace-only file", async () => {
+      const filePath = tmpFile("whitespace.ndjson");
+      fs.writeFileSync(filePath, "   \n  \n  ");
+
+      await expect(rp.loadRecording(filePath)).rejects.toThrow(
+        "empty or missing header",
+      );
+    });
+  });
+
+  // ─── getStatus returns correct progress ───────────────────────
+
+  describe("getStatus returns correct progress", () => {
+    it("should report progress during playback", async () => {
+      vi.useFakeTimers();
+
+      const filePath = tmpFile("replay-progress.ndjson");
+      const header = makeHeader();
+      const events: RecordingEvent[] = [
+        { timestamp: 100, type: "vehicle", data: {} },
+        { timestamp: 200, type: "direction", data: {} },
+        { timestamp: 300, type: "incident", data: { action: "created" } },
+        { timestamp: 400, type: "heatzone", data: {} },
+      ];
+      writeTestRecording(filePath, header, events);
+
+      await rp.loadRecording(filePath);
+
+      // Before starting, progress should be 0
+      let status = rp.getStatus();
+      expect(status.mode).toBe("replay");
+      expect(status.progress).toBe(0);
+      expect(status.duration).toBe(300); // 400 - 100
+
+      rp.startReplay(1);
+
+      // After all events
+      vi.advanceTimersByTime(500);
+      status = rp.getStatus();
+      // Replay should have ended (idle), progress = 1
+      expect(status.progress).toBe(1);
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -2,11 +2,14 @@ import type { Request, Response, NextFunction } from "express";
 import express from "express";
 import compression from "compression";
 import cors from "cors";
+import fs from "fs";
+import path from "path";
 import { WebSocketServer } from "ws";
 import { RoadNetwork } from "./modules/RoadNetwork";
 import { VehicleManager } from "./modules/VehicleManager";
 import { FleetManager } from "./modules/FleetManager";
 import { IncidentManager } from "./modules/IncidentManager";
+import { RecordingManager } from "./modules/RecordingManager";
 import { SimulationController } from "./modules/SimulationController";
 import { WebSocketBroadcaster } from "./modules/WebSocketBroadcaster";
 import type { IncidentType } from "./types";
@@ -44,6 +47,7 @@ const fleetManager = new FleetManager();
 const incidentManager = new IncidentManager();
 const vehicleManager = new VehicleManager(network, fleetManager);
 const simulationController = new SimulationController(vehicleManager, incidentManager);
+const recordingManager = new RecordingManager();
 
 // Vehicles loaded in main() below, after await
 
@@ -334,6 +338,115 @@ app.get("/heatzones", (_req, res) => {
   }
 });
 
+// ─── Recording ──────────────────────────────────────────────────────
+
+app.post(
+  "/recording/start",
+  expensiveRateLimiter.middleware(),
+  asyncHandler(async (_req, res) => {
+    if (recordingManager.isRecording()) {
+      res.status(409).json({ error: "Recording already in progress" });
+      return;
+    }
+    const options = simulationController.getOptions();
+    const vehicleCount = simulationController.getVehicles().length;
+    const filePath = recordingManager.startRecording(options, vehicleCount);
+    res.json({ status: "recording", filePath });
+  })
+);
+
+app.post(
+  "/recording/stop",
+  asyncHandler(async (_req, res) => {
+    if (!recordingManager.isRecording()) {
+      res.status(409).json({ error: "No recording in progress" });
+      return;
+    }
+    const metadata = recordingManager.stopRecording();
+    res.json(metadata);
+  })
+);
+
+app.get(
+  "/recordings",
+  asyncHandler(async (_req, res) => {
+    const dir = "recordings";
+    if (!fs.existsSync(dir)) {
+      res.json([]);
+      return;
+    }
+    const files = fs.readdirSync(dir);
+    const result = files.map((fileName) => {
+      const stat = fs.statSync(path.join(dir, fileName));
+      return {
+        fileName,
+        fileSize: stat.size,
+        modifiedAt: stat.mtime.toISOString(),
+      };
+    });
+    res.json(result);
+  })
+);
+
+// ─── Replay ─────────────────────────────────────────────────────────
+
+app.post(
+  "/replay/start",
+  expensiveRateLimiter.middleware(),
+  asyncHandler(async (req, res) => {
+    const { file, speed } = req.body;
+    if (!file || typeof file !== "string") {
+      res.status(400).json({ error: "file is required" });
+      return;
+    }
+    const filePath = path.join("recordings", file);
+    const header = await simulationController.startReplay(filePath, speed);
+    res.json({ status: "replaying", header });
+  })
+);
+
+app.post(
+  "/replay/pause",
+  asyncHandler(async (_req, res) => {
+    simulationController.pauseReplay();
+    res.json({ status: "paused" });
+  })
+);
+
+app.post(
+  "/replay/resume",
+  asyncHandler(async (_req, res) => {
+    simulationController.resumeReplay();
+    res.json({ status: "resumed" });
+  })
+);
+
+app.post(
+  "/replay/stop",
+  asyncHandler(async (_req, res) => {
+    simulationController.stopReplay();
+    res.json({ status: "stopped" });
+  })
+);
+
+app.post(
+  "/replay/seek",
+  asyncHandler(async (req, res) => {
+    const { timestamp } = req.body;
+    simulationController.seekReplay(timestamp);
+    res.json({ status: "seeked", timestamp });
+  })
+);
+
+app.get("/replay/status", (_req, res) => {
+  try {
+    res.json(simulationController.getReplayStatus());
+  } catch (error) {
+    logger.error(`Error in /replay/status: ${error}`);
+    res.status(500).json({ error: "Failed to get replay status" });
+  }
+});
+
 // ─── Incidents ──────────────────────────────────────────────────────
 
 const VALID_INCIDENT_TYPES: IncidentType[] = ["accident", "closure", "construction"];
@@ -482,6 +595,7 @@ async function main() {
   // Vehicle updates are batched by the broadcaster
   vehicleManager.on("update", (data) => {
     broadcaster.queueVehicleUpdate(data);
+    recordingManager.captureVehicleSnapshot([data]);
   });
 
   // Non-vehicle events are broadcast immediately
@@ -498,6 +612,26 @@ async function main() {
   incidentManager.on("incident:created", (data) => broadcaster.broadcast("incident:created", data));
   incidentManager.on("incident:cleared", (data) => broadcaster.broadcast("incident:cleared", data));
   vehicleManager.on("vehicle:rerouted", (data) => broadcaster.broadcast("vehicle:rerouted", data));
+
+  // Wire discrete events to recording manager
+  vehicleManager.on("direction", (data) => recordingManager.recordEvent("direction", data));
+  vehicleManager.on("waypoint:reached", (data) => recordingManager.recordEvent("waypoint", data));
+  vehicleManager.on("route:completed", (data) => recordingManager.recordEvent("route:completed", data));
+  vehicleManager.on("vehicle:rerouted", (data) => recordingManager.recordEvent("vehicle:rerouted", data));
+  network.on("heatzones", (data) => recordingManager.recordEvent("heatzone", data));
+  incidentManager.on("incident:created", (data) => recordingManager.recordEvent("incident", { action: "created", ...data }));
+  incidentManager.on("incident:cleared", (data) => recordingManager.recordEvent("incident", { action: "cleared", ...data }));
+
+  // Wire replay events from SimulationController to WS broadcaster
+  simulationController.on("replayVehicle", (data) => broadcaster.broadcast("vehicle", data));
+  simulationController.on("replayDirection", (data) => broadcaster.broadcast("direction", data));
+  simulationController.on("replayIncident:created", (data) => broadcaster.broadcast("incident:created", data));
+  simulationController.on("replayIncident:cleared", (data) => broadcaster.broadcast("incident:cleared", data));
+  simulationController.on("replayHeatzones", (data) => broadcaster.broadcast("heatzones", data));
+  simulationController.on("replayWaypoint:reached", (data) => broadcaster.broadcast("waypoint:reached", data));
+  simulationController.on("replayRoute:completed", (data) => broadcaster.broadcast("route:completed", data));
+  simulationController.on("replayVehicle:rerouted", (data) => broadcaster.broadcast("vehicle:rerouted", data));
+  simulationController.on("replayStatus", (data) => broadcaster.broadcast("replayStatus", data));
 
   wss.on("connection", (ws) => {
     logger.info(`Client connected (total: ${broadcaster.clientCount})`);

--- a/apps/simulator/src/modules/RecordingManager.ts
+++ b/apps/simulator/src/modules/RecordingManager.ts
@@ -36,7 +36,7 @@ export class RecordingManager extends EventEmitter {
   private vehicleCount = 0;
   private eventCount = 0;
 
-  private stream: fs.WriteStream | null = null;
+  private fd: number | null = null;
   private buffer: string[] = [];
   private flushTimer: NodeJS.Timeout | null = null;
 
@@ -83,11 +83,8 @@ export class RecordingManager extends EventEmitter {
     const dir = path.dirname(this.filePath);
     fs.mkdirSync(dir, { recursive: true });
 
-    // Open write stream
-    this.stream = fs.createWriteStream(this.filePath, { flags: "w" });
-    this.stream.on("error", (err) => {
-      this.emit("recording:error", err);
-    });
+    // Open file descriptor for synchronous writes
+    this.fd = fs.openSync(this.filePath, "w");
 
     // Write header as first line
     const header: RecordingHeader = {
@@ -97,7 +94,7 @@ export class RecordingManager extends EventEmitter {
       vehicleCount,
       options,
     };
-    this.stream.write(JSON.stringify(header) + "\n");
+    fs.writeSync(this.fd, JSON.stringify(header) + "\n");
 
     // Start periodic flush timer
     this.flushTimer = setInterval(() => this.flushBuffer(), BUFFER_FLUSH_INTERVAL_MS);
@@ -125,10 +122,10 @@ export class RecordingManager extends EventEmitter {
       this.flushTimer = null;
     }
 
-    // Close stream
-    if (this.stream) {
-      this.stream.end();
-      this.stream = null;
+    // Close file descriptor
+    if (this.fd !== null) {
+      fs.closeSync(this.fd);
+      this.fd = null;
     }
 
     this.recording = false;
@@ -138,7 +135,7 @@ export class RecordingManager extends EventEmitter {
     try {
       fileSize = fs.statSync(this.filePath).size;
     } catch {
-      // File may not be fully flushed yet; ignore
+      // ignore
     }
 
     const metadata: RecordingMetadata = {
@@ -233,13 +230,13 @@ export class RecordingManager extends EventEmitter {
   }
 
   /**
-   * Writes all buffered event lines to the stream.
+   * Writes all buffered event lines to the file.
    */
   private flushBuffer(): void {
-    if (this.buffer.length === 0 || !this.stream) return;
+    if (this.buffer.length === 0 || this.fd === null) return;
 
     const chunk = this.buffer.join("\n") + "\n";
     this.buffer = [];
-    this.stream.write(chunk);
+    fs.writeSync(this.fd, chunk);
   }
 }

--- a/apps/simulator/src/modules/RecordingManager.ts
+++ b/apps/simulator/src/modules/RecordingManager.ts
@@ -1,0 +1,245 @@
+import { EventEmitter } from "events";
+import fs from "fs";
+import path from "path";
+import type {
+  RecordingEventType,
+  RecordingHeader,
+  RecordingEvent,
+  RecordingMetadata,
+  StartOptions,
+  VehicleDTO,
+  VehicleSnapshot,
+} from "../types";
+
+/** Minimum position change (in degrees) to include a vehicle in a snapshot. ~1.1 meters. */
+const POSITION_DELTA_THRESHOLD = 0.00001;
+
+/** Maximum number of buffered events before a forced flush. */
+const BUFFER_FLUSH_COUNT = 1000;
+
+/** Flush interval in milliseconds. */
+const BUFFER_FLUSH_INTERVAL_MS = 1000;
+
+/**
+ * Records simulation events to NDJSON files for later replay.
+ *
+ * Emits:
+ * - `recording:started` — when a new recording begins
+ * - `recording:stopped` — with RecordingMetadata when a recording ends
+ * - `recording:error` — on write errors
+ */
+export class RecordingManager extends EventEmitter {
+  private recording = false;
+  private startTime = 0;
+  private filePath = "";
+  private startTimeISO = "";
+  private vehicleCount = 0;
+  private eventCount = 0;
+
+  private stream: fs.WriteStream | null = null;
+  private buffer: string[] = [];
+  private flushTimer: NodeJS.Timeout | null = null;
+
+  /** Last known position per vehicle id, used for delta dedup. */
+  private lastPositions: Map<string, [number, number]> = new Map();
+
+  constructor() {
+    super();
+  }
+
+  /**
+   * Begins capturing events to an NDJSON file.
+   *
+   * @param options - Current simulation start options (written into the header)
+   * @param vehicleCount - Number of vehicles at recording start
+   * @param filePath - Optional explicit file path; auto-generated if omitted
+   */
+  startRecording(
+    options: StartOptions,
+    vehicleCount: number,
+    filePath?: string
+  ): string {
+    if (this.recording) {
+      throw new Error("Recording already in progress");
+    }
+
+    this.startTime = Date.now();
+    this.startTimeISO = new Date(this.startTime).toISOString();
+    this.vehicleCount = vehicleCount;
+    this.eventCount = 0;
+    this.lastPositions.clear();
+    this.buffer = [];
+
+    // Determine file path
+    if (filePath) {
+      this.filePath = filePath;
+    } else {
+      const safeDate = this.startTimeISO.replace(/:/g, "-");
+      const fileName = `moveet-${safeDate}-${vehicleCount}v.ndjson`;
+      this.filePath = path.join("recordings", fileName);
+    }
+
+    // Ensure directory exists
+    const dir = path.dirname(this.filePath);
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Open write stream
+    this.stream = fs.createWriteStream(this.filePath, { flags: "w" });
+    this.stream.on("error", (err) => {
+      this.emit("recording:error", err);
+    });
+
+    // Write header as first line
+    const header: RecordingHeader = {
+      format: "moveet-recording",
+      version: 1,
+      startTime: this.startTimeISO,
+      vehicleCount,
+      options,
+    };
+    this.stream.write(JSON.stringify(header) + "\n");
+
+    // Start periodic flush timer
+    this.flushTimer = setInterval(() => this.flushBuffer(), BUFFER_FLUSH_INTERVAL_MS);
+
+    this.recording = true;
+    this.emit("recording:started", { filePath: this.filePath });
+
+    return this.filePath;
+  }
+
+  /**
+   * Finalizes the recording file and returns metadata.
+   */
+  stopRecording(): RecordingMetadata {
+    if (!this.recording) {
+      throw new Error("No recording in progress");
+    }
+
+    // Flush remaining buffered events
+    this.flushBuffer();
+
+    // Stop flush timer
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    // Close stream
+    if (this.stream) {
+      this.stream.end();
+      this.stream = null;
+    }
+
+    this.recording = false;
+
+    const duration = Date.now() - this.startTime;
+    let fileSize = 0;
+    try {
+      fileSize = fs.statSync(this.filePath).size;
+    } catch {
+      // File may not be fully flushed yet; ignore
+    }
+
+    const metadata: RecordingMetadata = {
+      filePath: this.filePath,
+      startTime: this.startTimeISO,
+      duration,
+      eventCount: this.eventCount,
+      fileSize,
+      vehicleCount: this.vehicleCount,
+    };
+
+    this.emit("recording:stopped", metadata);
+    return metadata;
+  }
+
+  /**
+   * Returns whether a recording is currently in progress.
+   */
+  isRecording(): boolean {
+    return this.recording;
+  }
+
+  /**
+   * Returns milliseconds elapsed since recording started.
+   * Returns 0 if not recording.
+   */
+  getElapsedMs(): number {
+    if (!this.recording) return 0;
+    return Date.now() - this.startTime;
+  }
+
+  /**
+   * Captures a vehicle position snapshot, applying delta dedup.
+   * Only vehicles whose position changed by more than POSITION_DELTA_THRESHOLD
+   * since the last snapshot are included.
+   *
+   * @param vehicles - Current vehicle DTOs from the game loop tick
+   */
+  captureVehicleSnapshot(vehicles: VehicleDTO[]): void {
+    if (!this.recording) return;
+
+    const changed: VehicleSnapshot[] = [];
+
+    for (const v of vehicles) {
+      const prev = this.lastPositions.get(v.id);
+      if (prev) {
+        const dlat = Math.abs(v.position[0] - prev[0]);
+        const dlng = Math.abs(v.position[1] - prev[1]);
+        if (dlat < POSITION_DELTA_THRESHOLD && dlng < POSITION_DELTA_THRESHOLD) {
+          continue;
+        }
+      }
+
+      changed.push({
+        id: v.id,
+        position: [v.position[0], v.position[1]],
+        speed: v.speed,
+        heading: v.heading,
+        edgeId: "", // VehicleDTO doesn't carry edgeId; caller can enrich if needed
+        ...(v.fleetId ? { fleetId: v.fleetId } : {}),
+      });
+
+      this.lastPositions.set(v.id, [v.position[0], v.position[1]]);
+    }
+
+    if (changed.length === 0) return;
+
+    this.recordEvent("vehicle", { vehicles: changed } as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Records a single discrete event.
+   *
+   * @param type - The event type
+   * @param data - Arbitrary event payload
+   */
+  recordEvent(type: RecordingEventType, data: Record<string, unknown>): void {
+    if (!this.recording) return;
+
+    const event: RecordingEvent = {
+      timestamp: Date.now() - this.startTime,
+      type,
+      data,
+    };
+
+    this.buffer.push(JSON.stringify(event));
+    this.eventCount++;
+
+    if (this.buffer.length >= BUFFER_FLUSH_COUNT) {
+      this.flushBuffer();
+    }
+  }
+
+  /**
+   * Writes all buffered event lines to the stream.
+   */
+  private flushBuffer(): void {
+    if (this.buffer.length === 0 || !this.stream) return;
+
+    const chunk = this.buffer.join("\n") + "\n";
+    this.buffer = [];
+    this.stream.write(chunk);
+  }
+}

--- a/apps/simulator/src/modules/ReplayManager.ts
+++ b/apps/simulator/src/modules/ReplayManager.ts
@@ -1,0 +1,335 @@
+import * as fs from "fs";
+import * as readline from "readline";
+import { EventEmitter } from "events";
+import type {
+  RecordingHeader,
+  RecordingEvent,
+  ReplayStatus,
+} from "../types";
+
+type ReplayState = "idle" | "playing" | "paused";
+
+type ReplayEventMap = {
+  vehicle: [unknown];
+  direction: [unknown];
+  "incident:created": [unknown];
+  "incident:cleared": [unknown];
+  heatzones: [unknown];
+  "waypoint:reached": [unknown];
+  "route:completed": [unknown];
+  "vehicle:rerouted": [unknown];
+  "simulation:start": [unknown];
+  "simulation:stop": [unknown];
+  "simulation:reset": [unknown];
+  replayStatus: [ReplayStatus];
+  replayEnd: [];
+};
+
+export class ReplayManager extends EventEmitter<ReplayEventMap> {
+  private events: RecordingEvent[] = [];
+  private header: RecordingHeader | null = null;
+  private filePath: string | null = null;
+
+  private state: ReplayState = "idle";
+  private speed: number = 1.0;
+  private currentIndex: number = 0;
+  private playbackTimer: NodeJS.Timeout | null = null;
+
+  /** Wall-clock time when playback started (or resumed) */
+  private playbackStartWall: number = 0;
+  /** Recording timestamp corresponding to playbackStartWall */
+  private playbackStartRecTs: number = 0;
+
+  constructor() {
+    super();
+  }
+
+  /**
+   * Loads and validates an NDJSON recording file. Reads the header (first line)
+   * and pre-loads all events into memory.
+   *
+   * @param filePath - Path to the NDJSON recording file
+   * @returns The recording header metadata
+   */
+  async loadRecording(filePath: string): Promise<RecordingHeader> {
+    this.cleanup();
+
+    this.filePath = filePath;
+    this.events = [];
+    this.header = null;
+
+    const stream = fs.createReadStream(filePath, { encoding: "utf-8" });
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    let isFirstLine = true;
+
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      const parsed = JSON.parse(trimmed);
+
+      if (isFirstLine) {
+        isFirstLine = false;
+        if (parsed.format !== "moveet-recording" || parsed.version !== 1) {
+          throw new Error(
+            `Invalid recording format: expected moveet-recording v1, got ${parsed.format} v${parsed.version}`
+          );
+        }
+        this.header = parsed as RecordingHeader;
+        continue;
+      }
+
+      this.events.push(parsed as RecordingEvent);
+    }
+
+    if (!this.header) {
+      throw new Error("Recording file is empty or missing header");
+    }
+
+    this.state = "idle";
+    this.currentIndex = 0;
+    this.emitStatus();
+
+    return this.header;
+  }
+
+  /**
+   * Begins replaying events at the recorded timestamps, adjusted by the
+   * speed multiplier.
+   *
+   * @param speed - Playback speed multiplier (default: 1.0)
+   */
+  startReplay(speed?: number): void {
+    if (!this.header || this.events.length === 0) {
+      throw new Error("No recording loaded");
+    }
+
+    this.speed = speed ?? 1.0;
+    this.state = "playing";
+    this.currentIndex = 0;
+
+    this.playbackStartRecTs = this.events[0].timestamp;
+    this.playbackStartWall = Date.now();
+
+    this.scheduleNextEvent();
+    this.emitStatus();
+  }
+
+  /**
+   * Pauses playback, saving the current position.
+   */
+  pauseReplay(): void {
+    if (this.state !== "playing") return;
+
+    this.state = "paused";
+    if (this.playbackTimer) {
+      clearTimeout(this.playbackTimer);
+      this.playbackTimer = null;
+    }
+    this.emitStatus();
+  }
+
+  /**
+   * Resumes playback from the paused position.
+   */
+  resumeReplay(): void {
+    if (this.state !== "paused") return;
+
+    this.state = "playing";
+
+    // Re-anchor wall clock to current position
+    if (this.currentIndex < this.events.length) {
+      this.playbackStartRecTs = this.events[this.currentIndex].timestamp;
+      this.playbackStartWall = Date.now();
+    }
+
+    this.scheduleNextEvent();
+    this.emitStatus();
+  }
+
+  /**
+   * Stops playback completely and resets state.
+   */
+  stopReplay(): void {
+    this.cleanup();
+    this.state = "idle";
+    this.currentIndex = 0;
+    this.emitStatus();
+  }
+
+  /**
+   * Seeks to a specific timestamp (ms offset from recording start).
+   * Uses binary search on the pre-loaded events array.
+   *
+   * @param timestamp - Target timestamp in ms offset from the start of the recording
+   */
+  seekTo(timestamp: number): void {
+    if (!this.header || this.events.length === 0) {
+      throw new Error("No recording loaded");
+    }
+
+    const wasPlaying = this.state === "playing";
+
+    // Cancel any pending scheduled event
+    if (this.playbackTimer) {
+      clearTimeout(this.playbackTimer);
+      this.playbackTimer = null;
+    }
+
+    // The absolute target timestamp in recording time
+    const recordingStartTs = this.events[0].timestamp;
+    const targetTs = recordingStartTs + timestamp;
+
+    // Binary search: find first event at or after targetTs
+    let lo = 0;
+    let hi = this.events.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this.events[mid].timestamp < targetTs) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+
+    this.currentIndex = lo;
+
+    if (wasPlaying || this.state === "playing") {
+      this.state = "playing";
+      if (this.currentIndex < this.events.length) {
+        this.playbackStartRecTs = this.events[this.currentIndex].timestamp;
+        this.playbackStartWall = Date.now();
+        this.scheduleNextEvent();
+      } else {
+        this.state = "idle";
+        this.emit("replayEnd");
+      }
+    }
+
+    this.emitStatus();
+  }
+
+  /**
+   * Returns the current replay status.
+   */
+  getStatus(): ReplayStatus {
+    if (!this.header || this.events.length === 0) {
+      return { mode: "live" };
+    }
+
+    const firstTs = this.events[0].timestamp;
+    const lastTs = this.events[this.events.length - 1].timestamp;
+    const duration = lastTs - firstTs;
+
+    const currentTs =
+      this.currentIndex < this.events.length
+        ? this.events[this.currentIndex].timestamp
+        : lastTs;
+
+    const currentTime = currentTs - firstTs;
+    const progress = duration > 0 ? currentTime / duration : 1;
+
+    return {
+      mode: "replay",
+      file: this.filePath ?? undefined,
+      progress,
+      duration,
+      currentTime,
+      speed: this.speed,
+      paused: this.state === "paused",
+    };
+  }
+
+  /**
+   * Schedules the next event for emission using setTimeout.
+   * Chains through all events sequentially.
+   */
+  private scheduleNextEvent(): void {
+    if (this.state !== "playing") return;
+    if (this.currentIndex >= this.events.length) {
+      this.state = "idle";
+      this.emitStatus();
+      this.emit("replayEnd");
+      return;
+    }
+
+    const event = this.events[this.currentIndex];
+    const delayMs =
+      (event.timestamp - this.playbackStartRecTs) / this.speed -
+      (Date.now() - this.playbackStartWall);
+
+    const actualDelay = Math.max(0, delayMs);
+
+    this.playbackTimer = setTimeout(() => {
+      if (this.state !== "playing") return;
+
+      this.emitRecordingEvent(event);
+      this.currentIndex++;
+      this.scheduleNextEvent();
+    }, actualDelay);
+  }
+
+  /**
+   * Emits a recording event using the appropriate event name.
+   */
+  private emitRecordingEvent(event: RecordingEvent): void {
+    switch (event.type) {
+      case "vehicle":
+        this.emit("vehicle", event.data);
+        break;
+      case "direction":
+        this.emit("direction", event.data);
+        break;
+      case "incident":
+        // Incident events contain an "action" field to distinguish created/cleared
+        if (event.data.action === "created") {
+          this.emit("incident:created", event.data);
+        } else if (event.data.action === "cleared") {
+          this.emit("incident:cleared", event.data);
+        }
+        break;
+      case "heatzone":
+        this.emit("heatzones", event.data);
+        break;
+      case "waypoint":
+        this.emit("waypoint:reached", event.data);
+        break;
+      case "route:completed":
+        this.emit("route:completed", event.data);
+        break;
+      case "vehicle:rerouted":
+        this.emit("vehicle:rerouted", event.data);
+        break;
+      case "simulation:start":
+        this.emit("simulation:start", event.data);
+        break;
+      case "simulation:stop":
+        this.emit("simulation:stop", event.data);
+        break;
+      case "simulation:reset":
+        this.emit("simulation:reset", event.data);
+        break;
+      // spawn and despawn are informational; no dedicated WS event
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Emits the current replay status.
+   */
+  private emitStatus(): void {
+    this.emit("replayStatus", this.getStatus());
+  }
+
+  /**
+   * Cleans up timers and resets playback state.
+   */
+  private cleanup(): void {
+    if (this.playbackTimer) {
+      clearTimeout(this.playbackTimer);
+      this.playbackTimer = null;
+    }
+  }
+}

--- a/apps/simulator/src/modules/ReplayManager.ts
+++ b/apps/simulator/src/modules/ReplayManager.ts
@@ -155,6 +155,9 @@ export class ReplayManager extends EventEmitter<ReplayEventMap> {
     this.cleanup();
     this.state = "idle";
     this.currentIndex = 0;
+    this.events = [];
+    this.header = null;
+    this.filePath = null;
     this.emitStatus();
   }
 

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -1,10 +1,13 @@
 import type { VehicleManager } from "./VehicleManager";
 import type { IncidentManager } from "./IncidentManager";
+import { ReplayManager } from "./ReplayManager";
 import type {
   DirectionRequest,
   DirectionResult,
   Direction,
   Incident,
+  RecordingHeader,
+  ReplayStatus,
   SimulationStatus,
   StartOptions,
   VehicleDTO,
@@ -21,12 +24,26 @@ interface ResetPayload {
 type EventEmitterMap = {
   updateStatus: [SimulationStatus];
   reset: [ResetPayload];
+  replayStatus: [ReplayStatus];
+  replayVehicle: [unknown];
+  replayDirection: [unknown];
+  "replayIncident:created": [unknown];
+  "replayIncident:cleared": [unknown];
+  replayHeatzones: [unknown];
+  "replayWaypoint:reached": [unknown];
+  "replayRoute:completed": [unknown];
+  "replayVehicle:rerouted": [unknown];
+  "replaySimulation:start": [unknown];
+  "replaySimulation:stop": [unknown];
+  "replaySimulation:reset": [unknown];
 };
 
 export class SimulationController extends EventEmitter<EventEmitterMap> {
   private autoHeatZoneInterval?: NodeJS.Timeout;
   private _ready = false;
   private incidentManager?: IncidentManager;
+  private _mode: "live" | "replay" = "live";
+  private replayManager?: ReplayManager;
 
   constructor(
     private vehicleManager: VehicleManager,
@@ -39,6 +56,13 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
     if (!config.adapterURL) {
       this._ready = true;
     }
+  }
+
+  /**
+   * Returns the current simulation mode: 'live' or 'replay'.
+   */
+  public get mode(): "live" | "replay" {
+    return this._mode;
   }
 
   /**
@@ -267,6 +291,119 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
    */
   public getIncidentManager(): IncidentManager | undefined {
     return this.incidentManager;
+  }
+
+  // ─── Replay Mode ────────────────────────────────────────────────────
+
+  /**
+   * Starts replay mode: stops the live simulation if running, loads the
+   * recording file, and begins playback. ReplayManager events are forwarded
+   * as SimulationController events so the WS broadcaster picks them up.
+   *
+   * @param filePath - Path to the NDJSON recording file
+   * @param speed - Playback speed multiplier (default: 1.0)
+   * @returns The recording header metadata
+   */
+  async startReplay(filePath: string, speed?: number): Promise<RecordingHeader> {
+    // Stop live simulation if running
+    if (this.vehicleManager.isRunning()) {
+      this.stop();
+    }
+
+    this._mode = "replay";
+
+    // Create a fresh ReplayManager and wire up event forwarding
+    this.replayManager = new ReplayManager();
+    this.wireReplayEvents(this.replayManager);
+
+    const header = await this.replayManager.loadRecording(filePath);
+    this.replayManager.startReplay(speed);
+
+    return header;
+  }
+
+  /**
+   * Pauses the current replay.
+   */
+  pauseReplay(): void {
+    if (this._mode !== "replay" || !this.replayManager) return;
+    this.replayManager.pauseReplay();
+  }
+
+  /**
+   * Resumes the current replay from its paused position.
+   */
+  resumeReplay(): void {
+    if (this._mode !== "replay" || !this.replayManager) return;
+    this.replayManager.resumeReplay();
+  }
+
+  /**
+   * Stops replay mode and returns to live mode.
+   * Cleans up the ReplayManager instance.
+   */
+  stopReplay(): void {
+    if (this.replayManager) {
+      this.replayManager.stopReplay();
+      this.replayManager.removeAllListeners();
+      this.replayManager = undefined;
+    }
+    this._mode = "live";
+    this.emit("replayStatus", { mode: "live" });
+  }
+
+  /**
+   * Seeks to a specific timestamp in the recording.
+   *
+   * @param timestamp - Target timestamp in ms offset from the start of the recording
+   */
+  seekReplay(timestamp: number): void {
+    if (this._mode !== "replay" || !this.replayManager) return;
+    this.replayManager.seekTo(timestamp);
+  }
+
+  /**
+   * Returns the current replay status, or a default live status if not in replay mode.
+   */
+  getReplayStatus(): ReplayStatus {
+    if (this.replayManager) {
+      return this.replayManager.getStatus();
+    }
+    return { mode: "live" };
+  }
+
+  /**
+   * Wires ReplayManager events to SimulationController events
+   * so the WS broadcaster can forward them to clients.
+   */
+  private wireReplayEvents(rm: ReplayManager): void {
+    const forwardEvents = [
+      ["vehicle", "replayVehicle"],
+      ["direction", "replayDirection"],
+      ["incident:created", "replayIncident:created"],
+      ["incident:cleared", "replayIncident:cleared"],
+      ["heatzones", "replayHeatzones"],
+      ["waypoint:reached", "replayWaypoint:reached"],
+      ["route:completed", "replayRoute:completed"],
+      ["vehicle:rerouted", "replayVehicle:rerouted"],
+      ["simulation:start", "replaySimulation:start"],
+      ["simulation:stop", "replaySimulation:stop"],
+      ["simulation:reset", "replaySimulation:reset"],
+    ] as const;
+
+    for (const [source, target] of forwardEvents) {
+      rm.on(source, (data: unknown) => {
+        (this.emit as (event: string, ...args: unknown[]) => boolean)(target, data);
+      });
+    }
+
+    rm.on("replayStatus", (status: ReplayStatus) => {
+      this.emit("replayStatus", status);
+    });
+
+    rm.on("replayEnd", () => {
+      this.stopReplay();
+    });
   }
 
   /**

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -214,3 +214,61 @@ export interface IncidentDTO {
   expiresAt: number;
   autoClears: boolean;
 }
+
+// ─── Recording & Replay ─────────────────────────────────────────────
+
+export type RecordingEventType =
+  | "vehicle"
+  | "incident"
+  | "heatzone"
+  | "spawn"
+  | "despawn"
+  | "direction"
+  | "waypoint"
+  | "route:completed"
+  | "vehicle:rerouted"
+  | "simulation:start"
+  | "simulation:stop"
+  | "simulation:reset";
+
+export interface RecordingHeader {
+  format: "moveet-recording";
+  version: 1;
+  startTime: string; // ISO 8601
+  vehicleCount: number;
+  options: StartOptions;
+}
+
+export interface RecordingEvent {
+  timestamp: number; // ms since recording start
+  type: RecordingEventType;
+  data: Record<string, unknown>;
+}
+
+export interface RecordingMetadata {
+  filePath: string;
+  startTime: string;
+  duration: number;
+  eventCount: number;
+  fileSize: number;
+  vehicleCount: number;
+}
+
+export interface VehicleSnapshot {
+  id: string;
+  position: [number, number];
+  speed: number;
+  heading: number;
+  edgeId: string;
+  fleetId?: string;
+}
+
+export interface ReplayStatus {
+  mode: "live" | "replay";
+  file?: string;
+  progress?: number; // 0-1
+  duration?: number; // total recording duration in ms
+  currentTime?: number; // current playback position in ms
+  speed?: number; // playback speed multiplier
+  paused?: boolean;
+}


### PR DESCRIPTION
## Summary
- **RecordingManager**: captures simulation events to NDJSON files with buffered sync writes, vehicle snapshot delta dedup (same 0.00001° threshold as WS broadcaster), and auto-generated file naming
- **ReplayManager**: loads NDJSON recordings, replays events via setTimeout chain with configurable speed multiplier (1x/2x/etc), pause/resume/seek support
- **SimulationController**: adds replay mode that stops live sim and forwards replay events to WS broadcaster
- **REST API**: full recording/replay lifecycle endpoints (start/stop recording, list recordings, start/pause/resume/stop/seek replay, get status)
- **Tests**: 18 new tests covering NDJSON roundtrip, delta dedup, timing, speed multiplier, pause/resume, seek, and format validation (410 total pass)

## Test plan
- [x] All 410 tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] CI passes (lint + test + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)