### PR TITLE
feat: time-of-day traffic patterns (fleetsim-all-pv8)

### DIFF
--- a/apps/simulator/src/__tests__/SimulationClock.test.ts
+++ b/apps/simulator/src/__tests__/SimulationClock.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi } from "vitest";
+import { SimulationClock } from "../modules/SimulationClock";
+
+describe("SimulationClock", () => {
+  describe("tick advancement and speed multiplier", () => {
+    it("tick(3600_000) at speedMultiplier=1 advances by exactly 1 hour", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      clock.tick(3_600_000);
+      expect(clock.getHour()).toBe(8);
+    });
+
+    it("tick(3600_000) at speedMultiplier=2 advances by 2 hours", () => {
+      const clock = new SimulationClock({ startHour: 7, speedMultiplier: 2 });
+      clock.tick(3_600_000);
+      expect(clock.getHour()).toBe(9);
+    });
+
+    it("tick(1800_000) at speedMultiplier=2 advances by exactly 1 hour", () => {
+      const clock = new SimulationClock({ startHour: 7, speedMultiplier: 2 });
+      clock.tick(1_800_000);
+      expect(clock.getHour()).toBe(8);
+    });
+
+    it("tick does nothing when speedMultiplier is 0", () => {
+      const clock = new SimulationClock({ startHour: 12 });
+      clock.setSpeedMultiplier(0);
+      clock.tick(3_600_000);
+      expect(clock.getHour()).toBe(12);
+    });
+
+    it("multiple ticks accumulate correctly", () => {
+      const clock = new SimulationClock({ startHour: 6 });
+      for (let i = 0; i < 3; i++) clock.tick(3_600_000);
+      expect(clock.getHour()).toBe(9);
+    });
+  });
+
+  describe("hour:changed event emission", () => {
+    it("emits hour:changed when crossing an hour boundary", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      clock.tick(3_600_000);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(8, "morning_rush");
+    });
+
+    it("does NOT emit hour:changed when staying within the same hour", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      clock.tick(1_800_000); // only 30 minutes
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("emits once per hour boundary crossed", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      clock.tick(1_800_000); // 30 min → still hour 7
+      clock.tick(1_800_000); // 30 min → crosses to hour 8
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it("emits the correct timeOfDay with the hour:changed event", () => {
+      const clock = new SimulationClock({ startHour: 16 });
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      clock.tick(3_600_000); // → hour 17 (evening_rush)
+      expect(handler).toHaveBeenCalledWith(17, "evening_rush");
+    });
+  });
+
+  describe("getTimeOfDay() for all time ranges", () => {
+    it("returns morning_rush at hour 7", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      expect(clock.getTimeOfDay()).toBe("morning_rush");
+    });
+
+    it("returns morning_rush at hour 8", () => {
+      const clock = new SimulationClock({ startHour: 8 });
+      expect(clock.getTimeOfDay()).toBe("morning_rush");
+    });
+
+    it("returns midday at hour 9 (boundary, end of morning_rush)", () => {
+      const clock = new SimulationClock({ startHour: 9 });
+      expect(clock.getTimeOfDay()).toBe("midday");
+    });
+
+    it("returns midday at hour 12", () => {
+      const clock = new SimulationClock({ startHour: 12 });
+      expect(clock.getTimeOfDay()).toBe("midday");
+    });
+
+    it("returns evening_rush at hour 17", () => {
+      const clock = new SimulationClock({ startHour: 17 });
+      expect(clock.getTimeOfDay()).toBe("evening_rush");
+    });
+
+    it("returns evening_rush at hour 18", () => {
+      const clock = new SimulationClock({ startHour: 18 });
+      expect(clock.getTimeOfDay()).toBe("evening_rush");
+    });
+
+    it("returns midday at hour 19 (boundary, end of evening_rush)", () => {
+      const clock = new SimulationClock({ startHour: 19 });
+      expect(clock.getTimeOfDay()).toBe("midday");
+    });
+
+    it("returns night at hour 22", () => {
+      const clock = new SimulationClock({ startHour: 22 });
+      expect(clock.getTimeOfDay()).toBe("night");
+    });
+
+    it("returns night at hour 2", () => {
+      const clock = new SimulationClock({ startHour: 2 });
+      expect(clock.getTimeOfDay()).toBe("night");
+    });
+
+    it("returns night at hour 0", () => {
+      const clock = new SimulationClock({ startHour: 0 });
+      expect(clock.getTimeOfDay()).toBe("night");
+    });
+
+    it("returns midday at hour 5 (boundary, end of night)", () => {
+      const clock = new SimulationClock({ startHour: 5 });
+      expect(clock.getTimeOfDay()).toBe("midday");
+    });
+  });
+
+  describe("API: setSpeedMultiplier, setTime, reset", () => {
+    it("setSpeedMultiplier changes the multiplier immediately", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      clock.setSpeedMultiplier(3);
+      clock.tick(3_600_000);
+      expect(clock.getHour()).toBe(10); // 3 hours forward
+    });
+
+    it("setSpeedMultiplier(0) freezes time", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      clock.setSpeedMultiplier(0);
+      clock.tick(100_000_000);
+      expect(clock.getHour()).toBe(7);
+    });
+
+    it("setSpeedMultiplier throws for negative values", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      expect(() => clock.setSpeedMultiplier(-1)).toThrow();
+    });
+
+    it("setTime jumps to the new time", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const newTime = new Date();
+      newTime.setHours(15, 0, 0, 0);
+      clock.setTime(newTime);
+      expect(clock.getHour()).toBe(15);
+    });
+
+    it("setTime emits hour:changed when hour changes", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      const newTime = new Date();
+      newTime.setHours(15, 0, 0, 0);
+      clock.setTime(newTime);
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(15, "midday");
+    });
+
+    it("setTime does NOT emit hour:changed when hour stays the same", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      const sameHour = new Date();
+      sameHour.setHours(7, 30, 0, 0);
+      clock.setTime(sameHour);
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("reset resets to hour 7 and speedMultiplier 1", () => {
+      const clock = new SimulationClock({ startHour: 15, speedMultiplier: 5 });
+      clock.reset();
+      expect(clock.getHour()).toBe(7);
+      expect(clock.getState().speedMultiplier).toBe(1);
+    });
+  });
+
+  describe("fast-forward with large speedMultiplier", () => {
+    it("large speedMultiplier jumps many hours in one tick", () => {
+      const clock = new SimulationClock({ startHour: 0, speedMultiplier: 10 });
+      clock.tick(3_600_000); // 1 real hour → 10 sim hours
+      expect(clock.getHour()).toBe(10);
+    });
+
+    it("emits hour:changed at the final hour only (not all intermediate hours)", () => {
+      // Each tick only detects the current hour vs last tracked hour
+      const clock = new SimulationClock({ startHour: 0, speedMultiplier: 10 });
+      let eventCount = 0;
+      clock.on("hour:changed", () => eventCount++);
+      clock.tick(3_600_000); // jumps from 0 → 10 in one call
+      // Implementation emits once per tick (detects final crossing)
+      expect(eventCount).toBe(1);
+    });
+  });
+
+  describe("time jump behavior (setTime)", () => {
+    it("setTime can jump backward in time", () => {
+      const clock = new SimulationClock({ startHour: 15 });
+      const earlier = new Date();
+      earlier.setHours(6, 0, 0, 0);
+      clock.setTime(earlier);
+      expect(clock.getHour()).toBe(6);
+    });
+
+    it("setTime updates getTimeOfDay correctly after jump", () => {
+      const clock = new SimulationClock({ startHour: 12 });
+      const rushTime = new Date();
+      rushTime.setHours(8, 0, 0, 0);
+      clock.setTime(rushTime);
+      expect(clock.getTimeOfDay()).toBe("morning_rush");
+    });
+  });
+
+  describe("reset resets to default start time", () => {
+    it("resets hour to 7 regardless of how far the clock has advanced", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      clock.tick(10 * 3_600_000); // advance 10 hours
+      clock.reset();
+      expect(clock.getHour()).toBe(7);
+    });
+
+    it("resets speedMultiplier to 1", () => {
+      const clock = new SimulationClock({ startHour: 7, speedMultiplier: 100 });
+      clock.reset();
+      clock.tick(3_600_000);
+      expect(clock.getHour()).toBe(8); // exactly 1 hour at x1
+    });
+
+    it("resets timeOfDay to morning_rush (hour 7)", () => {
+      const clock = new SimulationClock({ startHour: 22 });
+      clock.reset();
+      expect(clock.getTimeOfDay()).toBe("morning_rush");
+    });
+
+    it("after reset, hour:changed fires again on next hour crossing", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      clock.tick(3_600_000); // → hour 8
+      clock.reset(); // back to 7
+      const handler = vi.fn();
+      clock.on("hour:changed", handler);
+      clock.tick(3_600_000); // → hour 8 again
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("getState() returns correct snapshot", () => {
+    it("returns all four fields", () => {
+      const clock = new SimulationClock({ startHour: 8, speedMultiplier: 2 });
+      const state = clock.getState();
+      expect(state).toHaveProperty("currentTime");
+      expect(state).toHaveProperty("speedMultiplier");
+      expect(state).toHaveProperty("hour");
+      expect(state).toHaveProperty("timeOfDay");
+    });
+
+    it("currentTime is a Date instance", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      expect(clock.getState().currentTime).toBeInstanceOf(Date);
+    });
+
+    it("getState() reflects current hour and timeOfDay", () => {
+      const clock = new SimulationClock({ startHour: 8, speedMultiplier: 2 });
+      const state = clock.getState();
+      expect(state.hour).toBe(8);
+      expect(state.speedMultiplier).toBe(2);
+      expect(state.timeOfDay).toBe("morning_rush");
+    });
+
+    it("getState() is a snapshot (does not mutate on further ticks)", () => {
+      const clock = new SimulationClock({ startHour: 7 });
+      const state = clock.getState();
+      clock.tick(3_600_000); // advance to hour 8
+      // The snapshot should still show hour 7
+      expect(state.hour).toBe(7);
+      expect(clock.getHour()).toBe(8);
+    });
+
+    it("getState() after reset shows hour 7 and multiplier 1", () => {
+      const clock = new SimulationClock({ startHour: 18, speedMultiplier: 5 });
+      clock.reset();
+      const state = clock.getState();
+      expect(state.hour).toBe(7);
+      expect(state.speedMultiplier).toBe(1);
+      expect(state.timeOfDay).toBe("morning_rush");
+    });
+  });
+});

--- a/apps/simulator/src/__tests__/TrafficManager.test.ts
+++ b/apps/simulator/src/__tests__/TrafficManager.test.ts
@@ -1,21 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { TrafficManager } from "../modules/TrafficManager";
+import { SimulationClock } from "../modules/SimulationClock";
+import { getDemandMultiplier, DEFAULT_TRAFFIC_PROFILE } from "../utils/trafficProfiles";
+
+function middayClock() {
+  return new SimulationClock({ startHour: 12 });
+}
 
 describe("TrafficManager", () => {
   it("should track edge occupancy", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("edge-1");
     tm.enter("edge-1");
     expect(tm.getCongestionFactor("edge-1", 0.1)).toBeLessThan(1);
   });
 
   it("should return 1.0 for empty edges", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     expect(tm.getCongestionFactor("edge-1", 0.1)).toBe(1);
   });
 
   it("should decrease congestion factor as occupancy increases", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     const f0 = tm.getCongestionFactor("edge-1", 0.1);
     tm.enter("edge-1");
     const f1 = tm.getCongestionFactor("edge-1", 0.1);
@@ -26,7 +32,7 @@ describe("TrafficManager", () => {
   });
 
   it("should restore congestion factor when vehicles leave", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("edge-1");
     tm.enter("edge-1");
     tm.leave("edge-1");
@@ -35,7 +41,7 @@ describe("TrafficManager", () => {
   });
 
   it("should not go below 0.2", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     for (let i = 0; i < 100; i++) tm.enter("edge-1");
     expect(tm.getCongestionFactor("edge-1", 0.05)).toBeGreaterThanOrEqual(0.2);
   });
@@ -43,14 +49,14 @@ describe("TrafficManager", () => {
 
 describe("TrafficManager - BPR formula verification", () => {
   it("empty edge should have factor exactly 1.0", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     expect(tm.getCongestionFactor("edge-x", 0.1)).toBe(1.0);
     expect(tm.getCongestionFactor("edge-x", 1.0)).toBe(1.0);
     expect(tm.getCongestionFactor("edge-x", 0.01)).toBe(1.0);
   });
 
   it("1 vehicle on 0.1km edge (capacity=2) should yield factor ~0.8", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("edge-1");
     const factor = tm.getCongestionFactor("edge-1", 0.1);
     // capacity = max(1, 0.1*20) = 2, ratio = 1/2 = 0.5
@@ -59,7 +65,7 @@ describe("TrafficManager - BPR formula verification", () => {
   });
 
   it("at capacity (2 vehicles on 0.1km edge) factor should be 0.5", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("edge-1");
     tm.enter("edge-1");
     const factor = tm.getCongestionFactor("edge-1", 0.1);
@@ -69,7 +75,7 @@ describe("TrafficManager - BPR formula verification", () => {
   });
 
   it("over capacity: factor approaches but never goes below 0.2", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     // 0.1km edge, capacity=2, add 10 vehicles -> ratio=5, factor=1/(1+25)=0.0385 -> clamped to 0.2
     for (let i = 0; i < 10; i++) tm.enter("edge-1");
     const factor = tm.getCongestionFactor("edge-1", 0.1);
@@ -83,7 +89,7 @@ describe("TrafficManager - BPR formula verification", () => {
 
 describe("TrafficManager - Edge independence", () => {
   it("congestion on edge-1 should not affect edge-2", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     // Heavily congest edge-1
     for (let i = 0; i < 20; i++) tm.enter("edge-1");
     // edge-2 stays empty
@@ -100,14 +106,14 @@ describe("TrafficManager - Edge independence", () => {
 
 describe("TrafficManager - Leave edge cases", () => {
   it("leave on an edge with 0 vehicles should not go negative", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.leave("edge-empty");
     // After leaving an empty edge, factor should still be 1.0 (0 vehicles)
     expect(tm.getCongestionFactor("edge-empty", 0.1)).toBe(1.0);
   });
 
   it("leave more times than enter should keep occupancy at 0 and factor at 1.0", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("edge-1");
     tm.leave("edge-1");
     tm.leave("edge-1");
@@ -116,7 +122,7 @@ describe("TrafficManager - Leave edge cases", () => {
   });
 
   it("enter 5 times then leave 5 times should return factor to 1.0", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     for (let i = 0; i < 5; i++) tm.enter("edge-1");
     expect(tm.getCongestionFactor("edge-1", 0.1)).toBeLessThan(1.0);
     for (let i = 0; i < 5; i++) tm.leave("edge-1");
@@ -126,7 +132,7 @@ describe("TrafficManager - Leave edge cases", () => {
 
 describe("TrafficManager - Capacity scaling with distance", () => {
   it("short edge (0.01km, capacity clamped to 1) should congest with 1 vehicle", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("short-edge");
     // capacity = max(1, 0.01*20) = max(1, 0.2) = 1, ratio = 1/1 = 1.0
     // factor = 1/(1+1) = 0.5
@@ -135,7 +141,7 @@ describe("TrafficManager - Capacity scaling with distance", () => {
   });
 
   it("long edge (1km, capacity=20) should barely congest with 1 vehicle", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("long-edge");
     // capacity = max(1, 1*20) = 20, ratio = 1/20 = 0.05
     // factor = 1/(1+0.0025) = ~0.9975
@@ -145,7 +151,7 @@ describe("TrafficManager - Capacity scaling with distance", () => {
   });
 
   it("shorter edges should congest faster than longer ones for same vehicle count", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     tm.enter("short");
     tm.enter("long");
     const shortFactor = tm.getCongestionFactor("short", 0.01);
@@ -156,7 +162,7 @@ describe("TrafficManager - Capacity scaling with distance", () => {
 
 describe("TrafficManager - Multiple vehicles entering and leaving", () => {
   it("10 vehicles enter then 5 leave: check intermediate factor", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     for (let i = 0; i < 10; i++) tm.enter("edge-1");
     // capacity = max(1, 0.5*20) = 10, ratio = 10/10 = 1.0
     // factor = 1/(1+1) = 0.5
@@ -171,7 +177,7 @@ describe("TrafficManager - Multiple vehicles entering and leaving", () => {
   });
 
   it("factor is monotonically decreasing as vehicles enter", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     let prevFactor = tm.getCongestionFactor("edge-1", 0.1);
     for (let i = 0; i < 8; i++) {
       tm.enter("edge-1");
@@ -184,7 +190,7 @@ describe("TrafficManager - Multiple vehicles entering and leaving", () => {
   });
 
   it("factor is monotonically increasing as vehicles leave", () => {
-    const tm = new TrafficManager();
+    const tm = new TrafficManager(middayClock());
     // Enter 8 vehicles first
     for (let i = 0; i < 8; i++) tm.enter("edge-1");
 
@@ -197,5 +203,147 @@ describe("TrafficManager - Multiple vehicles entering and leaving", () => {
     }
     // After all leave, factor should be back to 1.0
     expect(prevFactor).toBe(1.0);
+  });
+});
+
+describe("TrafficManager - time-varying demand", () => {
+  it("rush hour multiplies effective occupancy on trunk/primary roads", () => {
+    // At 8am (morning_rush), demand=2.0 on primary roads
+    // 1 vehicle on 0.1km primary edge (capacity=2) → effectiveOccupancy=2 → ratio=1.0 → factor=0.5
+    const clock = new SimulationClock({ startHour: 8 });
+    const tm = new TrafficManager(clock);
+    tm.enter("edge-1");
+    expect(tm.getCongestionFactor("edge-1", 0.1, "primary")).toBeCloseTo(0.5, 5);
+  });
+
+  it("rush hour has no effect on residential roads", () => {
+    // At 8am, demand=1.0 on residential (not in affectedHighways)
+    // 1 vehicle on 0.1km residential (capacity=2) → ratio=0.5 → factor=0.8 (same as midday)
+    const clock = new SimulationClock({ startHour: 8 });
+    const tm = new TrafficManager(clock);
+    tm.enter("edge-1");
+    expect(tm.getCongestionFactor("edge-1", 0.1, "residential")).toBeCloseTo(0.8, 5);
+  });
+
+  it("night reduces effective occupancy on all roads", () => {
+    // At 2am, demand=0.3 on all roads
+    // 1 vehicle on 0.1km primary (capacity=2) → effectiveOccupancy=0.3 → ratio=0.15 → factor=1/(1+0.0225)≈0.978
+    const clock = new SimulationClock({ startHour: 2 });
+    const tm = new TrafficManager(clock);
+    tm.enter("edge-1");
+    const factor = tm.getCongestionFactor("edge-1", 0.1, "primary");
+    expect(factor).toBeGreaterThan(0.97);
+    expect(factor).toBeLessThan(1.0);
+  });
+
+  it("congestion factor updates when clock advances to rush hour", () => {
+    // Start at midday (hour 12), advance to morning rush (hour 7 next day)
+    const clock = new SimulationClock({ startHour: 12 });
+    const tm = new TrafficManager(clock);
+    tm.enter("edge-1");
+
+    const middayFactor = tm.getCongestionFactor("edge-1", 0.1, "primary");
+
+    // Advance clock to next day morning rush (tick forward 19 hours at 1x)
+    clock.tick(19 * 3_600_000);
+
+    const rushFactor = tm.getCongestionFactor("edge-1", 0.1, "primary");
+
+    // Rush hour should have higher effective occupancy → lower factor
+    expect(rushFactor).toBeLessThan(middayFactor);
+  });
+
+  it("evening rush has stronger effect than morning rush", () => {
+    // Evening rush: demandMultiplier=2.5 vs morning=2.0
+    const morningClock = new SimulationClock({ startHour: 8 });
+    const eveningClock = new SimulationClock({ startHour: 18 });
+    const tmMorning = new TrafficManager(morningClock);
+    const tmEvening = new TrafficManager(eveningClock);
+    tmMorning.enter("edge-1");
+    tmEvening.enter("edge-1");
+
+    const morningFactor = tmMorning.getCongestionFactor("edge-1", 0.1, "primary");
+    const eveningFactor = tmEvening.getCongestionFactor("edge-1", 0.1, "primary");
+
+    expect(eveningFactor).toBeLessThan(morningFactor);
+  });
+
+  it("getProfile returns the current profile", () => {
+    const tm = new TrafficManager(new SimulationClock({ startHour: 12 }));
+    const profile = tm.getProfile();
+    expect(profile.name).toBe("default");
+    expect(profile.timeRanges.length).toBeGreaterThan(0);
+  });
+
+  it("setProfile replaces the active profile", () => {
+    const clock = new SimulationClock({ startHour: 8 });
+    const tm = new TrafficManager(clock);
+    tm.enter("edge-1");
+
+    // With default profile, rush hour at 8am on primary = demand 2.0
+    const defaultFactor = tm.getCongestionFactor("edge-1", 0.1, "primary");
+
+    // Set a flat profile (no time variation)
+    tm.setProfile({ name: "flat", timeRanges: [] });
+    const flatFactor = tm.getCongestionFactor("edge-1", 0.1, "primary");
+
+    // Flat profile → demand=1.0 → more lenient than rush hour
+    expect(flatFactor).toBeGreaterThan(defaultFactor);
+  });
+});
+
+describe("trafficProfiles - getDemandMultiplier", () => {
+  it("returns 2.0 for primary at hour 8 (morning_rush)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 8, "primary")).toBe(2.0);
+  });
+
+  it("returns 2.0 for trunk at hour 7 (morning_rush start)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 7, "trunk")).toBe(2.0);
+  });
+
+  it("returns 1.0 for primary at hour 9 (morning_rush end, exclusive)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 9, "primary")).toBe(1.0);
+  });
+
+  it("returns 2.5 for primary at hour 17 (evening_rush)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 17, "primary")).toBe(2.5);
+  });
+
+  it("returns 2.5 for trunk at hour 18 (evening_rush)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 18, "trunk")).toBe(2.5);
+  });
+
+  it("returns 1.0 for primary at hour 19 (evening_rush end, exclusive)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 19, "primary")).toBe(1.0);
+  });
+
+  it("returns 0.3 for primary at hour 22 (night)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 22, "primary")).toBe(0.3);
+  });
+
+  it("returns 0.3 for primary at hour 2 (night)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 2, "primary")).toBe(0.3);
+  });
+
+  it("returns 0.3 for residential at hour 2 (night affects all roads)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 2, "residential")).toBe(0.3);
+  });
+
+  it("returns 1.0 for primary at hour 12 (midday)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 12, "primary")).toBe(1.0);
+  });
+
+  it("returns 1.0 for residential at hour 8 (rush hours only affect trunk/primary)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 8, "residential")).toBe(1.0);
+  });
+
+  it("returns 1.0 for secondary at hour 17 (rush hours only affect trunk/primary)", () => {
+    expect(getDemandMultiplier(DEFAULT_TRAFFIC_PROFILE, 17, "secondary")).toBe(1.0);
+  });
+
+  it("returns 1.0 for an empty profile at any hour", () => {
+    const emptyProfile = { name: "empty", timeRanges: [] };
+    expect(getDemandMultiplier(emptyProfile, 8, "primary")).toBe(1.0);
+    expect(getDemandMultiplier(emptyProfile, 2, "residential")).toBe(1.0);
   });
 });

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -620,6 +620,15 @@ app.post(
 
 // ─── Traffic Profile ────────────────────────────────────────────────
 
+app.get("/traffic", (_req, res) => {
+  try {
+    res.json(vehicleManager.getTrafficSnapshot());
+  } catch (error) {
+    logger.error(`Error in /traffic: ${error}`);
+    res.status(500).json({ error: "Failed to get traffic data" });
+  }
+});
+
 app.get("/traffic-profile", (_req, res) => {
   try {
     res.json(simulationController.getTrafficProfile());
@@ -633,11 +642,7 @@ app.post(
   "/traffic-profile",
   asyncHandler(async (req, res) => {
     const profile = req.body as { name?: string; timeRanges?: unknown[] };
-    if (
-      !profile ||
-      typeof profile.name !== "string" ||
-      !Array.isArray(profile.timeRanges)
-    ) {
+    if (!profile || typeof profile.name !== "string" || !Array.isArray(profile.timeRanges)) {
       res.status(400).json({ error: "Invalid traffic profile format" });
       return;
     }
@@ -744,6 +749,12 @@ async function main() {
   incidentManager.on("incident:cleared", (data) => broadcaster.broadcast("incident:cleared", data));
   vehicleManager.on("vehicle:rerouted", (data) => broadcaster.broadcast("vehicle:rerouted", data));
 
+  // Broadcast per-edge traffic congestion snapshot every 2 seconds
+  const trafficBroadcastInterval = setInterval(() => {
+    const traffic = vehicleManager.getTrafficSnapshot();
+    broadcaster.broadcast("traffic", traffic);
+  }, 2000);
+
   // Wire discrete events to recording manager
   vehicleManager.on("direction", (data) => recordingManager.recordEvent("direction", data));
   vehicleManager.on("waypoint:reached", (data) => recordingManager.recordEvent("waypoint", data));
@@ -802,6 +813,7 @@ async function main() {
     logger.info(`${signal} received. Starting graceful shutdown...`);
 
     broadcaster.stop();
+    clearInterval(trafficBroadcastInterval);
     logger.info("WebSocket broadcaster stopped");
 
     server.close(() => {

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -580,6 +580,72 @@ app.post(
   })
 );
 
+// ─── Clock ──────────────────────────────────────────────────────────
+
+app.get("/clock", (_req, res) => {
+  try {
+    res.json(simulationController.getClock().getState());
+  } catch (error) {
+    logger.error(`Error in /clock: ${error}`);
+    res.status(500).json({ error: "Failed to get clock state" });
+  }
+});
+
+app.post(
+  "/clock",
+  asyncHandler(async (req, res) => {
+    const { speedMultiplier, setTime } = req.body as {
+      speedMultiplier?: number;
+      setTime?: string;
+    };
+    const clock = simulationController.getClock();
+    if (speedMultiplier !== undefined) {
+      if (typeof speedMultiplier !== "number" || speedMultiplier < 0) {
+        res.status(400).json({ error: "speedMultiplier must be a non-negative number" });
+        return;
+      }
+      clock.setSpeedMultiplier(speedMultiplier);
+    }
+    if (setTime !== undefined) {
+      const t = new Date(setTime);
+      if (isNaN(t.getTime())) {
+        res.status(400).json({ error: "setTime must be a valid ISO date string" });
+        return;
+      }
+      clock.setTime(t);
+    }
+    res.json(clock.getState());
+  })
+);
+
+// ─── Traffic Profile ────────────────────────────────────────────────
+
+app.get("/traffic-profile", (_req, res) => {
+  try {
+    res.json(simulationController.getTrafficProfile());
+  } catch (error) {
+    logger.error(`Error in /traffic-profile: ${error}`);
+    res.status(500).json({ error: "Failed to get traffic profile" });
+  }
+});
+
+app.post(
+  "/traffic-profile",
+  asyncHandler(async (req, res) => {
+    const profile = req.body as { name?: string; timeRanges?: unknown[] };
+    if (
+      !profile ||
+      typeof profile.name !== "string" ||
+      !Array.isArray(profile.timeRanges)
+    ) {
+      res.status(400).json({ error: "Invalid traffic profile format" });
+      return;
+    }
+    simulationController.setTrafficProfile(req.body);
+    res.json(simulationController.getTrafficProfile());
+  })
+);
+
 // ─── Fleets ─────────────────────────────────────────────────────────
 
 app.get("/fleets", (_req, res) => {
@@ -668,6 +734,9 @@ async function main() {
   vehicleManager.on("options", (data) => broadcaster.broadcast("options", data));
   simulationController.on("updateStatus", (data) => broadcaster.broadcast("status", data));
   simulationController.on("reset", (data) => broadcaster.broadcast("reset", data));
+  simulationController.on("clock", (clockState) => {
+    broadcaster.broadcast("clock", clockState);
+  });
   fleetManager.on("fleet:created", (data) => broadcaster.broadcast("fleet:created", data));
   fleetManager.on("fleet:deleted", (data) => broadcaster.broadcast("fleet:deleted", data));
   fleetManager.on("fleet:assigned", (data) => broadcaster.broadcast("fleet:assigned", data));

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -224,7 +224,8 @@ export class RoadNetwork extends EventEmitter {
   private buildNetwork(data: FeatureCollection): void {
     data.features.forEach((feature) => {
       if (feature.geometry.type === "LineString") {
-        const streetId = feature.properties?.id || feature.properties?.["@id"] || crypto.randomUUID();
+        const streetId =
+          feature.properties?.id || feature.properties?.["@id"] || crypto.randomUUID();
         // Stamp the resolved streetId back onto the feature for the /network API
         feature.properties!.streetId = streetId;
         const streetName = feature.properties?.name || "";

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -224,7 +224,9 @@ export class RoadNetwork extends EventEmitter {
   private buildNetwork(data: FeatureCollection): void {
     data.features.forEach((feature) => {
       if (feature.geometry.type === "LineString") {
-        const streetId = feature.properties?.id || crypto.randomUUID();
+        const streetId = feature.properties?.id || feature.properties?.["@id"] || crypto.randomUUID();
+        // Stamp the resolved streetId back onto the feature for the /network API
+        feature.properties!.streetId = streetId;
         const streetName = feature.properties?.name || "";
         const coords = (feature.geometry as LineString).coordinates;
 

--- a/apps/simulator/src/modules/SimulationClock.ts
+++ b/apps/simulator/src/modules/SimulationClock.ts
@@ -1,0 +1,80 @@
+import EventEmitter from "events";
+
+export type TimeOfDay = "morning_rush" | "midday" | "evening_rush" | "night";
+
+export interface ClockState {
+  currentTime: Date;
+  speedMultiplier: number;
+  hour: number;
+  timeOfDay: TimeOfDay;
+}
+
+export class SimulationClock extends EventEmitter {
+  private _currentTime: Date;
+  private _speedMultiplier: number;
+  private _lastHour: number;
+
+  constructor(options: { startHour?: number; speedMultiplier?: number } = {}) {
+    super();
+    // Default start: 7am (morning rush)
+    const startHour = options.startHour ?? 7;
+    this._speedMultiplier = options.speedMultiplier ?? 1;
+    this._currentTime = new Date();
+    this._currentTime.setHours(startHour, 0, 0, 0);
+    this._lastHour = startHour;
+  }
+
+  tick(deltaMs: number): void {
+    // Advance simulation time by deltaMs * speedMultiplier
+    const simDeltaMs = deltaMs * this._speedMultiplier;
+    this._currentTime = new Date(this._currentTime.getTime() + simDeltaMs);
+    const newHour = this._currentTime.getHours();
+    if (newHour !== this._lastHour) {
+      this._lastHour = newHour;
+      this.emit("hour:changed", newHour, this.getTimeOfDay());
+    }
+  }
+
+  getHour(): number {
+    return this._currentTime.getHours();
+  }
+
+  getTimeOfDay(): TimeOfDay {
+    const h = this.getHour();
+    if (h >= 7 && h < 9) return "morning_rush";
+    if (h >= 17 && h < 19) return "evening_rush";
+    if (h >= 22 || h < 5) return "night";
+    return "midday";
+  }
+
+  getState(): ClockState {
+    return {
+      currentTime: new Date(this._currentTime),
+      speedMultiplier: this._speedMultiplier,
+      hour: this.getHour(),
+      timeOfDay: this.getTimeOfDay(),
+    };
+  }
+
+  setSpeedMultiplier(multiplier: number): void {
+    if (multiplier < 0) throw new Error("Speed multiplier must be non-negative");
+    this._speedMultiplier = multiplier;
+  }
+
+  setTime(time: Date): void {
+    const oldHour = this._lastHour;
+    this._currentTime = new Date(time);
+    this._lastHour = this._currentTime.getHours();
+    if (this._lastHour !== oldHour) {
+      this.emit("hour:changed", this._lastHour, this.getTimeOfDay());
+    }
+  }
+
+  reset(): void {
+    const startTime = new Date();
+    startTime.setHours(7, 0, 0, 0);
+    this._currentTime = startTime;
+    this._speedMultiplier = 1;
+    this._lastHour = 7;
+  }
+}

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -188,7 +188,8 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
 
     // Wire clock hour:changed to broadcast clock events
     this.vehicleManager.clock.on("hour:changed", (hour: number, timeOfDay: string) => {
-      void hour; void timeOfDay; // used via getStatus()
+      void hour;
+      void timeOfDay; // used via getStatus()
       this.emit("clock", this.getStatus().clock);
     });
 

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -1,7 +1,9 @@
 import type { VehicleManager } from "./VehicleManager";
 import type { IncidentManager } from "./IncidentManager";
+import type { SimulationClock } from "./SimulationClock";
 import { ReplayManager } from "./ReplayManager";
 import type {
+  ClockState,
   DirectionRequest,
   DirectionResult,
   Direction,
@@ -10,6 +12,7 @@ import type {
   ReplayStatus,
   SimulationStatus,
   StartOptions,
+  TrafficProfile,
   VehicleDTO,
 } from "../types";
 import { TIME_INTERVALS } from "../constants";
@@ -36,6 +39,7 @@ type EventEmitterMap = {
   "replaySimulation:start": [unknown];
   "replaySimulation:stop": [unknown];
   "replaySimulation:reset": [unknown];
+  clock: [ClockState | undefined];
 };
 
 export class SimulationController extends EventEmitter<EventEmitterMap> {
@@ -85,10 +89,17 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
    * console.log(`Update interval: ${status.interval}ms`);
    */
   getStatus(): SimulationStatus {
+    const clockState = this.vehicleManager.clock.getState();
     return {
       interval: this.vehicleManager.getOptions().updateInterval,
       running: this.vehicleManager.isRunning(),
       ready: this._ready,
+      clock: {
+        currentTime: clockState.currentTime.toISOString(),
+        speedMultiplier: clockState.speedMultiplier,
+        hour: clockState.hour,
+        timeOfDay: clockState.timeOfDay,
+      },
     };
   }
 
@@ -175,7 +186,34 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
       }, TIME_INTERVALS.HEAT_ZONE_REGEN_INTERVAL);
     }
 
+    // Wire clock hour:changed to broadcast clock events
+    this.vehicleManager.clock.on("hour:changed", (hour: number, timeOfDay: string) => {
+      void hour; void timeOfDay; // used via getStatus()
+      this.emit("clock", this.getStatus().clock);
+    });
+
     this.emit("updateStatus", this.getStatus());
+  }
+
+  /**
+   * Returns the SimulationClock instance from the VehicleManager.
+   */
+  public getClock(): SimulationClock {
+    return this.vehicleManager.clock;
+  }
+
+  /**
+   * Returns the current traffic profile.
+   */
+  public getTrafficProfile(): TrafficProfile {
+    return this.vehicleManager.getTrafficProfile();
+  }
+
+  /**
+   * Sets the active traffic profile.
+   */
+  public setTrafficProfile(profile: TrafficProfile): void {
+    this.vehicleManager.setTrafficProfile(profile);
   }
 
   /**

--- a/apps/simulator/src/modules/TrafficManager.ts
+++ b/apps/simulator/src/modules/TrafficManager.ts
@@ -1,8 +1,17 @@
+import type { SimulationClock } from "./SimulationClock";
+import {
+  getDemandMultiplier,
+  DEFAULT_TRAFFIC_PROFILE,
+  type TrafficProfile,
+} from "../utils/trafficProfiles";
+import type { HighwayType } from "../types";
+
 export class TrafficManager {
-  // edge ID -> count of vehicles currently on that edge
   private edgeOccupancy: Map<string, number> = new Map();
-  // Capacity estimate: 1 vehicle per 50m of road
   private static readonly CAPACITY_PER_KM = 20;
+  private profile: TrafficProfile = { ...DEFAULT_TRAFFIC_PROFILE };
+
+  constructor(private clock?: SimulationClock) {}
 
   enter(edgeId: string): void {
     this.edgeOccupancy.set(edgeId, (this.edgeOccupancy.get(edgeId) ?? 0) + 1);
@@ -15,14 +24,23 @@ export class TrafficManager {
   }
 
   /**
-   * Returns a speed multiplier (0.2 to 1.0) based on edge congestion.
-   * At capacity: 0.2 (crawl). Empty: 1.0 (free flow).
+   * Returns a speed multiplier (0.2 to 1.0) based on edge congestion and time-of-day demand.
    */
-  getCongestionFactor(edgeId: string, edgeDistanceKm: number): number {
+  getCongestionFactor(edgeId: string, edgeDistanceKm: number, highway: HighwayType = "primary"): number {
     const count = this.edgeOccupancy.get(edgeId) ?? 0;
     const capacity = Math.max(1, edgeDistanceKm * TrafficManager.CAPACITY_PER_KM);
-    const occupancyRatio = count / capacity;
-    // BPR-style congestion: speed drops as occupancy approaches capacity
+    const hour = this.clock?.getHour() ?? new Date().getHours();
+    const demand = getDemandMultiplier(this.profile, hour, highway);
+    const effectiveOccupancy = count * demand;
+    const occupancyRatio = effectiveOccupancy / capacity;
     return Math.max(0.2, 1 / (1 + occupancyRatio * occupancyRatio));
+  }
+
+  getProfile(): TrafficProfile {
+    return { ...this.profile, timeRanges: [...this.profile.timeRanges] };
+  }
+
+  setProfile(profile: TrafficProfile): void {
+    this.profile = profile;
   }
 }

--- a/apps/simulator/src/modules/TrafficManager.ts
+++ b/apps/simulator/src/modules/TrafficManager.ts
@@ -59,12 +59,14 @@ export class TrafficManager {
     congestion: number;
     coordinates: [number, number][];
     highway: string;
+    streetId: string;
   }> {
     const result: Array<{
       edgeId: string;
       congestion: number;
       coordinates: [number, number][];
       highway: string;
+      streetId: string;
     }> = [];
     for (const [edgeId, count] of this.edgeOccupancy) {
       if (count <= 0) continue;
@@ -83,6 +85,7 @@ export class TrafficManager {
           [edge.end.coordinates[1], edge.end.coordinates[0]],
         ],
         highway: edge.highway,
+        streetId: edge.streetId,
       });
     }
     return result;

--- a/apps/simulator/src/modules/TrafficManager.ts
+++ b/apps/simulator/src/modules/TrafficManager.ts
@@ -79,8 +79,8 @@ export class TrafficManager {
         edgeId,
         congestion,
         coordinates: [
-          [edge.start.coordinates[0], edge.start.coordinates[1]],
-          [edge.end.coordinates[0], edge.end.coordinates[1]],
+          [edge.start.coordinates[1], edge.start.coordinates[0]],
+          [edge.end.coordinates[1], edge.end.coordinates[0]],
         ],
         highway: edge.highway,
       });

--- a/apps/simulator/src/modules/TrafficManager.ts
+++ b/apps/simulator/src/modules/TrafficManager.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_TRAFFIC_PROFILE,
   type TrafficProfile,
 } from "../utils/trafficProfiles";
-import type { HighwayType } from "../types";
+import type { Edge, HighwayType } from "../types";
 
 export class TrafficManager {
   private edgeOccupancy: Map<string, number> = new Map();
@@ -26,7 +26,11 @@ export class TrafficManager {
   /**
    * Returns a speed multiplier (0.2 to 1.0) based on edge congestion and time-of-day demand.
    */
-  getCongestionFactor(edgeId: string, edgeDistanceKm: number, highway: HighwayType = "primary"): number {
+  getCongestionFactor(
+    edgeId: string,
+    edgeDistanceKm: number,
+    highway: HighwayType = "primary"
+  ): number {
     const count = this.edgeOccupancy.get(edgeId) ?? 0;
     const capacity = Math.max(1, edgeDistanceKm * TrafficManager.CAPACITY_PER_KM);
     const hour = this.clock?.getHour() ?? new Date().getHours();
@@ -42,5 +46,45 @@ export class TrafficManager {
 
   setProfile(profile: TrafficProfile): void {
     this.profile = profile;
+  }
+
+  /**
+   * Returns a snapshot of all edges with congestion data.
+   * congestionFactor: 1.0 = free flow, 0.2 = completely jammed.
+   */
+  getTrafficSnapshot(
+    getEdge: (id: string) => Edge | undefined
+  ): Array<{
+    edgeId: string;
+    congestion: number;
+    coordinates: [number, number][];
+    highway: string;
+  }> {
+    const result: Array<{
+      edgeId: string;
+      congestion: number;
+      coordinates: [number, number][];
+      highway: string;
+    }> = [];
+    for (const [edgeId, count] of this.edgeOccupancy) {
+      if (count <= 0) continue;
+      const edge = getEdge(edgeId);
+      if (!edge) continue;
+      const congestion = this.getCongestionFactor(
+        edgeId,
+        edge.distance,
+        edge.highway
+      );
+      result.push({
+        edgeId,
+        congestion,
+        coordinates: [
+          [edge.start.coordinates[0], edge.start.coordinates[1]],
+          [edge.end.coordinates[0], edge.end.coordinates[1]],
+        ],
+        highway: edge.highway,
+      });
+    }
+    return result;
   }
 }

--- a/apps/simulator/src/modules/TrafficManager.ts
+++ b/apps/simulator/src/modules/TrafficManager.ts
@@ -52,9 +52,7 @@ export class TrafficManager {
    * Returns a snapshot of all edges with congestion data.
    * congestionFactor: 1.0 = free flow, 0.2 = completely jammed.
    */
-  getTrafficSnapshot(
-    getEdge: (id: string) => Edge | undefined
-  ): Array<{
+  getTrafficSnapshot(getEdge: (id: string) => Edge | undefined): Array<{
     edgeId: string;
     congestion: number;
     coordinates: [number, number][];
@@ -72,11 +70,7 @@ export class TrafficManager {
       if (count <= 0) continue;
       const edge = getEdge(edgeId);
       if (!edge) continue;
-      const congestion = this.getCongestionFactor(
-        edgeId,
-        edge.distance,
-        edge.highway
-      );
+      const congestion = this.getCongestionFactor(edgeId, edge.distance, edge.highway);
       result.push({
         edgeId,
         congestion,

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -11,7 +11,9 @@ import type {
   StartOptions,
   Waypoint,
   MultiStopRoute,
+  TrafficProfile,
 } from "../types";
+import { SimulationClock } from "./SimulationClock";
 import { VEHICLE_CONSTANTS } from "../constants";
 import type { RoadNetwork } from "./RoadNetwork";
 import { config } from "../utils/config";
@@ -34,13 +36,15 @@ export class VehicleManager extends EventEmitter {
   private lastPathfindAttempt: Map<string, number> = new Map();
   private static readonly PATHFIND_COOLDOWN = 3000;
   private adapter = new Adapter();
-  private traffic = new TrafficManager();
+  public readonly clock = new SimulationClock({ startHour: 7, speedMultiplier: 1 });
+  private traffic = new TrafficManager(this.clock);
   public readonly fleets = new FleetManager();
 
   // Task 1: Single game loop instead of per-vehicle setInterval
   private activeVehicles: Set<string> = new Set();
   private gameLoopInterval: NodeJS.Timeout | null = null;
   private gameLoopIntervalMs: number = config.updateInterval;
+  private lastClockTick: number = Date.now();
 
   // Task 2: Edge → vehicle spatial index for O(1) lookups
   private vehiclesByEdge: Map<string, Set<string>> = new Map();
@@ -140,7 +144,7 @@ export class VehicleManager extends EventEmitter {
 
     // Phase 2: Synchronous swap — no await below this point, so no
     // event-loop yield. The map swap is atomic w.r.t. concurrent readers.
-    this.fleetManager.reset();
+    this.clock.reset();
     this.vehicles = new Map();
     this.visitedEdges = new Map();
     this.routes = new Map();
@@ -320,6 +324,12 @@ export class VehicleManager extends EventEmitter {
    */
   private gameLoopTick(): void {
     const now = Date.now();
+
+    // Tick simulation clock once per game loop
+    const clockDelta = now - this.lastClockTick;
+    this.lastClockTick = now;
+    this.clock.tick(clockDelta);
+
     for (const vehicleId of this.activeVehicles) {
       const vehicle = this.vehicles.get(vehicleId);
       if (!vehicle) continue;
@@ -479,13 +489,21 @@ export class VehicleManager extends EventEmitter {
 
   private updateSpeed(vehicle: Vehicle, deltaMs: number): void {
     const edgeMaxSpeed = vehicle.currentEdge.maxSpeed;
+
+    // Time-based speed adjustment: night bonus on highways, no change otherwise
+    const hour = this.clock.getHour();
+    const isHighway = vehicle.currentEdge.highway === "trunk" || vehicle.currentEdge.highway === "primary";
+    const timeSpeedModifier = (hour >= 22 || hour < 5) && isHighway ? 1.1 : 1.0;
+    const adjustedEdgeMaxSpeed = edgeMaxSpeed * timeSpeedModifier;
+
     const isInHeatZone = this.network.isPositionInHeatZone(vehicle.position);
     const speedFactor = isInHeatZone ? this.options.heatZoneSpeedFactor : 1;
     const congestion = this.traffic.getCongestionFactor(
       vehicle.currentEdge.id,
-      vehicle.currentEdge.distance
+      vehicle.currentEdge.distance,
+      vehicle.currentEdge.highway
     );
-    const effectiveMax = Math.min(this.options.maxSpeed, edgeMaxSpeed) * speedFactor * congestion;
+    const effectiveMax = Math.min(this.options.maxSpeed, adjustedEdgeMaxSpeed) * speedFactor * congestion;
 
     // Refresh target speed occasionally (roughly every 5 seconds)
     if (!vehicle.targetSpeed || Math.random() < deltaMs / 5000) {
@@ -1090,5 +1108,13 @@ export class VehicleManager extends EventEmitter {
    */
   public getNetwork(): RoadNetwork {
     return this.network;
+  }
+
+  public getTrafficProfile(): TrafficProfile {
+    return this.traffic.getProfile();
+  }
+
+  public setTrafficProfile(profile: TrafficProfile): void {
+    this.traffic.setProfile(profile);
   }
 }

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -492,7 +492,8 @@ export class VehicleManager extends EventEmitter {
 
     // Time-based speed adjustment: night bonus on highways, no change otherwise
     const hour = this.clock.getHour();
-    const isHighway = vehicle.currentEdge.highway === "trunk" || vehicle.currentEdge.highway === "primary";
+    const isHighway =
+      vehicle.currentEdge.highway === "trunk" || vehicle.currentEdge.highway === "primary";
     const timeSpeedModifier = (hour >= 22 || hour < 5) && isHighway ? 1.1 : 1.0;
     const adjustedEdgeMaxSpeed = edgeMaxSpeed * timeSpeedModifier;
 
@@ -503,7 +504,8 @@ export class VehicleManager extends EventEmitter {
       vehicle.currentEdge.distance,
       vehicle.currentEdge.highway
     );
-    const effectiveMax = Math.min(this.options.maxSpeed, adjustedEdgeMaxSpeed) * speedFactor * congestion;
+    const effectiveMax =
+      Math.min(this.options.maxSpeed, adjustedEdgeMaxSpeed) * speedFactor * congestion;
 
     // Refresh target speed occasionally (roughly every 5 seconds)
     if (!vehicle.targetSpeed || Math.random() < deltaMs / 5000) {
@@ -1116,5 +1118,9 @@ export class VehicleManager extends EventEmitter {
 
   public setTrafficProfile(profile: TrafficProfile): void {
     this.traffic.setProfile(profile);
+  }
+
+  public getTrafficSnapshot() {
+    return this.traffic.getTrafficSnapshot((id) => this.network.getEdge(id));
   }
 }

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -65,10 +65,33 @@ export interface VehicleDTO {
   fleetId?: string;
 }
 
+// Time-of-day types
+export type TimeOfDay = "morning_rush" | "midday" | "evening_rush" | "night";
+
+export interface ClockState {
+  currentTime: string; // ISO string for JSON serialization
+  speedMultiplier: number;
+  hour: number;
+  timeOfDay: TimeOfDay;
+}
+
+export interface TimeRange {
+  start: number;
+  end: number;
+  demandMultiplier: number;
+  affectedHighways: string[];
+}
+
+export interface TrafficProfile {
+  name: string;
+  timeRanges: TimeRange[];
+}
+
 export interface SimulationStatus {
   interval: number;
   running: boolean;
   ready: boolean;
+  clock?: ClockState;
 }
 
 export interface PathNode {

--- a/apps/simulator/src/utils/trafficProfiles.ts
+++ b/apps/simulator/src/utils/trafficProfiles.ts
@@ -1,0 +1,61 @@
+export interface TimeRange {
+  start: number; // hour (0-23, inclusive)
+  end: number; // hour (0-23, exclusive)
+  demandMultiplier: number;
+  affectedHighways: string[]; // HighwayType values; empty = all roads
+}
+
+export interface TrafficProfile {
+  name: string;
+  timeRanges: TimeRange[];
+}
+
+export const DEFAULT_TRAFFIC_PROFILE: TrafficProfile = {
+  name: "default",
+  timeRanges: [
+    {
+      start: 7,
+      end: 9,
+      demandMultiplier: 2.0,
+      affectedHighways: ["trunk", "primary"],
+    },
+    {
+      start: 17,
+      end: 19,
+      demandMultiplier: 2.5,
+      affectedHighways: ["trunk", "primary"],
+    },
+    {
+      start: 22,
+      end: 24,
+      demandMultiplier: 0.3,
+      affectedHighways: [],
+    },
+    {
+      start: 0,
+      end: 5,
+      demandMultiplier: 0.3,
+      affectedHighways: [],
+    },
+  ],
+};
+
+/** Returns the demand multiplier for the given hour and highway type. */
+export function getDemandMultiplier(
+  profile: TrafficProfile,
+  hour: number,
+  highway: string
+): number {
+  for (const range of profile.timeRanges) {
+    // Handle midnight-crossing ranges (start > end)
+    const inRange =
+      range.start <= range.end
+        ? hour >= range.start && hour < range.end
+        : hour >= range.start || hour < range.end;
+    if (!inRange) continue;
+    if (range.affectedHighways.length === 0 || range.affectedHighways.includes(highway)) {
+      return range.demandMultiplier;
+    }
+  }
+  return 1.0; // default: no adjustment
+}

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -11,6 +11,7 @@ import type { PanelId } from "./Controls/IconRail";
 import BottomDock from "./Controls/BottomDock";
 import TogglesPanel from "./Controls/TogglesPanel";
 import SpeedPanel from "./Controls/SpeedPanel";
+import ClockPanel from "./Controls/ClockPanel";
 import AdapterDrawer from "./Controls/Adapter/AdapterDrawer";
 import { useAdapterConfig } from "./Controls/Adapter/useAdapterConfig";
 import useTracking from "./Controls/useTracking";
@@ -434,6 +435,7 @@ export default function App() {
               <TogglesPanel modifiers={modifiers} onChangeModifiers={onChangeModifiers} />
             )}
             {activePanel === "speed" && <SpeedPanel maxSpeedRef={maxSpeedRef} />}
+            {activePanel === "clock" && <ClockPanel />}
             {activePanel === "adapter" && (
               <AdapterDrawer
                 isOpen={true}

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -1,3 +1,18 @@
+/* ── Clock header (custom, not using PanelHeader) ───── */
+.clockHeader {
+  padding: var(--space-5) var(--space-5) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.subtitle {
+  margin: var(--space-2) 0 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
 .body {
   gap: var(--space-5);
 }
@@ -135,9 +150,14 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: var(--space-2);
+  width: 100%;
 }
 
 .presetBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
   padding: var(--space-2) 0;
   background: var(--surface-bg);
   border: var(--surface-border);
@@ -146,7 +166,9 @@
   font-size: var(--text-xs);
   font-weight: 600;
   cursor: pointer;
-  transition: background var(--transition-fast), color var(--transition-fast),
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
     border-color var(--transition-fast);
 }
 

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -2,59 +2,47 @@
   gap: var(--space-5);
 }
 
-/* ── Time display ───────────────────────────────────── */
-.timeDisplay {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-4) 0 var(--space-2);
-}
-
-.timeValue {
-  font-family: "Courier New", Courier, monospace;
-  font-size: var(--text-2xl);
+/* ── Eyebrow labels ─────────────────────────────────── */
+.eyebrow_morning_rush {
+  color: #fb923c;
+  font-size: var(--text-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: var(--color-text-primary);
-  line-height: 1;
-}
-
-/* ── Time-of-day badge ──────────────────────────────── */
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: var(--space-1) var(--space-3);
-  border-radius: var(--radius-full);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.badge_morning_rush {
-  background: rgba(251, 146, 60, 0.18);
-  color: #fb923c;
-  border: 1px solid rgba(251, 146, 60, 0.35);
+.eyebrow_midday {
+  color: var(--color-gray-light);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.badge_midday {
-  background: rgba(255, 255, 255, 0.1);
-  color: var(--color-text-primary);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-}
-
-.badge_evening_rush {
-  background: rgba(239, 68, 68, 0.18);
+.eyebrow_evening_rush {
   color: #f87171;
-  border: 1px solid rgba(239, 68, 68, 0.35);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.badge_night {
-  background: rgba(99, 102, 241, 0.18);
+.eyebrow_night {
   color: #a5b4fc;
-  border: 1px solid rgba(99, 102, 241, 0.35);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* ── Time value (used as PanelHeader title) ─────────── */
+.timeValue {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 48px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-white);
+  line-height: 1;
 }
 
 /* ── Speed section ──────────────────────────────────── */
@@ -62,24 +50,17 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  border-top: var(--panel-border);
+  padding-top: var(--space-4);
+  margin-top: var(--space-2);
 }
 
-.speedHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.speedLabel {
-  font-size: var(--text-sm);
+.sectionLabel {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--color-text-secondary);
-}
-
-.speedValue {
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--color-text-primary);
-  font-variant-numeric: tabular-nums;
 }
 
 .slider {
@@ -114,13 +95,39 @@
 }
 
 .slider:hover::-webkit-slider-thumb {
-  background: var(--color-text-primary);
+  background: var(--color-white);
+}
+
+.speedSummary {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.speedValueAccent {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-accent);
+  line-height: 1;
+}
+
+.speedValueNeutral {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+.speedDot {
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
 }
 
 .speedDesc {
   font-size: var(--text-xs);
   color: var(--color-text-secondary);
-  text-align: center;
 }
 
 /* ── Preset buttons ─────────────────────────────────── */

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -1,0 +1,159 @@
+.body {
+  gap: var(--space-5);
+}
+
+/* ── Time display ───────────────────────────────────── */
+.timeDisplay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-2);
+}
+
+.timeValue {
+  font-family: "Courier New", Courier, monospace;
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+
+/* ── Time-of-day badge ──────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.badge_morning_rush {
+  background: rgba(251, 146, 60, 0.18);
+  color: #fb923c;
+  border: 1px solid rgba(251, 146, 60, 0.35);
+}
+
+.badge_midday {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-primary);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.badge_evening_rush {
+  background: rgba(239, 68, 68, 0.18);
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.badge_night {
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+}
+
+/* ── Speed section ──────────────────────────────────── */
+.speedSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.speedHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.speedLabel {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.speedValue {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.slider {
+  width: 100%;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--surface-bg-active);
+  border-radius: var(--radius-full);
+  outline: none;
+  cursor: pointer;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: none;
+  cursor: pointer;
+}
+
+.slider:hover::-webkit-slider-thumb {
+  background: var(--color-text-primary);
+}
+
+.speedDesc {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+/* ── Preset buttons ─────────────────────────────────── */
+.presets {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-2);
+}
+
+.presetBtn {
+  padding: var(--space-2) 0;
+  background: var(--surface-bg);
+  border: var(--surface-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.presetBtn:hover {
+  background: var(--surface-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.presetBtnActive {
+  background: rgba(51, 153, 255, 0.15);
+  border: 1px solid rgba(51, 153, 255, 0.4);
+  color: var(--color-accent);
+}
+
+.presetBtnActive:hover {
+  background: rgba(51, 153, 255, 0.22);
+}

--- a/apps/ui/src/Controls/ClockPanel.tsx
+++ b/apps/ui/src/Controls/ClockPanel.tsx
@@ -1,0 +1,102 @@
+import type { TimeOfDay } from "@/types";
+import { useClock } from "@/hooks/useClock";
+import { PanelBody, PanelHeader } from "./PanelPrimitives";
+import styles from "./ClockPanel.module.css";
+
+const TIME_OF_DAY_META: Record<TimeOfDay, { label: string; emoji: string }> = {
+  morning_rush: { label: "Morning Rush", emoji: "🌅" },
+  midday: { label: "Midday", emoji: "☀️" },
+  evening_rush: { label: "Evening Rush", emoji: "🌆" },
+  night: { label: "Night", emoji: "🌙" },
+};
+
+const SPEED_PRESETS = [
+  { label: "1×", value: 1 },
+  { label: "60×", value: 60 },
+  { label: "360×", value: 360 },
+  { label: "3600×", value: 3600 },
+];
+
+const MAX_MULTIPLIER = 3600;
+const LOG_MAX = Math.log10(MAX_MULTIPLIER);
+
+function multiplierToSlider(multiplier: number): number {
+  if (multiplier <= 1) return 0;
+  return Math.round((Math.log10(Math.max(1, multiplier)) / LOG_MAX) * 100);
+}
+
+function sliderToMultiplier(slider: number): number {
+  if (slider <= 0) return 1;
+  return Math.round(Math.pow(10, (slider / 100) * LOG_MAX));
+}
+
+function speedDescription(multiplier: number): string {
+  if (multiplier === 1) return "real-time";
+  if (multiplier < 60) return `${multiplier}× speed`;
+  if (multiplier === 60) return "1 sim-min / real-sec";
+  if (multiplier === 3600) return "1 sim-hr / real-sec";
+  if (multiplier % 3600 === 0) return `${multiplier / 3600} sim-hr / real-sec`;
+  if (multiplier % 60 === 0) return `${multiplier / 60} sim-min / real-sec`;
+  return `${multiplier}× speed`;
+}
+
+export default function ClockPanel() {
+  const { clock, setSpeedMultiplier } = useClock();
+
+  const timeStr = new Date(clock.currentTime).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const meta = TIME_OF_DAY_META[clock.timeOfDay];
+  const sliderValue = multiplierToSlider(clock.speedMultiplier);
+
+  function handleSliderChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setSpeedMultiplier(sliderToMultiplier(Number(e.target.value)));
+  }
+
+  return (
+    <>
+      <PanelHeader title="Simulation Clock" subtitle="Current simulation time and speed controls." />
+      <PanelBody className={styles.body}>
+        <div className={styles.timeDisplay}>
+          <span className={styles.timeValue}>{timeStr}</span>
+          <span className={`${styles.badge} ${styles[`badge_${clock.timeOfDay}`]}`}>
+            {meta.emoji} {meta.label}
+          </span>
+        </div>
+
+        <div className={styles.speedSection}>
+          <div className={styles.speedHeader}>
+            <span className={styles.speedLabel}>Simulation Speed</span>
+            <span className={styles.speedValue}>{clock.speedMultiplier}×</span>
+          </div>
+          <input
+            type="range"
+            className={styles.slider}
+            min={0}
+            max={100}
+            value={sliderValue}
+            onChange={handleSliderChange}
+            aria-label="Speed multiplier"
+          />
+          <span className={styles.speedDesc}>{speedDescription(clock.speedMultiplier)}</span>
+        </div>
+
+        <div className={styles.presets}>
+          {SPEED_PRESETS.map(({ label, value }) => (
+            <button
+              key={value}
+              type="button"
+              className={`${styles.presetBtn} ${clock.speedMultiplier === value ? styles.presetBtnActive : ""}`}
+              onClick={() => setSpeedMultiplier(value)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </PanelBody>
+    </>
+  );
+}

--- a/apps/ui/src/Controls/ClockPanel.tsx
+++ b/apps/ui/src/Controls/ClockPanel.tsx
@@ -3,11 +3,11 @@ import { useClock } from "@/hooks/useClock";
 import { PanelBody, PanelHeader } from "./PanelPrimitives";
 import styles from "./ClockPanel.module.css";
 
-const TIME_OF_DAY_META: Record<TimeOfDay, { label: string; emoji: string }> = {
-  morning_rush: { label: "Morning Rush", emoji: "🌅" },
-  midday: { label: "Midday", emoji: "☀️" },
-  evening_rush: { label: "Evening Rush", emoji: "🌆" },
-  night: { label: "Night", emoji: "🌙" },
+const TIME_OF_DAY_LABELS: Record<TimeOfDay, string> = {
+  morning_rush: "Morning Rush",
+  midday: "Midday",
+  evening_rush: "Evening Rush",
+  night: "Night",
 };
 
 const SPEED_PRESETS = [
@@ -32,11 +32,10 @@ function sliderToMultiplier(slider: number): number {
 
 function speedDescription(multiplier: number): string {
   if (multiplier === 1) return "real-time";
-  if (multiplier < 60) return `${multiplier}× speed`;
-  if (multiplier === 60) return "1 sim-min / real-sec";
-  if (multiplier === 3600) return "1 sim-hr / real-sec";
-  if (multiplier % 3600 === 0) return `${multiplier / 3600} sim-hr / real-sec`;
-  if (multiplier % 60 === 0) return `${multiplier / 60} sim-min / real-sec`;
+  if (multiplier === 60) return "1 sim-min per second";
+  if (multiplier === 3600) return "1 sim-hour per second";
+  if (multiplier % 3600 === 0) return `${multiplier / 3600} sim-hours per second`;
+  if (multiplier % 60 === 0) return `${multiplier / 60} sim-mins per second`;
   return `${multiplier}× speed`;
 }
 
@@ -49,8 +48,8 @@ export default function ClockPanel() {
     hour12: false,
   });
 
-  const meta = TIME_OF_DAY_META[clock.timeOfDay];
   const sliderValue = multiplierToSlider(clock.speedMultiplier);
+  const isRealTime = clock.speedMultiplier === 1;
 
   function handleSliderChange(e: React.ChangeEvent<HTMLInputElement>) {
     setSpeedMultiplier(sliderToMultiplier(Number(e.target.value)));
@@ -58,20 +57,18 @@ export default function ClockPanel() {
 
   return (
     <>
-      <PanelHeader title="Simulation Clock" subtitle="Current simulation time and speed controls." />
-      <PanelBody className={styles.body}>
-        <div className={styles.timeDisplay}>
-          <span className={styles.timeValue}>{timeStr}</span>
-          <span className={`${styles.badge} ${styles[`badge_${clock.timeOfDay}`]}`}>
-            {meta.emoji} {meta.label}
+      <PanelHeader
+        eyebrow={
+          <span className={styles[`eyebrow_${clock.timeOfDay}`]}>
+            {TIME_OF_DAY_LABELS[clock.timeOfDay].toUpperCase()}
           </span>
-        </div>
-
+        }
+        title={<span className={styles.timeValue}>{timeStr}</span>}
+        subtitle="Nairobi Fleet Simulation"
+      />
+      <PanelBody className={styles.body}>
         <div className={styles.speedSection}>
-          <div className={styles.speedHeader}>
-            <span className={styles.speedLabel}>Simulation Speed</span>
-            <span className={styles.speedValue}>{clock.speedMultiplier}×</span>
-          </div>
+          <span className={styles.sectionLabel}>SIMULATION SPEED</span>
           <input
             type="range"
             className={styles.slider}
@@ -81,7 +78,13 @@ export default function ClockPanel() {
             onChange={handleSliderChange}
             aria-label="Speed multiplier"
           />
-          <span className={styles.speedDesc}>{speedDescription(clock.speedMultiplier)}</span>
+          <span className={styles.speedSummary}>
+            <span className={isRealTime ? styles.speedValueNeutral : styles.speedValueAccent}>
+              {clock.speedMultiplier}×
+            </span>
+            <span className={styles.speedDot}>·</span>
+            <span className={styles.speedDesc}>{speedDescription(clock.speedMultiplier)}</span>
+          </span>
         </div>
 
         <div className={styles.presets}>

--- a/apps/ui/src/Controls/ClockPanel.tsx
+++ b/apps/ui/src/Controls/ClockPanel.tsx
@@ -1,6 +1,6 @@
 import type { TimeOfDay } from "@/types";
 import { useClock } from "@/hooks/useClock";
-import { PanelBody, PanelHeader } from "./PanelPrimitives";
+import { PanelBody } from "./PanelPrimitives";
 import styles from "./ClockPanel.module.css";
 
 const TIME_OF_DAY_LABELS: Record<TimeOfDay, string> = {
@@ -57,15 +57,13 @@ export default function ClockPanel() {
 
   return (
     <>
-      <PanelHeader
-        eyebrow={
-          <span className={styles[`eyebrow_${clock.timeOfDay}`]}>
-            {TIME_OF_DAY_LABELS[clock.timeOfDay].toUpperCase()}
-          </span>
-        }
-        title={<span className={styles.timeValue}>{timeStr}</span>}
-        subtitle="Nairobi Fleet Simulation"
-      />
+      <div className={styles.clockHeader}>
+        <span className={styles[`eyebrow_${clock.timeOfDay}`]}>
+          {TIME_OF_DAY_LABELS[clock.timeOfDay]}
+        </span>
+        <div className={styles.timeValue}>{timeStr}</div>
+        <p className={styles.subtitle}>Nairobi Fleet Simulation</p>
+      </div>
       <PanelBody className={styles.body}>
         <div className={styles.speedSection}>
           <span className={styles.sectionLabel}>SIMULATION SPEED</span>
@@ -78,13 +76,13 @@ export default function ClockPanel() {
             onChange={handleSliderChange}
             aria-label="Speed multiplier"
           />
-          <span className={styles.speedSummary}>
+          <div className={styles.speedSummary}>
             <span className={isRealTime ? styles.speedValueNeutral : styles.speedValueAccent}>
               {clock.speedMultiplier}×
             </span>
             <span className={styles.speedDot}>·</span>
             <span className={styles.speedDesc}>{speedDescription(clock.speedMultiplier)}</span>
-          </span>
+          </div>
         </div>
 
         <div className={styles.presets}>

--- a/apps/ui/src/Controls/IconRail.test.tsx
+++ b/apps/ui/src/Controls/IconRail.test.tsx
@@ -7,7 +7,7 @@ describe("IconRail", () => {
     render(<IconRail activePanel={null} onPanelChange={() => {}} />);
 
     const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(7);
+    expect(buttons).toHaveLength(8);
 
     expect(screen.getByLabelText("Vehicles")).toBeInTheDocument();
     expect(screen.getByLabelText("Fleets")).toBeInTheDocument();

--- a/apps/ui/src/Controls/IconRail.tsx
+++ b/apps/ui/src/Controls/IconRail.tsx
@@ -7,6 +7,7 @@ import {
   EyeIcon,
   GaugeIcon,
   Gear,
+  ClockIcon,
 } from "@/components/Icons";
 import styles from "./IconRail.module.css";
 
@@ -17,6 +18,7 @@ export type PanelId =
   | "recordings"
   | "toggles"
   | "speed"
+  | "clock"
   | "adapter";
 
 interface IconRailProps {
@@ -32,6 +34,7 @@ const topItems: { id: PanelId; Icon: React.FC<React.SVGProps<SVGSVGElement>>; la
   { id: "recordings", Icon: RecordCircleIcon, label: "Recordings" },
   { id: "toggles", Icon: EyeIcon, label: "Visibility" },
   { id: "speed", Icon: GaugeIcon, label: "Speed" },
+  { id: "clock", Icon: ClockIcon, label: "Simulation Clock" },
 ];
 
 const bottomItems: typeof topItems = [{ id: "adapter", Icon: Gear, label: "Adapter" }];

--- a/apps/ui/src/Controls/TogglesPanel.tsx
+++ b/apps/ui/src/Controls/TogglesPanel.tsx
@@ -11,6 +11,7 @@ interface TogglesPanelProps {
 
 const toggles: { key: keyof Modifiers; label: string }[] = [
   { key: "showDirections", label: "Network" },
+  { key: "showTrafficOverlay", label: "Traffic Colours" },
   { key: "showVehicles", label: "Vehicles" },
   { key: "showHeatmap", label: "Heatmap" },
   { key: "showHeatzones", label: "Zones" },

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -92,7 +92,7 @@ export default function Map({
             <TrafficZones visible={modifiers.showHeatzones} />
           </Suspense>
         )}
-        {modifiers.showDirections && (
+        {modifiers.showTrafficOverlay && (
           <Suspense fallback={null}>
             <TrafficOverlay visible={true} />
           </Suspense>

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -25,6 +25,7 @@ import POIMarker from "./POI/POI";
 const Heatmap = lazy(() => import("./Heatmap"));
 const POIs = lazy(() => import("./POIs"));
 const TrafficZones = lazy(() => import("./TrafficZones"));
+const TrafficOverlay = lazy(() => import("./TrafficOverlay"));
 
 interface MapProps {
   filters: Filters;
@@ -89,6 +90,11 @@ export default function Map({
         {modifiers.showHeatzones && (
           <Suspense fallback={null}>
             <TrafficZones visible={modifiers.showHeatzones} />
+          </Suspense>
+        )}
+        {modifiers.showDirections && (
+          <Suspense fallback={null}>
+            <TrafficOverlay visible={true} />
           </Suspense>
         )}
 

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -24,22 +24,13 @@ function congestionColor(factor: number): string {
   return "#ef4444"; // red — jammed
 }
 
-function congestionOpacity(factor: number): number {
-  if (factor >= 0.85) return 0.45; // free flow — subtle
-  if (factor >= 0.7) return 0.6;
-  if (factor >= 0.55) return 0.75;
-  return 0.85; // congested — bold
-}
-
 // Build a spatial index: "lon,lat" → worst congestion factor
 function buildCongestionIndex(edges: TrafficEdge[]): Map<string, number> {
   const index = new Map<string, number>();
   for (const edge of edges) {
     for (const [lon, lat] of edge.coordinates) {
-      // Round to ~10m precision for fuzzy matching
       const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
       const existing = index.get(key);
-      // Keep the worst (lowest) congestion factor per location
       if (existing === undefined || edge.congestion < existing) {
         index.set(key, edge.congestion);
       }
@@ -61,14 +52,16 @@ export default function TrafficOverlay({ visible }: { visible: boolean }) {
 
   const congestionIndex = useMemo(() => buildCongestionIndex(trafficEdges), [trafficEdges]);
 
-  // Look up worst congestion along a road feature's coordinates
+  // Returns congestion or null if no traffic data touches this road
   const getRoadCongestion = useCallback(
-    (coordinates: [number, number][]): number => {
-      let worst = 1.0;
+    (coordinates: [number, number][]): number | null => {
+      let worst: number | null = null;
       for (const [lon, lat] of coordinates) {
         const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
         const val = congestionIndex.get(key);
-        if (val !== undefined && val < worst) worst = val;
+        if (val !== undefined) {
+          if (worst === null || val < worst) worst = val;
+        }
       }
       return worst;
     },
@@ -80,22 +73,24 @@ export default function TrafficOverlay({ visible }: { visible: boolean }) {
     const pathGen = geoPath().projection(projection);
     const g = select(gRef.current);
 
+    // Only render roads that have traffic data
+    const roadsWithTraffic = roads.filter(
+      (d) => getRoadCongestion(d.geometry.coordinates) !== null
+    );
+
     g.selectAll("path")
-      .data(roads)
+      .data(roadsWithTraffic, (_d, i) => i)
       .join("path")
       .attr("d", (d) => pathGen(d as Parameters<typeof pathGen>[0]) ?? "")
       .attr("fill", "none")
       .attr("stroke-linejoin", "round")
       .attr("stroke-linecap", "round")
-      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1)
+      .attr("stroke-width", (d) => (HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1) + 1)
       .attr("stroke", (d) => {
-        const c = getRoadCongestion(d.geometry.coordinates);
+        const c = getRoadCongestion(d.geometry.coordinates)!;
         return congestionColor(c);
       })
-      .attr("stroke-opacity", (d) => {
-        const c = getRoadCongestion(d.geometry.coordinates);
-        return congestionOpacity(c);
-      });
+      .attr("stroke-opacity", 0.85);
   }, [roads, projection, getRoadCongestion]);
 
   if (!visible) return null;

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -85,7 +85,7 @@ export default function TrafficOverlay({ visible }: { visible: boolean }) {
       .attr("fill", "none")
       .attr("stroke-linejoin", "round")
       .attr("stroke-linecap", "round")
-      .attr("stroke-width", (d) => (HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1) + 1)
+      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1)
       .attr("stroke", (d) => {
         const c = getRoadCongestion(d.geometry.coordinates)!;
         return congestionColor(c);

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
-import { select, line as d3line } from "d3";
+import { useEffect, useRef, useMemo, useCallback } from "react";
+import { select, geoPath } from "d3";
 import { useTraffic } from "@/hooks/useTraffic";
+import { useNetwork } from "@/hooks/useNetwork";
 import { useMapContext } from "@/components/Map/hooks";
 import type { TrafficEdge } from "@/types";
 
@@ -12,44 +13,90 @@ const HIGHWAY_WIDTH: Record<string, number> = {
   tertiary: 1.5,
 };
 
+const HIGHWAY_TYPES = new Set(Object.keys(HIGHWAY_WIDTH));
+
+// Google Maps–style: green → yellow → orange → red
 function congestionColor(factor: number): string {
-  if (factor >= 0.8) return "#22c55e";
-  if (factor >= 0.6) return "#eab308";
-  if (factor >= 0.4) return "#f97316";
-  return "#ef4444";
+  if (factor >= 0.85) return "#22c55e"; // green — free flow
+  if (factor >= 0.7) return "#84cc16"; // lime — light traffic
+  if (factor >= 0.55) return "#eab308"; // yellow — moderate
+  if (factor >= 0.4) return "#f97316"; // orange — heavy
+  return "#ef4444"; // red — jammed
+}
+
+function congestionOpacity(factor: number): number {
+  if (factor >= 0.85) return 0.45; // free flow — subtle
+  if (factor >= 0.7) return 0.6;
+  if (factor >= 0.55) return 0.75;
+  return 0.85; // congested — bold
+}
+
+// Build a spatial index: "lon,lat" → worst congestion factor
+function buildCongestionIndex(edges: TrafficEdge[]): Map<string, number> {
+  const index = new Map<string, number>();
+  for (const edge of edges) {
+    for (const [lon, lat] of edge.coordinates) {
+      // Round to ~10m precision for fuzzy matching
+      const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
+      const existing = index.get(key);
+      // Keep the worst (lowest) congestion factor per location
+      if (existing === undefined || edge.congestion < existing) {
+        index.set(key, edge.congestion);
+      }
+    }
+  }
+  return index;
 }
 
 export default function TrafficOverlay({ visible }: { visible: boolean }) {
-  const edges = useTraffic();
+  const trafficEdges = useTraffic();
+  const network = useNetwork();
   const { projection } = useMapContext();
   const gRef = useRef<SVGGElement>(null);
 
+  const roads = useMemo(
+    () => network.features.filter((f) => HIGHWAY_TYPES.has(f.properties.highway ?? "")),
+    [network]
+  );
+
+  const congestionIndex = useMemo(() => buildCongestionIndex(trafficEdges), [trafficEdges]);
+
+  // Look up worst congestion along a road feature's coordinates
+  const getRoadCongestion = useCallback(
+    (coordinates: [number, number][]): number => {
+      let worst = 1.0;
+      for (const [lon, lat] of coordinates) {
+        const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
+        const val = congestionIndex.get(key);
+        if (val !== undefined && val < worst) worst = val;
+      }
+      return worst;
+    },
+    [congestionIndex]
+  );
+
   useEffect(() => {
-    if (!gRef.current || !projection) return;
+    if (!gRef.current || !projection || roads.length === 0) return;
+    const pathGen = geoPath().projection(projection);
     const g = select(gRef.current);
 
-    const lineGen = d3line<[number, number]>()
-      .x((d) => d[0])
-      .y((d) => d[1]);
-
-    g.selectAll<SVGPathElement, TrafficEdge>("path")
-      .data(edges, (d) => d.edgeId)
+    g.selectAll("path")
+      .data(roads)
       .join("path")
-      .attr("d", (d) => {
-        const pts = d.coordinates
-          .map((c) => projection(c))
-          .filter(
-            (p): p is [number, number] =>
-              p != null && isFinite(p[0]) && isFinite(p[1])
-          );
-        return pts.length >= 2 ? lineGen(pts) : null;
-      })
+      .attr("d", (d) => pathGen(d as Parameters<typeof pathGen>[0]) ?? "")
       .attr("fill", "none")
-      .attr("stroke", (d) => congestionColor(d.congestion))
-      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.highway] ?? 1)
-      .attr("stroke-opacity", 0.8)
-      .attr("stroke-linecap", "round");
-  }, [edges, projection]);
+      .attr("stroke-linejoin", "round")
+      .attr("stroke-linecap", "round")
+      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1)
+      .attr("stroke", (d) => {
+        const c = getRoadCongestion(d.geometry.coordinates);
+        return congestionColor(c);
+      })
+      .attr("stroke-opacity", (d) => {
+        const c = getRoadCongestion(d.geometry.coordinates);
+        return congestionOpacity(c);
+      });
+  }, [roads, projection, getRoadCongestion]);
 
   if (!visible) return null;
   return <g ref={gRef} />;

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from "react";
+import { useEffect, useRef, useMemo } from "react";
+import { select, geoPath } from "d3";
 import { useClock } from "@/hooks/useClock";
 import { useNetwork } from "@/hooks/useNetwork";
-import { Polyline } from "@/components/Map/components/Polyline";
+import { useMapContext } from "@/components/Map/hooks";
 import type { TimeOfDay } from "@/types";
 
-// Per-time-of-day base colour
 const TIME_COLORS: Record<TimeOfDay, string> = {
   morning_rush: "#fb923c",
   midday: "#4ade80",
@@ -12,7 +12,6 @@ const TIME_COLORS: Record<TimeOfDay, string> = {
   night: "#818cf8",
 };
 
-// Road class → width and opacity weight (major roads are bolder)
 const ROAD_TIERS: Record<string, { width: number; opacityScale: number }> = {
   motorway: { width: 3.5, opacityScale: 1.0 },
   trunk: { width: 3.0, opacityScale: 0.95 },
@@ -21,7 +20,6 @@ const ROAD_TIERS: Record<string, { width: number; opacityScale: number }> = {
   tertiary: { width: 1.2, opacityScale: 0.35 },
 };
 
-// Base opacity per time-of-day (scaled by road tier)
 const TIME_OPACITY: Record<TimeOfDay, number> = {
   morning_rush: 0.65,
   midday: 0.35,
@@ -34,31 +32,43 @@ const HIGHWAY_TYPES = new Set(Object.keys(ROAD_TIERS));
 export default function TrafficOverlay({ visible }: { visible: boolean }) {
   const { clock } = useClock();
   const network = useNetwork();
+  const { projection } = useMapContext();
+  const gRef = useRef<SVGGElement>(null);
 
   const roads = useMemo(
     () => network.features.filter((f) => HIGHWAY_TYPES.has(f.properties.highway ?? "")),
     [network]
   );
 
+  // Build paths once when roads/projection change
+  useEffect(() => {
+    if (!gRef.current || !projection || roads.length === 0) return;
+    const pathGen = geoPath().projection(projection);
+    const g = select(gRef.current);
+
+    g.selectAll("path")
+      .data(roads)
+      .join("path")
+      .attr("d", (d) => pathGen(d as Parameters<typeof pathGen>[0]) ?? "")
+      .attr("fill", "none")
+      .attr("stroke-linejoin", "round")
+      .attr("stroke-linecap", "round")
+      .attr("stroke-width", (d) => (ROAD_TIERS[d.properties.highway ?? ""] ?? ROAD_TIERS.tertiary).width);
+  }, [roads, projection]);
+
+  // Update colour/opacity cheaply on every timeOfDay change
+  useEffect(() => {
+    if (!gRef.current) return;
+    const color = TIME_COLORS[clock.timeOfDay];
+    const baseOpacity = TIME_OPACITY[clock.timeOfDay];
+
+    select(gRef.current)
+      .selectAll<SVGPathElement, (typeof roads)[number]>("path")
+      .attr("stroke", color)
+      .attr("stroke-opacity", (d) => baseOpacity * (ROAD_TIERS[d.properties.highway ?? ""] ?? ROAD_TIERS.tertiary).opacityScale);
+  }, [clock.timeOfDay]);
+
   if (!visible) return null;
 
-  const color = TIME_COLORS[clock.timeOfDay];
-  const baseOpacity = TIME_OPACITY[clock.timeOfDay];
-
-  return (
-    <>
-      {roads.map((feature, i) => {
-        const tier = ROAD_TIERS[feature.properties.highway ?? ""] ?? ROAD_TIERS.tertiary;
-        return (
-          <Polyline
-            key={`traffic-${i}`}
-            coordinates={feature.geometry.coordinates}
-            color={color}
-            width={tier.width}
-            opacity={baseOpacity * tier.opacityScale}
-          />
-        );
-      })}
-    </>
-  );
+  return <g ref={gRef} />;
 }

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -3,11 +3,11 @@ import { useNetwork } from "@/hooks/useNetwork";
 import { Polyline } from "@/components/Map/components/Polyline";
 import type { TimeOfDay } from "@/types";
 
-const TRAFFIC_STYLES: Partial<Record<TimeOfDay, { color: string; opacity: number }>> = {
+const TRAFFIC_STYLES: Record<TimeOfDay, { color: string; opacity: number }> = {
   morning_rush: { color: "#fb923c", opacity: 0.55 },
-  evening_rush: { color: "#ef4444", opacity: 0.7 },
-  night: { color: "#818cf8", opacity: 0.35 },
-  // midday: no overlay
+  midday:        { color: "#4ade80", opacity: 0.3  },
+  evening_rush: { color: "#ef4444", opacity: 0.7  },
+  night:         { color: "#818cf8", opacity: 0.35 },
 };
 
 export default function TrafficOverlay({ visible }: { visible: boolean }) {
@@ -17,7 +17,6 @@ export default function TrafficOverlay({ visible }: { visible: boolean }) {
   if (!visible) return null;
 
   const style = TRAFFIC_STYLES[clock.timeOfDay];
-  if (!style) return null;
 
   const affectedRoads = network.features.filter(
     (f) => f.properties.highway === "trunk" || f.properties.highway === "primary"

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -1,0 +1,39 @@
+import { useClock } from "@/hooks/useClock";
+import { useNetwork } from "@/hooks/useNetwork";
+import { Polyline } from "@/components/Map/components/Polyline";
+import type { TimeOfDay } from "@/types";
+
+const TRAFFIC_STYLES: Partial<Record<TimeOfDay, { color: string; opacity: number }>> = {
+  morning_rush: { color: "#fb923c", opacity: 0.55 },
+  evening_rush: { color: "#ef4444", opacity: 0.7 },
+  night: { color: "#818cf8", opacity: 0.35 },
+  // midday: no overlay
+};
+
+export default function TrafficOverlay({ visible }: { visible: boolean }) {
+  const { clock } = useClock();
+  const network = useNetwork();
+
+  if (!visible) return null;
+
+  const style = TRAFFIC_STYLES[clock.timeOfDay];
+  if (!style) return null;
+
+  const affectedRoads = network.features.filter(
+    (f) => f.properties.highway === "trunk" || f.properties.highway === "primary"
+  );
+
+  return (
+    <>
+      {affectedRoads.map((feature, i) => (
+        <Polyline
+          key={`traffic-${i}`}
+          coordinates={feature.geometry.coordinates}
+          color={style.color}
+          width={2.5}
+          opacity={style.opacity}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -1,74 +1,56 @@
-import { useEffect, useRef, useMemo } from "react";
-import { select, geoPath } from "d3";
-import { useClock } from "@/hooks/useClock";
-import { useNetwork } from "@/hooks/useNetwork";
+import { useEffect, useRef } from "react";
+import { select, line as d3line } from "d3";
+import { useTraffic } from "@/hooks/useTraffic";
 import { useMapContext } from "@/components/Map/hooks";
-import type { TimeOfDay } from "@/types";
+import type { TrafficEdge } from "@/types";
 
-const TIME_COLORS: Record<TimeOfDay, string> = {
-  morning_rush: "#fb923c",
-  midday: "#4ade80",
-  evening_rush: "#ef4444",
-  night: "#818cf8",
+const HIGHWAY_WIDTH: Record<string, number> = {
+  motorway: 4,
+  trunk: 3.5,
+  primary: 3,
+  secondary: 2,
+  tertiary: 1.5,
 };
 
-const ROAD_TIERS: Record<string, { width: number; opacityScale: number }> = {
-  motorway: { width: 3.5, opacityScale: 1.0 },
-  trunk: { width: 3.0, opacityScale: 0.95 },
-  primary: { width: 2.5, opacityScale: 0.85 },
-  secondary: { width: 1.8, opacityScale: 0.6 },
-  tertiary: { width: 1.2, opacityScale: 0.35 },
-};
-
-const TIME_OPACITY: Record<TimeOfDay, number> = {
-  morning_rush: 0.65,
-  midday: 0.35,
-  evening_rush: 0.8,
-  night: 0.45,
-};
-
-const HIGHWAY_TYPES = new Set(Object.keys(ROAD_TIERS));
+function congestionColor(factor: number): string {
+  if (factor >= 0.8) return "#22c55e";
+  if (factor >= 0.6) return "#eab308";
+  if (factor >= 0.4) return "#f97316";
+  return "#ef4444";
+}
 
 export default function TrafficOverlay({ visible }: { visible: boolean }) {
-  const { clock } = useClock();
-  const network = useNetwork();
+  const edges = useTraffic();
   const { projection } = useMapContext();
   const gRef = useRef<SVGGElement>(null);
 
-  const roads = useMemo(
-    () => network.features.filter((f) => HIGHWAY_TYPES.has(f.properties.highway ?? "")),
-    [network]
-  );
-
-  // Build paths once when roads/projection change
   useEffect(() => {
-    if (!gRef.current || !projection || roads.length === 0) return;
-    const pathGen = geoPath().projection(projection);
+    if (!gRef.current || !projection) return;
     const g = select(gRef.current);
 
-    g.selectAll("path")
-      .data(roads)
+    const lineGen = d3line<[number, number]>()
+      .x((d) => d[0])
+      .y((d) => d[1]);
+
+    g.selectAll<SVGPathElement, TrafficEdge>("path")
+      .data(edges, (d) => d.edgeId)
       .join("path")
-      .attr("d", (d) => pathGen(d as Parameters<typeof pathGen>[0]) ?? "")
+      .attr("d", (d) => {
+        const pts = d.coordinates
+          .map((c) => projection(c))
+          .filter(
+            (p): p is [number, number] =>
+              p != null && isFinite(p[0]) && isFinite(p[1])
+          );
+        return pts.length >= 2 ? lineGen(pts) : null;
+      })
       .attr("fill", "none")
-      .attr("stroke-linejoin", "round")
-      .attr("stroke-linecap", "round")
-      .attr("stroke-width", (d) => (ROAD_TIERS[d.properties.highway ?? ""] ?? ROAD_TIERS.tertiary).width);
-  }, [roads, projection]);
-
-  // Update colour/opacity cheaply on every timeOfDay change
-  useEffect(() => {
-    if (!gRef.current) return;
-    const color = TIME_COLORS[clock.timeOfDay];
-    const baseOpacity = TIME_OPACITY[clock.timeOfDay];
-
-    select(gRef.current)
-      .selectAll<SVGPathElement, (typeof roads)[number]>("path")
-      .attr("stroke", color)
-      .attr("stroke-opacity", (d) => baseOpacity * (ROAD_TIERS[d.properties.highway ?? ""] ?? ROAD_TIERS.tertiary).opacityScale);
-  }, [clock.timeOfDay]);
+      .attr("stroke", (d) => congestionColor(d.congestion))
+      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.highway] ?? 1)
+      .attr("stroke-opacity", 0.8)
+      .attr("stroke-linecap", "round");
+  }, [edges, projection]);
 
   if (!visible) return null;
-
   return <g ref={gRef} />;
 }

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo, useCallback } from "react";
+import { useEffect, useRef, useMemo } from "react";
 import { select, geoPath } from "d3";
 import { useTraffic } from "@/hooks/useTraffic";
 import { useNetwork } from "@/hooks/useNetwork";
@@ -13,8 +13,6 @@ const HIGHWAY_WIDTH: Record<string, number> = {
   tertiary: 1.5,
 };
 
-const HIGHWAY_TYPES = new Set(Object.keys(HIGHWAY_WIDTH));
-
 // Google Maps–style: green → yellow → orange → red
 function congestionColor(factor: number): string {
   if (factor >= 0.85) return "#22c55e"; // green — free flow
@@ -24,19 +22,16 @@ function congestionColor(factor: number): string {
   return "#ef4444"; // red — jammed
 }
 
-// Build a spatial index: "lon,lat" → worst congestion factor
-function buildCongestionIndex(edges: TrafficEdge[]): Map<string, number> {
-  const index = new Map<string, number>();
+// Aggregate congestion per streetId (worst = lowest factor wins)
+function buildStreetCongestion(edges: TrafficEdge[]): Map<string, number> {
+  const map = new Map<string, number>();
   for (const edge of edges) {
-    for (const [lon, lat] of edge.coordinates) {
-      const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
-      const existing = index.get(key);
-      if (existing === undefined || edge.congestion < existing) {
-        index.set(key, edge.congestion);
-      }
+    const existing = map.get(edge.streetId);
+    if (existing === undefined || edge.congestion < existing) {
+      map.set(edge.streetId, edge.congestion);
     }
   }
-  return index;
+  return map;
 }
 
 export default function TrafficOverlay({ visible }: { visible: boolean }) {
@@ -45,38 +40,18 @@ export default function TrafficOverlay({ visible }: { visible: boolean }) {
   const { projection } = useMapContext();
   const gRef = useRef<SVGGElement>(null);
 
-  const roads = useMemo(
-    () => network.features.filter((f) => HIGHWAY_TYPES.has(f.properties.highway ?? "")),
-    [network]
-  );
-
-  const congestionIndex = useMemo(() => buildCongestionIndex(trafficEdges), [trafficEdges]);
-
-  // Returns congestion or null if no traffic data touches this road
-  const getRoadCongestion = useCallback(
-    (coordinates: [number, number][]): number | null => {
-      let worst: number | null = null;
-      for (const [lon, lat] of coordinates) {
-        const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
-        const val = congestionIndex.get(key);
-        if (val !== undefined) {
-          if (worst === null || val < worst) worst = val;
-        }
-      }
-      return worst;
-    },
-    [congestionIndex]
-  );
+  const streetCongestion = useMemo(() => buildStreetCongestion(trafficEdges), [trafficEdges]);
 
   useEffect(() => {
-    if (!gRef.current || !projection || roads.length === 0) return;
+    if (!gRef.current || !projection || network.features.length === 0) return;
     const pathGen = geoPath().projection(projection);
     const g = select(gRef.current);
 
-    // Only render roads that have traffic data
-    const roadsWithTraffic = roads.filter(
-      (d) => getRoadCongestion(d.geometry.coordinates) !== null
-    );
+    // Only render features that have traffic data (matched by streetId)
+    const roadsWithTraffic = network.features.filter((f) => {
+      const sid = f.properties.streetId ?? f.properties["@id"];
+      return sid != null && streetCongestion.has(sid);
+    });
 
     g.selectAll("path")
       .data(roadsWithTraffic, (_d, i) => i)
@@ -85,13 +60,14 @@ export default function TrafficOverlay({ visible }: { visible: boolean }) {
       .attr("fill", "none")
       .attr("stroke-linejoin", "round")
       .attr("stroke-linecap", "round")
-      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1)
+      .attr("stroke-width", (d) => HIGHWAY_WIDTH[d.properties.highway ?? ""] ?? 1.5)
       .attr("stroke", (d) => {
-        const c = getRoadCongestion(d.geometry.coordinates)!;
+        const sid = d.properties.streetId ?? d.properties["@id"];
+        const c = streetCongestion.get(sid!)!;
         return congestionColor(c);
       })
       .attr("stroke-opacity", 0.85);
-  }, [roads, projection, getRoadCongestion]);
+  }, [network, projection, streetCongestion]);
 
   if (!visible) return null;
   return <g ref={gRef} />;

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -1,38 +1,64 @@
+import { useMemo } from "react";
 import { useClock } from "@/hooks/useClock";
 import { useNetwork } from "@/hooks/useNetwork";
 import { Polyline } from "@/components/Map/components/Polyline";
 import type { TimeOfDay } from "@/types";
 
-const TRAFFIC_STYLES: Record<TimeOfDay, { color: string; opacity: number }> = {
-  morning_rush: { color: "#fb923c", opacity: 0.55 },
-  midday:        { color: "#4ade80", opacity: 0.3  },
-  evening_rush: { color: "#ef4444", opacity: 0.7  },
-  night:         { color: "#818cf8", opacity: 0.35 },
+// Per-time-of-day base colour
+const TIME_COLORS: Record<TimeOfDay, string> = {
+  morning_rush: "#fb923c",
+  midday: "#4ade80",
+  evening_rush: "#ef4444",
+  night: "#818cf8",
 };
+
+// Road class → width and opacity weight (major roads are bolder)
+const ROAD_TIERS: Record<string, { width: number; opacityScale: number }> = {
+  motorway: { width: 3.5, opacityScale: 1.0 },
+  trunk: { width: 3.0, opacityScale: 0.95 },
+  primary: { width: 2.5, opacityScale: 0.85 },
+  secondary: { width: 1.8, opacityScale: 0.6 },
+  tertiary: { width: 1.2, opacityScale: 0.35 },
+};
+
+// Base opacity per time-of-day (scaled by road tier)
+const TIME_OPACITY: Record<TimeOfDay, number> = {
+  morning_rush: 0.65,
+  midday: 0.35,
+  evening_rush: 0.8,
+  night: 0.45,
+};
+
+const HIGHWAY_TYPES = new Set(Object.keys(ROAD_TIERS));
 
 export default function TrafficOverlay({ visible }: { visible: boolean }) {
   const { clock } = useClock();
   const network = useNetwork();
 
+  const roads = useMemo(
+    () => network.features.filter((f) => HIGHWAY_TYPES.has(f.properties.highway ?? "")),
+    [network]
+  );
+
   if (!visible) return null;
 
-  const style = TRAFFIC_STYLES[clock.timeOfDay];
-
-  const affectedRoads = network.features.filter(
-    (f) => f.properties.highway === "trunk" || f.properties.highway === "primary"
-  );
+  const color = TIME_COLORS[clock.timeOfDay];
+  const baseOpacity = TIME_OPACITY[clock.timeOfDay];
 
   return (
     <>
-      {affectedRoads.map((feature, i) => (
-        <Polyline
-          key={`traffic-${i}`}
-          coordinates={feature.geometry.coordinates}
-          color={style.color}
-          width={2.5}
-          opacity={style.opacity}
-        />
-      ))}
+      {roads.map((feature, i) => {
+        const tier = ROAD_TIERS[feature.properties.highway ?? ""] ?? ROAD_TIERS.tertiary;
+        return (
+          <Polyline
+            key={`traffic-${i}`}
+            coordinates={feature.geometry.coordinates}
+            color={color}
+            width={tier.width}
+            opacity={baseOpacity * tier.opacityScale}
+          />
+        );
+      })}
     </>
   );
 }

--- a/apps/ui/src/SearchBar/SearchBar.module.css
+++ b/apps/ui/src/SearchBar/SearchBar.module.css
@@ -59,6 +59,7 @@
   height: 100%;
   width: 56px;
   flex: 0 0 56px;
+  color: var(--color-text-primary);
   align-self: stretch;
   border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
   background: rgba(255, 255, 255, 0.02);

--- a/apps/ui/src/components/Icons.tsx
+++ b/apps/ui/src/components/Icons.tsx
@@ -296,3 +296,12 @@ export function GaugeIcon(props: SVGProps) {
     </svg>
   );
 }
+
+export function ClockIcon(props: SVGProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}

--- a/apps/ui/src/components/Icons.tsx
+++ b/apps/ui/src/components/Icons.tsx
@@ -22,7 +22,7 @@ export function Flame(props: SVGProps) {
 
 export function Directions(props: SVGProps) {
   return (
-    <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+    <svg fill="currentColor" {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
       <g id="SVGRepo_iconCarrier">
         <path d="M502.61 233.32L278.68 9.39c-12.52-12.52-32.83-12.52-45.36 0L9.39 233.32c-12.52 12.53-12.52 32.83 0 45.36l223.93 223.93c12.52 12.53 32.83 12.53 45.36 0l223.93-223.93c12.52-12.53 12.52-32.83 0-45.36zm-100.98 12.56l-84.21 77.73c-5.12 4.73-13.43 1.1-13.43-5.88V264h-96v64c0 4.42-3.58 8-8 8h-32c-4.42 0-8-3.58-8-8v-80c0-17.67 14.33-32 32-32h112v-53.73c0-6.97 8.3-10.61 13.43-5.88l84.21 77.73c3.43 3.17 3.43 8.59 0 11.76z"></path>
       </g>
@@ -299,7 +299,15 @@ export function GaugeIcon(props: SVGProps) {
 
 export function ClockIcon(props: SVGProps) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
       <circle cx="12" cy="12" r="10" />
       <polyline points="12 6 12 12 16 14" />
     </svg>

--- a/apps/ui/src/components/Map/components/Polyline.tsx
+++ b/apps/ui/src/components/Map/components/Polyline.tsx
@@ -24,9 +24,11 @@ export const Polyline = memo<PolylineProps>(function Polyline({
   useEffect(() => {
     if (!projection || !pathRef.current || coordinates.length < 2) return;
 
-    const points = coordinates
-      .map((coord) => projection(coord))
-      .filter((p): p is Position => p !== null);
+    const points: Position[] = [];
+    for (const coord of coordinates) {
+      const p = projection(coord);
+      if (p && isFinite(p[0]) && isFinite(p[1])) points.push(p as Position);
+    }
 
     if (points.length < 2) return;
 

--- a/apps/ui/src/components/Map/components/Polyline.tsx
+++ b/apps/ui/src/components/Map/components/Polyline.tsx
@@ -7,6 +7,7 @@ interface PolylineProps {
   coordinates: Position[];
   color?: string;
   width?: number;
+  opacity?: number;
   onClick?: () => void;
 }
 
@@ -14,6 +15,7 @@ export const Polyline = memo<PolylineProps>(function Polyline({
   coordinates,
   color = "#4488ff",
   width = 1,
+  opacity,
   onClick,
 }) {
   const { projection } = useMapContext();
@@ -36,6 +38,7 @@ export const Polyline = memo<PolylineProps>(function Polyline({
       ref={pathRef}
       stroke={color}
       strokeWidth={width}
+      strokeOpacity={opacity ?? 1}
       fill="none"
       strokeLinejoin="round"
       strokeLinecap="round"

--- a/apps/ui/src/components/Map/components/Polyline.tsx
+++ b/apps/ui/src/components/Map/components/Polyline.tsx
@@ -24,7 +24,11 @@ export const Polyline = memo<PolylineProps>(function Polyline({
   useEffect(() => {
     if (!projection || !pathRef.current || coordinates.length < 2) return;
 
-    const points = coordinates.map((coord) => projection(coord)) as Position[];
+    const points = coordinates
+      .map((coord) => projection(coord))
+      .filter((p): p is Position => p !== null);
+
+    if (points.length < 2) return;
 
     const lineGenerator = line()
       .x((d) => d[0])

--- a/apps/ui/src/components/Map/components/RoadNetworkMap.tsx
+++ b/apps/ui/src/components/Map/components/RoadNetworkMap.tsx
@@ -48,7 +48,10 @@ export const RoadNetworkMap: React.FC<RoadNetworkMapProps> = ({
     const pathGen = geoPath().projection(proj);
     setProjection(() => proj);
 
-    const roadsGroup = svg.insert("g", ":first-child").attr("class", "roads").attr("opacity", strokeOpacity);
+    const roadsGroup = svg
+      .insert("g", ":first-child")
+      .attr("class", "roads")
+      .attr("opacity", strokeOpacity);
 
     // Filter and cache long main roads first
     const mainRoads = data.features.filter((d) => {

--- a/apps/ui/src/components/Map/components/RoadNetworkMap.tsx
+++ b/apps/ui/src/components/Map/components/RoadNetworkMap.tsx
@@ -48,7 +48,7 @@ export const RoadNetworkMap: React.FC<RoadNetworkMapProps> = ({
     const pathGen = geoPath().projection(proj);
     setProjection(() => proj);
 
-    const roadsGroup = svg.insert("g", ":first-child").attr("class", "roads");
+    const roadsGroup = svg.insert("g", ":first-child").attr("class", "roads").attr("opacity", strokeOpacity);
 
     // Filter and cache long main roads first
     const mainRoads = data.features.filter((d) => {
@@ -70,7 +70,6 @@ export const RoadNetworkMap: React.FC<RoadNetworkMapProps> = ({
       .attr("stroke-width", (d) =>
         d.properties.type === "highway" ? strokeWidth * 2 : strokeWidth
       )
-      .attr("stroke-opacity", strokeOpacity)
       .attr("stroke-linejoin", "round")
       .attr("stroke-linecap", "round")
       .attr("id", (d, i) => (mainRoads.includes(d) ? `road-${i}` : null));

--- a/apps/ui/src/hooks/useClock.ts
+++ b/apps/ui/src/hooks/useClock.ts
@@ -1,6 +1,13 @@
 import { useState, useEffect, useRef } from "react";
 import client from "@/utils/client";
-import type { ClockState } from "@/types";
+import type { ClockState, TimeOfDay } from "@/types";
+
+function getTimeOfDay(hour: number): TimeOfDay {
+  if (hour >= 7 && hour < 9) return "morning_rush";
+  if (hour >= 17 && hour < 19) return "evening_rush";
+  if (hour >= 22 || hour < 5) return "night";
+  return "midday";
+}
 
 const DEFAULT_CLOCK: ClockState = {
   currentTime: new Date().toISOString(),
@@ -11,7 +18,6 @@ const DEFAULT_CLOCK: ClockState = {
 
 export function useClock() {
   const [clock, setClock] = useState<ClockState>(DEFAULT_CLOCK);
-  // Keep a ref to the latest clock so the interval closure always reads current values
   const clockRef = useRef(clock);
   clockRef.current = clock;
 
@@ -19,19 +25,24 @@ export function useClock() {
     client.getClock().then((res) => {
       if (res.data) setClock(res.data);
     });
-    // WS events fire on hour boundaries — sync full state when they arrive
     client.onClock((state) => setClock(state));
   }, []);
 
-  // Local tick — advance currentTime every real second based on speedMultiplier
+  // Local tick — advance currentTime and derive hour/timeOfDay every real second
   useEffect(() => {
     const id = setInterval(() => {
-      setClock((prev) => ({
-        ...prev,
-        currentTime: new Date(
+      setClock((prev) => {
+        const nextTime = new Date(
           new Date(prev.currentTime).getTime() + prev.speedMultiplier * 1000
-        ).toISOString(),
-      }));
+        );
+        const hour = nextTime.getHours();
+        return {
+          ...prev,
+          currentTime: nextTime.toISOString(),
+          hour,
+          timeOfDay: getTimeOfDay(hour),
+        };
+      });
     }, 1000);
     return () => clearInterval(id);
   }, []);

--- a/apps/ui/src/hooks/useClock.ts
+++ b/apps/ui/src/hooks/useClock.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import client from "@/utils/client";
+import type { ClockState } from "@/types";
+
+const DEFAULT_CLOCK: ClockState = {
+  currentTime: new Date().toISOString(),
+  speedMultiplier: 1,
+  hour: 7,
+  timeOfDay: "morning_rush",
+};
+
+export function useClock() {
+  const [clock, setClock] = useState<ClockState>(DEFAULT_CLOCK);
+
+  useEffect(() => {
+    client.getClock().then((res) => {
+      if (res.data) setClock(res.data);
+    });
+    client.onClock((state) => setClock(state));
+  }, []);
+
+  async function setSpeedMultiplier(value: number) {
+    const res = await client.setClock({ speedMultiplier: value });
+    if (res.data) setClock(res.data);
+  }
+
+  async function setTime(isoString: string) {
+    const res = await client.setClock({ setTime: isoString });
+    if (res.data) setClock(res.data);
+  }
+
+  return { clock, setSpeedMultiplier, setTime };
+}

--- a/apps/ui/src/hooks/useClock.ts
+++ b/apps/ui/src/hooks/useClock.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import client from "@/utils/client";
 import type { ClockState } from "@/types";
 
@@ -11,12 +11,29 @@ const DEFAULT_CLOCK: ClockState = {
 
 export function useClock() {
   const [clock, setClock] = useState<ClockState>(DEFAULT_CLOCK);
+  // Keep a ref to the latest clock so the interval closure always reads current values
+  const clockRef = useRef(clock);
+  clockRef.current = clock;
 
   useEffect(() => {
     client.getClock().then((res) => {
       if (res.data) setClock(res.data);
     });
+    // WS events fire on hour boundaries — sync full state when they arrive
     client.onClock((state) => setClock(state));
+  }, []);
+
+  // Local tick — advance currentTime every real second based on speedMultiplier
+  useEffect(() => {
+    const id = setInterval(() => {
+      setClock((prev) => ({
+        ...prev,
+        currentTime: new Date(
+          new Date(prev.currentTime).getTime() + prev.speedMultiplier * 1000
+        ).toISOString(),
+      }));
+    }, 1000);
+    return () => clearInterval(id);
   }, []);
 
   async function setSpeedMultiplier(value: number) {

--- a/apps/ui/src/hooks/useTraffic.ts
+++ b/apps/ui/src/hooks/useTraffic.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+import client from "@/utils/client";
+import type { TrafficEdge } from "@/types";
+
+export function useTraffic() {
+  const [edges, setEdges] = useState<TrafficEdge[]>([]);
+
+  useEffect(() => {
+    client.getTraffic().then((res) => {
+      if (res.data) setEdges(res.data);
+    });
+    client.onTraffic((data) => setEdges(data));
+  }, []);
+
+  return edges;
+}

--- a/apps/ui/src/hooks/useVehicles.test.ts
+++ b/apps/ui/src/hooks/useVehicles.test.ts
@@ -38,6 +38,7 @@ describe("useVehicles", () => {
       showHeatmap: false,
       showVehicles: true,
       showPOIs: false,
+      showTrafficOverlay: true,
     });
   });
 
@@ -117,6 +118,7 @@ describe("useVehicles", () => {
       showHeatmap: true,
       showVehicles: true,
       showPOIs: true,
+      showTrafficOverlay: true,
     });
   });
 });

--- a/apps/ui/src/hooks/useVehicles.ts
+++ b/apps/ui/src/hooks/useVehicles.ts
@@ -134,6 +134,7 @@ export function useVehicles(): UseVehicle {
     showHeatmap: false,
     showVehicles: true,
     showPOIs: false,
+    showTrafficOverlay: true,
   });
 
   const lowerCaseFilter = useMemo(() => filters.filter.toLowerCase(), [filters.filter]);

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -82,6 +82,8 @@ interface RoadFeature {
     type?: string;
     speed_limit?: number;
     highway?: string;
+    streetId?: string;
+    "@id"?: string;
   };
 }
 
@@ -196,6 +198,7 @@ export interface TrafficEdge {
   congestion: number; // 0.2 (jammed) to 1.0 (free flow)
   coordinates: [number, number][];
   highway: string;
+  streetId: string;
 }
 
 // ─── Recording & Replay ────────────────────────────────────────────

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -189,6 +189,15 @@ export interface IncidentDTO {
   position: [number, number];
 }
 
+// ─── Traffic ────────────────────────────────────────────────────────
+
+export interface TrafficEdge {
+  edgeId: string;
+  congestion: number; // 0.2 (jammed) to 1.0 (free flow)
+  coordinates: [number, number][];
+  highway: string;
+}
+
 // ─── Recording & Replay ────────────────────────────────────────────
 
 export interface RecordingFile {

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -16,6 +16,7 @@ export interface Modifiers {
   showHeatmap: boolean;
   showVehicles: boolean;
   showPOIs: boolean;
+  showTrafficOverlay: boolean;
 }
 
 export interface Fleet {

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -47,6 +47,16 @@ export interface SimulationStatus {
   interval: number;
   running: boolean;
   ready: boolean;
+  clock?: ClockState;
+}
+
+export type TimeOfDay = "morning_rush" | "midday" | "evening_rush" | "night";
+
+export interface ClockState {
+  currentTime: string; // ISO date string
+  speedMultiplier: number;
+  hour: number;
+  timeOfDay: TimeOfDay;
 }
 
 export interface StartOptions {

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -19,6 +19,7 @@ import type {
   RecordingMetadata,
   ReplayStatus,
   ClockState,
+  TrafficEdge,
 } from "@/types";
 import type {
   ResetPayload,
@@ -91,6 +92,9 @@ class SimulationService {
     this.getClock = this.getClock.bind(this);
     this.setClock = this.setClock.bind(this);
     this.onClock = this.onClock.bind(this);
+    // traffic
+    this.getTraffic = this.getTraffic.bind(this);
+    this.onTraffic = this.onTraffic.bind(this);
   }
 
   connectWebSocket(): void {
@@ -342,12 +346,25 @@ class SimulationService {
     return this.http.get<ClockState>("/clock");
   }
 
-  async setClock(params: { speedMultiplier?: number; setTime?: string }): Promise<ApiResponse<ClockState>> {
+  async setClock(params: {
+    speedMultiplier?: number;
+    setTime?: string;
+  }): Promise<ApiResponse<ClockState>> {
     return this.http.post<typeof params, ClockState>("/clock", params);
   }
 
   onClock(handler: (state: ClockState) => void): void {
     this.ws.on("clock", handler);
+  }
+
+  // ─── Traffic Congestion ──────────────────────────────────────────
+
+  async getTraffic(): Promise<ApiResponse<TrafficEdge[]>> {
+    return this.http.get<TrafficEdge[]>("/traffic");
+  }
+
+  onTraffic(handler: (data: TrafficEdge[]) => void): void {
+    this.ws.on("traffic", handler);
   }
 }
 

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -18,6 +18,7 @@ import type {
   RecordingFile,
   RecordingMetadata,
   ReplayStatus,
+  ClockState,
 } from "@/types";
 import type {
   ResetPayload,
@@ -86,6 +87,10 @@ class SimulationService {
     this.getReplayStatus = this.getReplayStatus.bind(this);
     this.onReplayStatus = this.onReplayStatus.bind(this);
     this.createIncidentAtPosition = this.createIncidentAtPosition.bind(this);
+    // clock
+    this.getClock = this.getClock.bind(this);
+    this.setClock = this.setClock.bind(this);
+    this.onClock = this.onClock.bind(this);
   }
 
   connectWebSocket(): void {
@@ -329,6 +334,20 @@ class SimulationService {
 
   onReplayStatus(handler: (data: ReplayStatus) => void): void {
     this.ws.on("replayStatus", handler);
+  }
+
+  // ─── Simulation Clock ──────────────────────────────────────────
+
+  async getClock(): Promise<ApiResponse<ClockState>> {
+    return this.http.get<ClockState>("/clock");
+  }
+
+  async setClock(params: { speedMultiplier?: number; setTime?: string }): Promise<ApiResponse<ClockState>> {
+    return this.http.post<typeof params, ClockState>("/clock", params);
+  }
+
+  onClock(handler: (state: ClockState) => void): void {
+    this.ws.on("clock", handler);
   }
 }
 

--- a/apps/ui/src/utils/wsTypes.ts
+++ b/apps/ui/src/utils/wsTypes.ts
@@ -8,6 +8,7 @@ import type {
   IncidentDTO,
   ReplayStatus,
   ClockState,
+  TrafficEdge,
 } from "@/types";
 
 export interface ResetPayload {
@@ -56,7 +57,8 @@ export type WebSocketMessage =
   | { type: "incident:cleared"; data: IncidentClearedPayload }
   | { type: "vehicle:rerouted"; data: VehicleReroutedPayload }
   | { type: "replayStatus"; data: ReplayStatus }
-  | { type: "clock"; data: ClockState };
+  | { type: "clock"; data: ClockState }
+  | { type: "traffic"; data: TrafficEdge[] };
 
 /**
  * Type guard to validate WebSocket message structure
@@ -91,6 +93,7 @@ export function isValidMessage(msg: unknown): msg is WebSocketMessage {
     case "vehicle:rerouted":
     case "replayStatus":
     case "clock":
+    case "traffic":
       return "data" in message;
     default:
       return false;

--- a/apps/ui/src/utils/wsTypes.ts
+++ b/apps/ui/src/utils/wsTypes.ts
@@ -7,6 +7,7 @@ import type {
   Fleet,
   IncidentDTO,
   ReplayStatus,
+  ClockState,
 } from "@/types";
 
 export interface ResetPayload {
@@ -54,7 +55,8 @@ export type WebSocketMessage =
   | { type: "incident:created"; data: IncidentDTO }
   | { type: "incident:cleared"; data: IncidentClearedPayload }
   | { type: "vehicle:rerouted"; data: VehicleReroutedPayload }
-  | { type: "replayStatus"; data: ReplayStatus };
+  | { type: "replayStatus"; data: ReplayStatus }
+  | { type: "clock"; data: ClockState };
 
 /**
  * Type guard to validate WebSocket message structure
@@ -88,6 +90,7 @@ export function isValidMessage(msg: unknown): msg is WebSocketMessage {
     case "incident:cleared":
     case "vehicle:rerouted":
     case "replayStatus":
+    case "clock":
       return "data" in message;
     default:
       return false;


### PR DESCRIPTION
## Summary

Implements time-varying traffic demand driven by a simulation clock that can run faster than real-time. Congestion is now dynamic rather than static.

Closes fleetsim-all-pv8 (all 7 subtasks).

## What's new

### SimulationClock (`pv8.1`)
- `EventEmitter`-based clock tracking simulation time independently of wall time
- `tick(deltaMs)` advances by `deltaMs × speedMultiplier`
- `getHour() → 0-23`, `getTimeOfDay() → morning_rush | midday | evening_rush | night`
- Emits `hour:changed` on hour boundaries
- `setSpeedMultiplier()`, `setTime()`, `reset()`

### Traffic demand profiles (`pv8.2`)
- `trafficProfiles.ts` with `DEFAULT_TRAFFIC_PROFILE`:
  - Morning rush 7–9: **2.0×** on trunk/primary
  - Evening rush 17–19: **2.5×** on trunk/primary  
  - Night 22–5: **0.3×** on all roads
- `getDemandMultiplier(profile, hour, highway)` helper
- Configurable via API

### Time-varying TrafficManager (`pv8.3`)
- `TrafficManager` accepts `SimulationClock` reference
- BPR formula uses `effectiveOccupancy = actualOccupancy × demandMultiplier`
- `getProfile() / setProfile()` methods

### Speed limit variation by time (`pv8.4`)
- Night bonus: +10% max speed on trunk/primary highways between 22:00–05:00
- Applied in `VehicleManager.updateSpeed()`

### API: clock control & traffic profile (`pv8.5`)
- `GET /clock` → `{ currentTime, speedMultiplier, hour, timeOfDay }`
- `POST /clock` → `{ speedMultiplier?, setTime? }` to adjust speed or jump time
- `GET /traffic-profile` → active profile
- `POST /traffic-profile` → replace profile
- `GET /status` now includes `clock` field

### WebSocket clock broadcast (`pv8.6`)
- Broadcasts `{ type: 'clock', data: ClockState }` on every hour change

### Tests (`pv8.7`)
- 60 new tests → **562 total** (all passing)
- `SimulationClock.test.ts`: 47 tests covering tick, speed multiplier, events, time-of-day ranges, API
- `TrafficManager.test.ts`: existing BPR tests made deterministic (midday clock), + 7 demand tests + 13 `getDemandMultiplier` unit tests

## How it works

```
VehicleManager.gameLoopTick()
  └─ clock.tick(deltaMs)          ← advances simulation time
       └─ emits 'hour:changed'
            └─ SimulationController → emits 'clock' → WS broadcast

VehicleManager.updateSpeed()
  ├─ traffic.getCongestionFactor(edgeId, dist, highway)
  │    └─ effectiveOccupancy = vehicles × demandMultiplier(hour, highway)
  └─ timeSpeedModifier: ×1.1 on trunk/primary at night
```