### PR TITLE
feat: vehicle types with differentiated behavior

### DIFF
--- a/apps/adapter/src/plugins/sinks/graphql.ts
+++ b/apps/adapter/src/plugins/sinks/graphql.ts
@@ -17,6 +17,7 @@ const defaultVariablesTransform: VariablesTransformFn = (updates) => ({
       latitude: v.latitude,
       longitude: v.longitude,
       id: v.id,
+      type: v.type,
       positionReceivedAt: new Date().toISOString(),
     })),
   },

--- a/apps/adapter/src/plugins/sinks/redpanda.ts
+++ b/apps/adapter/src/plugins/sinks/redpanda.ts
@@ -54,6 +54,7 @@ export class RedpandaSink implements DataSink {
         eventId: `vehicle.position-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
         occurredOn: now,
         vehicleId: update.id,
+        vehicleType: update.type,
         latitude: update.latitude,
         longitude: update.longitude,
         timestamp: now,

--- a/apps/adapter/src/plugins/sources/static.ts
+++ b/apps/adapter/src/plugins/sources/static.ts
@@ -1,5 +1,5 @@
 import type { ConfigField, DataSource, HealthCheckResult, PluginConfig } from "../types";
-import type { ExportVehicle, Fleet } from "../../types";
+import type { ExportVehicle, Fleet, VehicleType } from "../../types";
 
 export class StaticSource implements DataSource {
   readonly type = "static";
@@ -12,10 +12,12 @@ export class StaticSource implements DataSource {
 
   async connect(config: PluginConfig): Promise<void> {
     const count = (config.count as number) || 10;
+    const vehicleTypes: VehicleType[] = ["car", "truck", "motorcycle", "ambulance", "bus"];
     this.vehicles = Array.from({ length: count }, (_, i) => ({
       id: `static-${i}`,
       name: `Test Vehicle ${i + 1}`,
       position: [-1.28 + Math.random() * 0.1, 36.8 + Math.random() * 0.1] as [number, number],
+      type: vehicleTypes[i % vehicleTypes.length],
     }));
 
     const half = Math.ceil(count / 2);

--- a/apps/adapter/src/types/index.ts
+++ b/apps/adapter/src/types/index.ts
@@ -25,16 +25,20 @@ export interface Vehicle {
   latitude: number;
   longitude: number;
 }
+export type VehicleType = "car" | "truck" | "motorcycle" | "ambulance" | "bus";
+
 export interface ExportVehicle {
   id: string;
   name: string;
   position: [number, number];
+  type?: VehicleType;
 }
 
 export interface VehicleUpdate {
   latitude: number;
   longitude: number;
   id: string;
+  type?: VehicleType;
 }
 
 export interface Fleet {

--- a/apps/simulator/src/__tests__/RecordingReplay.test.ts
+++ b/apps/simulator/src/__tests__/RecordingReplay.test.ts
@@ -40,6 +40,7 @@ function makeVehicle(
   return {
     id,
     name: `Vehicle ${id}`,
+    type: "car",
     position: [lat, lng],
     speed: 45,
     heading: 90,

--- a/apps/simulator/src/__tests__/VehicleManager.test.ts
+++ b/apps/simulator/src/__tests__/VehicleManager.test.ts
@@ -3,6 +3,7 @@ import { VehicleManager } from "../modules/VehicleManager";
 import { FleetManager } from "../modules/FleetManager";
 import { RoadNetwork } from "../modules/RoadNetwork";
 import { config } from "../utils/config";
+import { getProfile } from "../utils/vehicleProfiles";
 import type { Vehicle } from "../types";
 import path from "path";
 
@@ -88,10 +89,10 @@ describe("VehicleManager", () => {
       }
     });
 
-    it("should assign initial speed equal to minSpeed from options", () => {
-      const opts = manager.getOptions();
+    it("should assign initial speed equal to minSpeed from vehicle profile", () => {
       for (const v of internalVehicles().values()) {
-        expect(v.speed).toBe(opts.minSpeed);
+        const profile = getProfile(v.type);
+        expect(v.speed).toBe(profile.minSpeed);
       }
     });
 

--- a/apps/simulator/src/__tests__/WebSocketBroadcaster.test.ts
+++ b/apps/simulator/src/__tests__/WebSocketBroadcaster.test.ts
@@ -42,6 +42,7 @@ function makeVehicle(id: string, overrides: Partial<VehicleDTO> = {}): VehicleDT
   return {
     id,
     name: `Vehicle ${id}`,
+    type: "car",
     position: [-1.286, 36.817],
     speed: 40,
     heading: 90,

--- a/apps/simulator/src/__tests__/vehicleTypes.test.ts
+++ b/apps/simulator/src/__tests__/vehicleTypes.test.ts
@@ -1,0 +1,530 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { VehicleManager } from "../modules/VehicleManager";
+import { FleetManager } from "../modules/FleetManager";
+import { RoadNetwork } from "../modules/RoadNetwork";
+import { config } from "../utils/config";
+import {
+  VEHICLE_PROFILES,
+  FOLLOWING_DISTANCE_BY_SIZE,
+  getProfile,
+} from "../utils/vehicleProfiles";
+import { serializeVehicle } from "../utils/serializer";
+import { buildGraph, findRoute } from "../workers/pathfinding-worker";
+import type { Vehicle, VehicleType } from "../types";
+import path from "path";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
+const ALL_TYPES: VehicleType[] = [
+  "car",
+  "truck",
+  "motorcycle",
+  "ambulance",
+  "bus",
+];
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+function createManager(
+  network: RoadNetwork,
+  vehicleTypes?: Partial<Record<VehicleType, number>>
+): VehicleManager {
+  // Stub setRandomDestination to prevent pathfinding on tiny test network
+  const proto = VehicleManager.prototype as any;
+  const orig = proto.setRandomDestination;
+  proto.setRandomDestination = function () {};
+
+  if (vehicleTypes) {
+    // Set pending types before constructor calls loadFromData
+    const origInit = proto.init;
+    proto.init = function (this: any) {
+      this.pendingVehicleTypes = vehicleTypes;
+      origInit.call(this);
+    };
+    const mgr = new VehicleManager(network, new FleetManager());
+    proto.init = origInit;
+    proto.setRandomDestination = orig;
+    return mgr;
+  }
+
+  const mgr = new VehicleManager(network, new FleetManager());
+  proto.setRandomDestination = orig;
+  return mgr;
+}
+
+function getInternalVehicles(manager: VehicleManager): Map<string, Vehicle> {
+  return (manager as any).vehicles;
+}
+
+function cleanupManager(manager: VehicleManager): void {
+  for (const v of manager.getVehicles()) {
+    manager.stopVehicleMovement(v.id);
+  }
+  manager.stopLocationUpdates();
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+describe("Vehicle Types", () => {
+  let network: RoadNetwork;
+  let manager: VehicleManager;
+  let origVehicleCount: number;
+  let origAdapterURL: string;
+
+  beforeEach(() => {
+    origVehicleCount = config.vehicleCount;
+    origAdapterURL = config.adapterURL;
+    (config as any).vehicleCount = 5;
+    (config as any).adapterURL = "";
+    network = new RoadNetwork(FIXTURE_PATH);
+    manager = createManager(network);
+  });
+
+  afterEach(() => {
+    (config as any).vehicleCount = origVehicleCount;
+    (config as any).adapterURL = origAdapterURL;
+    cleanupManager(manager);
+    vi.restoreAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 1. Profile loading and defaults
+  // ────────────────────────────────────────────────────────────────
+  describe("Profile loading and defaults", () => {
+    it("has a valid profile for every vehicle type", () => {
+      for (const type of ALL_TYPES) {
+        const profile = VEHICLE_PROFILES[type];
+        expect(profile).toBeDefined();
+        expect(profile.type).toBe(type);
+        expect(profile.minSpeed).toBeGreaterThan(0);
+        expect(profile.maxSpeed).toBeGreaterThan(profile.minSpeed);
+        expect(profile.acceleration).toBeGreaterThan(0);
+        expect(profile.deceleration).toBeGreaterThan(0);
+        expect(["small", "medium", "large"]).toContain(profile.size);
+      }
+    });
+
+    it("car profile has expected defaults", () => {
+      const car = VEHICLE_PROFILES.car;
+      expect(car.minSpeed).toBe(20);
+      expect(car.maxSpeed).toBe(60);
+      expect(car.acceleration).toBe(5);
+      expect(car.deceleration).toBe(7);
+      expect(car.size).toBe("medium");
+      expect(car.ignoreHeatZones).toBe(false);
+      expect(car.restrictedHighways).toEqual([]);
+    });
+
+    it("ambulance profile has ignoreHeatZones enabled", () => {
+      expect(VEHICLE_PROFILES.ambulance.ignoreHeatZones).toBe(true);
+    });
+
+    it("truck and bus restrict residential highways", () => {
+      expect(VEHICLE_PROFILES.truck.restrictedHighways).toContain("residential");
+      expect(VEHICLE_PROFILES.bus.restrictedHighways).toContain("residential");
+    });
+
+    it("getProfile returns the correct profile for each type", () => {
+      for (const type of ALL_TYPES) {
+        const profile = getProfile(type);
+        expect(profile).toBe(VEHICLE_PROFILES[type]);
+      }
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 2. Vehicle type assignment
+  // ────────────────────────────────────────────────────────────────
+  describe("Vehicle type assignment", () => {
+    it("default vehicles are type 'car'", () => {
+      const vehicles = getInternalVehicles(manager);
+      for (const vehicle of vehicles.values()) {
+        expect(vehicle.type).toBe("car");
+      }
+    });
+
+    it("VehicleDTO includes type field via serializer", () => {
+      const dtos = manager.getVehicles();
+      expect(dtos.length).toBeGreaterThan(0);
+      for (const dto of dtos) {
+        expect(dto.type).toBeDefined();
+        expect(dto.type).toBe("car");
+      }
+    });
+
+    it("all 5 vehicle types are valid profile keys", () => {
+      expect(Object.keys(VEHICLE_PROFILES)).toHaveLength(5);
+      for (const type of ALL_TYPES) {
+        expect(VEHICLE_PROFILES).toHaveProperty(type);
+      }
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 3. Type-specific speed bounds
+  // ────────────────────────────────────────────────────────────────
+  describe("Type-specific speed bounds", () => {
+    it("car vehicles start at car profile minSpeed", () => {
+      const vehicles = getInternalVehicles(manager);
+      const carProfile = getProfile("car");
+      for (const vehicle of vehicles.values()) {
+        expect(vehicle.speed).toBe(carProfile.minSpeed);
+      }
+    });
+
+    it("truck has lower maxSpeed than car", () => {
+      expect(VEHICLE_PROFILES.truck.maxSpeed).toBeLessThan(
+        VEHICLE_PROFILES.car.maxSpeed
+      );
+    });
+
+    it("motorcycle has higher maxSpeed than car", () => {
+      expect(VEHICLE_PROFILES.motorcycle.maxSpeed).toBeGreaterThan(
+        VEHICLE_PROFILES.car.maxSpeed
+      );
+    });
+
+    it("vehicles of different types start at their own profile minSpeed", () => {
+      cleanupManager(manager);
+      manager = createManager(network, {
+        car: 1,
+        truck: 1,
+        motorcycle: 1,
+      });
+      const vehicles = getInternalVehicles(manager);
+      for (const vehicle of vehicles.values()) {
+        const profile = getProfile(vehicle.type);
+        expect(vehicle.speed).toBe(profile.minSpeed);
+      }
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 4. Ambulance ignores heat zones
+  // ────────────────────────────────────────────────────────────────
+  describe("Ambulance ignores heat zones", () => {
+    it("ambulance speed is not reduced in heat zones", () => {
+      cleanupManager(manager);
+      manager = createManager(network, { ambulance: 1, car: 1 });
+
+      const vehicles = getInternalVehicles(manager);
+      const ambulance = [...vehicles.values()].find(
+        (v) => v.type === "ambulance"
+      )!;
+      const car = [...vehicles.values()].find((v) => v.type === "car")!;
+
+      // Place both on the same edge so edge maxSpeed is identical
+      car.currentEdge = ambulance.currentEdge;
+      const edgeMax = ambulance.currentEdge.maxSpeed;
+
+      const ambProfile = getProfile("ambulance");
+      const carProfile = getProfile("car");
+
+      // Set both to same starting speed
+      const startSpeed = Math.min(edgeMax, ambProfile.maxSpeed, carProfile.maxSpeed);
+      ambulance.speed = startSpeed;
+      ambulance.targetSpeed = startSpeed;
+      car.speed = startSpeed;
+      car.targetSpeed = startSpeed;
+
+      // Mock heat zone ON
+      vi.spyOn(network, "isPositionInHeatZone").mockReturnValue(true);
+
+      const updateSpeed = (manager as any).updateSpeed.bind(manager);
+      updateSpeed(ambulance, 1000);
+      updateSpeed(car, 1000);
+
+      const heatZoneFactor = (manager as any).options.heatZoneSpeedFactor;
+      expect(heatZoneFactor).toBeLessThan(1);
+
+      // Car's effective max is reduced by heatZoneFactor; ambulance's is not
+      // So after updateSpeed, ambulance speed >= car speed
+      expect(ambulance.speed).toBeGreaterThanOrEqual(car.speed);
+    });
+
+    it("car speed IS reduced in heat zones", () => {
+      cleanupManager(manager);
+      manager = createManager(network, { car: 1 });
+
+      vi.spyOn(network, "isPositionInHeatZone").mockReturnValue(true);
+
+      const vehicles = getInternalVehicles(manager);
+      const car = [...vehicles.values()].find((v) => v.type === "car")!;
+      const carProfile = getProfile("car");
+
+      car.speed = carProfile.maxSpeed;
+      car.targetSpeed = carProfile.maxSpeed;
+
+      const updateSpeed = (manager as any).updateSpeed.bind(manager);
+      updateSpeed(car, 1000);
+
+      const heatZoneFactor = (manager as any).options.heatZoneSpeedFactor;
+      const effectiveMax =
+        Math.min(carProfile.maxSpeed, car.currentEdge.maxSpeed) *
+        heatZoneFactor;
+      // Car speed must be clamped to heat-zone-adjusted max
+      expect(car.speed).toBeLessThanOrEqual(effectiveMax + 0.01);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 5. Following distance by size
+  // ────────────────────────────────────────────────────────────────
+  describe("Following distance by size", () => {
+    it("small vehicles (motorcycle) use 15m gap", () => {
+      expect(FOLLOWING_DISTANCE_BY_SIZE.small).toBe(0.015);
+    });
+
+    it("medium vehicles (car) use 20m gap", () => {
+      expect(FOLLOWING_DISTANCE_BY_SIZE.medium).toBe(0.02);
+    });
+
+    it("large vehicles (truck/bus) use 30m gap", () => {
+      expect(FOLLOWING_DISTANCE_BY_SIZE.large).toBe(0.03);
+    });
+
+    it("all sizes are covered", () => {
+      expect(Object.keys(FOLLOWING_DISTANCE_BY_SIZE)).toEqual(
+        expect.arrayContaining(["small", "medium", "large"])
+      );
+    });
+
+    it("following distances increase with vehicle size", () => {
+      expect(FOLLOWING_DISTANCE_BY_SIZE.small).toBeLessThan(
+        FOLLOWING_DISTANCE_BY_SIZE.medium
+      );
+      expect(FOLLOWING_DISTANCE_BY_SIZE.medium).toBeLessThan(
+        FOLLOWING_DISTANCE_BY_SIZE.large
+      );
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 6. API spawn with type distribution
+  // ────────────────────────────────────────────────────────────────
+  describe("API spawn with type distribution", () => {
+    it("creates correct distribution from vehicleTypes", () => {
+      cleanupManager(manager);
+      manager = createManager(network, { car: 2, truck: 1 });
+
+      const vehicles = getInternalVehicles(manager);
+      expect(vehicles.size).toBe(3);
+
+      const types = [...vehicles.values()].map((v) => v.type);
+      expect(types.filter((t) => t === "car")).toHaveLength(2);
+      expect(types.filter((t) => t === "truck")).toHaveLength(1);
+    });
+
+    it("creates vehicles of all types when specified", () => {
+      cleanupManager(manager);
+      manager = createManager(network, {
+        car: 1,
+        truck: 1,
+        motorcycle: 1,
+        ambulance: 1,
+        bus: 1,
+      });
+
+      const vehicles = getInternalVehicles(manager);
+      expect(vehicles.size).toBe(5);
+
+      const typeCounts = new Map<string, number>();
+      for (const v of vehicles.values()) {
+        typeCounts.set(v.type, (typeCounts.get(v.type) || 0) + 1);
+      }
+      for (const type of ALL_TYPES) {
+        expect(typeCounts.get(type)).toBe(1);
+      }
+    });
+
+    it("creates only trucks when only truck is specified", () => {
+      cleanupManager(manager);
+      manager = createManager(network, { truck: 3 });
+
+      const vehicles = getInternalVehicles(manager);
+      expect(vehicles.size).toBe(3);
+      for (const v of vehicles.values()) {
+        expect(v.type).toBe("truck");
+      }
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 7. Backward compatibility
+  // ────────────────────────────────────────────────────────────────
+  describe("Backward compatibility", () => {
+    it("defaults to 'car' when no type is specified", () => {
+      const vehicles = getInternalVehicles(manager);
+      expect(vehicles.size).toBe(config.vehicleCount);
+      for (const v of vehicles.values()) {
+        expect(v.type).toBe("car");
+      }
+    });
+
+    it("falls back to config.vehicleCount cars when vehicleTypes not provided", () => {
+      (config as any).vehicleCount = 4;
+      cleanupManager(manager);
+      manager = createManager(network);
+
+      const vehicles = getInternalVehicles(manager);
+      expect(vehicles.size).toBe(4);
+      for (const v of vehicles.values()) {
+        expect(v.type).toBe("car");
+      }
+    });
+
+    it("falls back to config.vehicleCount when vehicleTypes is empty", () => {
+      (config as any).vehicleCount = 3;
+      cleanupManager(manager);
+      manager = createManager(network, {});
+
+      const vehicles = getInternalVehicles(manager);
+      expect(vehicles.size).toBe(3);
+      for (const v of vehicles.values()) {
+        expect(v.type).toBe("car");
+      }
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 8. Pathfinding restrictions
+  // ────────────────────────────────────────────────────────────────
+  describe("Pathfinding restrictions", () => {
+    let nodes: ReturnType<typeof buildGraph>;
+
+    beforeEach(() => {
+      nodes = buildGraph(FIXTURE_PATH);
+    });
+
+    it("builds a graph from the test fixture", () => {
+      expect(nodes.size).toBeGreaterThan(0);
+    });
+
+    it("findRoute finds a route between connected nodes", () => {
+      // Use known start/end from the test network (road-1 + road-2 form a path)
+      const startId = "45.5017,-73.5673";
+      const endId = "45.5029,-73.5661";
+      const route = findRoute(nodes, startId, endId);
+      expect(route).not.toBeNull();
+      expect(route!.edgeIds.length).toBeGreaterThan(0);
+      expect(route!.distance).toBeGreaterThan(0);
+    });
+
+    it("restricting all highway types yields no route", () => {
+      const startId = "45.5017,-73.5673";
+      const endId = "45.5029,-73.5661";
+      // Block all road types in the test network
+      const route = findRoute(nodes, startId, endId, undefined, [
+        "primary",
+        "secondary",
+        "tertiary",
+      ]);
+      expect(route).toBeNull();
+    });
+
+    it("restricting unused highway types still finds a route", () => {
+      const startId = "45.5017,-73.5673";
+      const endId = "45.5029,-73.5661";
+      // "residential" doesn't exist in test network, so restriction has no effect
+      const route = findRoute(nodes, startId, endId, undefined, [
+        "residential",
+      ]);
+      expect(route).not.toBeNull();
+      expect(route!.edgeIds.length).toBeGreaterThan(0);
+    });
+
+    it("restricting 'primary' forces an alternate route or returns null", () => {
+      // road-1 is primary, road-2 is secondary, road-3 is tertiary
+      // Start at road-1 start, end at road-2 end — primary is needed to enter the network
+      const startId = "45.5017,-73.5673";
+      const endId = "45.5029,-73.5661";
+
+      // With primary restricted, the start node's only forward edge is blocked (oneway primary)
+      const restricted = findRoute(nodes, startId, endId, undefined, [
+        "primary",
+      ]);
+      // Either null or uses a different path
+      if (restricted === null) {
+        // Fallback: without restrictions, route exists
+        const unrestricted = findRoute(nodes, startId, endId);
+        expect(unrestricted).not.toBeNull();
+      } else {
+        // If found, it shouldn't use primary edges directly
+        expect(restricted.edgeIds.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("worker fallback: route found without restrictions when restricted returns null", () => {
+      // Simulate the worker fallback logic
+      const startId = "45.5017,-73.5673";
+      const endId = "45.5029,-73.5661";
+      const heavyRestrictions = ["primary", "secondary", "tertiary"];
+
+      let route = findRoute(
+        nodes,
+        startId,
+        endId,
+        undefined,
+        heavyRestrictions
+      );
+
+      // Mimic worker fallback: if no route with restrictions, retry without
+      if (!route && heavyRestrictions.length > 0) {
+        route = findRoute(nodes, startId, endId);
+      }
+
+      expect(route).not.toBeNull();
+      expect(route!.edgeIds.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // 9. VehicleDTO includes type
+  // ────────────────────────────────────────────────────────────────
+  describe("VehicleDTO includes type", () => {
+    it("serializeVehicle includes type field matching vehicle type", () => {
+      for (const type of ALL_TYPES) {
+        const vehicle = {
+          id: `v-${type}`,
+          name: `Test ${type}`,
+          type,
+          position: [1.0, 36.0] as [number, number],
+          speed: 30,
+          bearing: 90,
+          progress: 0,
+          currentEdge: { id: "e1" },
+        } as unknown as Vehicle;
+
+        const dto = serializeVehicle(vehicle);
+        expect(dto.type).toBe(type);
+        expect(dto.id).toBe(`v-${type}`);
+      }
+    });
+
+    it("getVehicles() returns DTOs with correct types for mixed fleet", () => {
+      cleanupManager(manager);
+      manager = createManager(network, { car: 1, ambulance: 1, bus: 1 });
+
+      const dtos = manager.getVehicles();
+      expect(dtos).toHaveLength(3);
+
+      const dtoTypes = dtos.map((d) => d.type).sort();
+      expect(dtoTypes).toEqual(["ambulance", "bus", "car"]);
+    });
+
+    it("DTO does not leak internal vehicle fields", () => {
+      const dtos = manager.getVehicles();
+      for (const dto of dtos) {
+        expect(dto).toHaveProperty("type");
+        expect(dto).toHaveProperty("id");
+        expect(dto).toHaveProperty("name");
+        expect(dto).toHaveProperty("position");
+        expect(dto).toHaveProperty("speed");
+        expect(dto).toHaveProperty("heading");
+        // Internal fields should not be present
+        expect(dto).not.toHaveProperty("bearing");
+        expect(dto).not.toHaveProperty("progress");
+        expect(dto).not.toHaveProperty("currentEdge");
+      }
+    });
+  });
+});

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -15,6 +15,7 @@ import { WebSocketBroadcaster } from "./modules/WebSocketBroadcaster";
 import type { IncidentType } from "./types";
 import { config, verifyConfig } from "./utils/config";
 import { HEAT_ZONE_DEFAULTS } from "./constants";
+import { VEHICLE_PROFILES } from "./utils/vehicleProfiles";
 import { generalRateLimiter, expensiveRateLimiter } from "./middleware/rateLimiter";
 import logger from "./utils/logger";
 
@@ -89,6 +90,10 @@ app.get("/status", (_req, res) => {
   }
 });
 
+app.get("/vehicle-types", (_req, res) => {
+  res.json(VEHICLE_PROFILES);
+});
+
 app.post(
   "/reset",
   asyncHandler(async (_req, res) => {
@@ -101,7 +106,7 @@ app.post(
   "/start",
   asyncHandler(async (req, res) => {
     await simulationController.start(req.body);
-    res.json({ status: "started" });
+    res.json({ status: "started", vehicleTypes: req.body.vehicleTypes ?? null });
   })
 );
 

--- a/apps/simulator/src/modules/Adapter.ts
+++ b/apps/simulator/src/modules/Adapter.ts
@@ -7,6 +7,7 @@ interface SyncVehicle {
   name: string;
   latitude: number;
   longitude: number;
+  type?: string;
 }
 
 interface SyncData {

--- a/apps/simulator/src/modules/PathfindingPool.ts
+++ b/apps/simulator/src/modules/PathfindingPool.ts
@@ -78,7 +78,8 @@ export class PathfindingPool {
   public findRoute(
     startId: string,
     endId: string,
-    incidentEdges?: Map<string, number>
+    incidentEdges?: Map<string, number>,
+    restrictedHighways?: string[]
   ): Promise<PathfindingResult | null> {
     if (this.workers.length === 0) {
       return Promise.resolve(null);
@@ -94,6 +95,9 @@ export class PathfindingPool {
       const msg: Record<string, unknown> = { type: "findRoute", id, startId, endId };
       if (incidentEdges) {
         msg.incidentEdges = Object.fromEntries(incidentEdges);
+      }
+      if (restrictedHighways && restrictedHighways.length > 0) {
+        msg.restrictedHighways = restrictedHighways;
       }
       worker.postMessage(msg);
     });

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -588,7 +588,7 @@ export class RoadNetwork extends EventEmitter {
    *
    * Falls back to synchronous findRoute if the worker pool is unavailable.
    */
-  public async findRouteAsync(start: Node, end: Node): Promise<Route | null> {
+  public async findRouteAsync(start: Node, end: Node, restrictedHighways?: string[]): Promise<Route | null> {
     // Lazy-init the pool on first async call
     if (!this.pathfindingPool) {
       this.pathfindingPool = new PathfindingPool(this.geojsonPath);
@@ -597,7 +597,8 @@ export class RoadNetwork extends EventEmitter {
     const result = await this.pathfindingPool.findRoute(
       start.id,
       end.id,
-      this.incidentEdges.size > 0 ? this.incidentEdges : undefined
+      this.incidentEdges.size > 0 ? this.incidentEdges : undefined,
+      restrictedHighways
     );
     if (!result) return null;
 

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -12,6 +12,7 @@ import type {
   Waypoint,
   MultiStopRoute,
   TrafficProfile,
+  VehicleType,
 } from "../types";
 import { SimulationClock } from "./SimulationClock";
 import { VEHICLE_CONSTANTS } from "../constants";
@@ -25,6 +26,7 @@ import { TrafficManager } from "./TrafficManager";
 import { FleetManager } from "./FleetManager";
 import Adapter from "./Adapter";
 import logger from "../utils/logger";
+import { getProfile, FOLLOWING_DISTANCE_BY_SIZE, VEHICLE_PROFILES } from "../utils/vehicleProfiles";
 
 export class VehicleManager extends EventEmitter {
   private vehicles: Map<string, Vehicle> = new Map();
@@ -49,6 +51,8 @@ export class VehicleManager extends EventEmitter {
   // Task 2: Edge → vehicle spatial index for O(1) lookups
   private vehiclesByEdge: Map<string, Set<string>> = new Map();
 
+  private pendingVehicleTypes?: Partial<Record<VehicleType, number>>;
+
   private options: StartOptions = {
     updateInterval: config.updateInterval,
     minSpeed: config.minSpeed,
@@ -70,7 +74,7 @@ export class VehicleManager extends EventEmitter {
 
   private init(): void {
     if (!config.adapterURL) {
-      this.loadFromData();
+      this.loadFromData(this.pendingVehicleTypes);
     }
     // When adapterURL is set, vehicles are loaded via initFromAdapter()
   }
@@ -100,9 +104,19 @@ export class VehicleManager extends EventEmitter {
     }
   }
 
-  private loadFromData(): void {
-    for (let i = 0; i < config.vehicleCount; i++) {
-      this.addVehicle(i.toString(), `V${i}`);
+  private loadFromData(vehicleTypes?: Partial<Record<VehicleType, number>>): void {
+    if (vehicleTypes && Object.keys(vehicleTypes).length > 0) {
+      let idx = 0;
+      for (const [type, count] of Object.entries(vehicleTypes)) {
+        for (let i = 0; i < (count as number); i++) {
+          this.addVehicle(idx.toString(), `V${idx}`, undefined, type as VehicleType);
+          idx++;
+        }
+      }
+    } else {
+      for (let i = 0; i < config.vehicleCount; i++) {
+        this.addVehicle(i.toString(), `V${i}`);
+      }
     }
   }
 
@@ -157,7 +171,7 @@ export class VehicleManager extends EventEmitter {
         this.addVehicle(v.id, v.name, v.position);
       });
     } else {
-      this.loadFromData();
+      this.loadFromData(this.pendingVehicleTypes);
     }
 
     // Clean up game loop and active vehicles
@@ -176,7 +190,7 @@ export class VehicleManager extends EventEmitter {
    * When seedPosition is provided, finds the nearest node and uses one of
    * its connected edges as the starting edge instead of a random one.
    */
-  private addVehicle(id: string, name: string, seedPosition?: [number, number]): void {
+  private addVehicle(id: string, name: string, seedPosition?: [number, number], vehicleType: VehicleType = "car"): void {
     let startEdge: Edge;
 
     if (seedPosition) {
@@ -190,12 +204,14 @@ export class VehicleManager extends EventEmitter {
       startEdge = this.network.getRandomEdge();
     }
 
+    const profile = getProfile(vehicleType);
     this.vehicles.set(id, {
       id,
       name,
+      type: vehicleType,
       currentEdge: startEdge,
       position: startEdge.start.coordinates,
-      speed: this.options.minSpeed,
+      speed: profile.minSpeed,
       bearing: startEdge.bearing,
       progress: 0,
     });
@@ -262,8 +278,9 @@ export class VehicleManager extends EventEmitter {
 
     // Fire-and-forget async pathfinding via worker pool.
     // The vehicle continues random movement until the route resolves.
+    const profile = getProfile(vehicle.type);
     this.network
-      .findRouteAsync(startNode, destination)
+      .findRouteAsync(startNode, destination, profile.restrictedHighways)
       .then((route) => {
         // Vehicle may have been removed while we were pathfinding
         if (!this.vehicles.has(vehicleId)) return;
@@ -437,19 +454,24 @@ export class VehicleManager extends EventEmitter {
    * @example
    * vehicleManager.setOptions({ maxSpeed: 80, heatZoneSpeedFactor: 0.6 });
    */
-  public setOptions(options: Partial<StartOptions>): void {
+  public setOptions(options: Partial<StartOptions & { vehicleTypes?: Partial<Record<VehicleType, number>> }>): void {
+    const { vehicleTypes, ...startOptions } = options;
+    if (vehicleTypes) {
+      this.pendingVehicleTypes = vehicleTypes;
+    }
     const prevInterval = this.options.updateInterval;
-    this.options = { ...this.options, ...options };
+    this.options = { ...this.options, ...startOptions };
 
     // Restart game loop if updateInterval changed and vehicles are running
     if (
-      options.updateInterval &&
-      options.updateInterval !== prevInterval &&
+      startOptions.updateInterval &&
+      startOptions.updateInterval !== prevInterval &&
       this.activeVehicles.size > 0
     ) {
-      this.restartGameLoop(options.updateInterval);
+      this.restartGameLoop(startOptions.updateInterval);
     }
 
+    this.gameLoopIntervalMs = this.options.updateInterval;
     this.emit("options", this.options);
   }
 
@@ -460,6 +482,10 @@ export class VehicleManager extends EventEmitter {
    */
   public getOptions(): StartOptions {
     return this.options;
+  }
+
+  public getVehicleProfiles() {
+    return VEHICLE_PROFILES;
   }
 
   private updateVehicle(vehicle: Vehicle, deltaMs: number): void {
@@ -488,6 +514,7 @@ export class VehicleManager extends EventEmitter {
   }
 
   private updateSpeed(vehicle: Vehicle, deltaMs: number): void {
+    const profile = getProfile(vehicle.type);
     const edgeMaxSpeed = vehicle.currentEdge.maxSpeed;
 
     // Time-based speed adjustment: night bonus on highways, no change otherwise
@@ -498,21 +525,21 @@ export class VehicleManager extends EventEmitter {
     const adjustedEdgeMaxSpeed = edgeMaxSpeed * timeSpeedModifier;
 
     const isInHeatZone = this.network.isPositionInHeatZone(vehicle.position);
-    const speedFactor = isInHeatZone ? this.options.heatZoneSpeedFactor : 1;
+    const speedFactor = isInHeatZone && !profile.ignoreHeatZones ? this.options.heatZoneSpeedFactor : 1;
     const congestion = this.traffic.getCongestionFactor(
       vehicle.currentEdge.id,
       vehicle.currentEdge.distance,
       vehicle.currentEdge.highway
     );
     const effectiveMax =
-      Math.min(this.options.maxSpeed, adjustedEdgeMaxSpeed) * speedFactor * congestion;
+      Math.min(profile.maxSpeed, adjustedEdgeMaxSpeed) * speedFactor * congestion;
 
     // Refresh target speed occasionally (roughly every 5 seconds)
     if (!vehicle.targetSpeed || Math.random() < deltaMs / 5000) {
       const variation = 1 + (Math.random() * 2 - 1) * this.options.speedVariation;
       vehicle.targetSpeed = Math.min(
         effectiveMax,
-        Math.max(this.options.minSpeed, effectiveMax * variation)
+        Math.max(profile.minSpeed, effectiveMax * variation)
       );
     }
 
@@ -524,7 +551,7 @@ export class VehicleManager extends EventEmitter {
       if (bearingDiff > this.options.turnThreshold) {
         // Scale deceleration by turn sharpness
         const sharpness = Math.min(bearingDiff / 180, 1);
-        vehicle.targetSpeed = Math.max(this.options.minSpeed, effectiveMax * (1 - sharpness * 0.6));
+        vehicle.targetSpeed = Math.max(profile.minSpeed, effectiveMax * (1 - sharpness * 0.6));
       }
     }
 
@@ -533,8 +560,8 @@ export class VehicleManager extends EventEmitter {
 
     if (ahead) {
       const gap = (ahead.progress - vehicle.progress) * vehicle.currentEdge.distance;
-      const MIN_GAP_KM = 0.02; // 20 meters
-      if (gap < MIN_GAP_KM) {
+      const minGap = FOLLOWING_DISTANCE_BY_SIZE[profile.size];
+      if (gap < minGap) {
         vehicle.targetSpeed = Math.min(vehicle.targetSpeed, ahead.speed * 0.9);
       }
     }
@@ -542,11 +569,11 @@ export class VehicleManager extends EventEmitter {
     // Smoothly interpolate toward target (accel/decel rates are in km/h per second)
     const deltaSec = deltaMs / 1000;
     const accelRate =
-      vehicle.speed < vehicle.targetSpeed ? this.options.acceleration : this.options.deceleration;
+      vehicle.speed < vehicle.targetSpeed ? profile.acceleration : profile.deceleration;
     const diff = vehicle.targetSpeed - vehicle.speed;
     const maxChange = accelRate * deltaSec;
     vehicle.speed = vehicle.speed + Math.sign(diff) * Math.min(Math.abs(diff), maxChange);
-    vehicle.speed = Math.min(effectiveMax, Math.max(this.options.minSpeed, vehicle.speed));
+    vehicle.speed = Math.min(effectiveMax, Math.max(profile.minSpeed, vehicle.speed));
   }
 
   /**
@@ -812,7 +839,8 @@ export class VehicleManager extends EventEmitter {
       };
     }
 
-    const route = await this.network.findRouteAsync(startNode, endNode);
+    const profile = getProfile(vehicle.type);
+    const route = await this.network.findRouteAsync(startNode, endNode, profile.restrictedHighways);
     if (!route || route.edges.length === 0) {
       logger.error("No route found to destination");
       return {
@@ -876,6 +904,7 @@ export class VehicleManager extends EventEmitter {
     const legResults: { start: [number, number]; end: [number, number]; distance: number }[] = [];
 
     // Compute A* for each consecutive pair
+    const waypointProfile = getProfile(vehicle.type);
     for (let i = 0; i < positions.length - 1; i++) {
       const startNode = this.network.findNearestNode(positions[i]);
       const endNode = this.network.findNearestNode(positions[i + 1]);
@@ -889,7 +918,7 @@ export class VehicleManager extends EventEmitter {
         };
       }
 
-      const route = await this.network.findRouteAsync(startNode, endNode);
+      const route = await this.network.findRouteAsync(startNode, endNode, waypointProfile.restrictedHighways);
       if (!route || route.edges.length === 0) {
         return {
           vehicleId,
@@ -1063,9 +1092,10 @@ export class VehicleManager extends EventEmitter {
       const startNode = vehicle.currentEdge.end;
       const lastEdge = route.edges[route.edges.length - 1];
       const destinationNode = lastEdge.end;
+      const rerouteProfile = getProfile(vehicle.type);
 
       this.network
-        .findRouteAsync(startNode, destinationNode)
+        .findRouteAsync(startNode, destinationNode, rerouteProfile.restrictedHighways)
         .then((newRoute) => {
           // Vehicle may have been removed or route cleared while pathfinding
           if (!this.vehicles.has(vehicleId)) return;

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -423,6 +423,7 @@ export class VehicleManager extends EventEmitter {
           vehicles: vehicles.map((v) => ({
             id: v.id,
             name: v.name,
+            type: v.type,
             latitude: v.position[0],
             longitude: v.position[1],
           })),

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -20,6 +20,20 @@ export type HighwayType =
   | "tertiary"
   | "residential";
 
+export type VehicleType = "car" | "truck" | "motorcycle" | "ambulance" | "bus";
+export type VehicleSize = "small" | "medium" | "large";
+
+export interface VehicleProfile {
+  type: VehicleType;
+  minSpeed: number;
+  maxSpeed: number;
+  acceleration: number;
+  deceleration: number;
+  restrictedHighways: HighwayType[];
+  ignoreHeatZones: boolean;
+  size: VehicleSize;
+}
+
 export interface Node {
   id: string;
   coordinates: [number, number];
@@ -43,6 +57,7 @@ export interface Edge {
 export interface Vehicle {
   id: string;
   name: string;
+  type: VehicleType;
   currentEdge: Edge;
   position: [number, number];
   speed: number;
@@ -59,6 +74,7 @@ export interface Vehicle {
 export interface VehicleDTO {
   id: string;
   name: string;
+  type: VehicleType;
   position: [number, number];
   speed: number;
   heading: number;
@@ -281,6 +297,7 @@ export interface RecordingMetadata {
 
 export interface VehicleSnapshot {
   id: string;
+  type?: VehicleType;
   position: [number, number];
   speed: number;
   heading: number;

--- a/apps/simulator/src/utils/serializer.ts
+++ b/apps/simulator/src/utils/serializer.ts
@@ -4,6 +4,7 @@ export function serializeVehicle(vehicle: Vehicle, fleetId?: string): VehicleDTO
   return {
     id: vehicle.id,
     name: vehicle.name,
+    type: vehicle.type,
     position: vehicle.position,
     speed: vehicle.speed,
     heading: vehicle.bearing,

--- a/apps/simulator/src/utils/vehicleProfiles.ts
+++ b/apps/simulator/src/utils/vehicleProfiles.ts
@@ -1,0 +1,64 @@
+import type { VehicleProfile, VehicleType } from "../types";
+
+export const VEHICLE_PROFILES: Record<VehicleType, VehicleProfile> = {
+  car: {
+    type: "car",
+    minSpeed: 20,
+    maxSpeed: 60,
+    acceleration: 5,
+    deceleration: 7,
+    restrictedHighways: [],
+    ignoreHeatZones: false,
+    size: "medium",
+  },
+  truck: {
+    type: "truck",
+    minSpeed: 15,
+    maxSpeed: 45,
+    acceleration: 3,
+    deceleration: 5,
+    restrictedHighways: ["residential"],
+    ignoreHeatZones: false,
+    size: "large",
+  },
+  motorcycle: {
+    type: "motorcycle",
+    minSpeed: 25,
+    maxSpeed: 70,
+    acceleration: 8,
+    deceleration: 9,
+    restrictedHighways: [],
+    ignoreHeatZones: false,
+    size: "small",
+  },
+  ambulance: {
+    type: "ambulance",
+    minSpeed: 30,
+    maxSpeed: 80,
+    acceleration: 7,
+    deceleration: 10,
+    restrictedHighways: [],
+    ignoreHeatZones: true,
+    size: "medium",
+  },
+  bus: {
+    type: "bus",
+    minSpeed: 15,
+    maxSpeed: 40,
+    acceleration: 2,
+    deceleration: 4,
+    restrictedHighways: ["residential"],
+    ignoreHeatZones: false,
+    size: "large",
+  },
+};
+
+export const FOLLOWING_DISTANCE_BY_SIZE: Record<string, number> = {
+  small: 0.015,  // 15 meters in km
+  medium: 0.02,  // 20 meters in km
+  large: 0.03,   // 30 meters in km
+};
+
+export function getProfile(type: VehicleType): VehicleProfile {
+  return VEHICLE_PROFILES[type];
+}

--- a/apps/simulator/src/workers/pathfinding-worker.ts
+++ b/apps/simulator/src/workers/pathfinding-worker.ts
@@ -24,6 +24,7 @@ interface WorkerEdge {
   distance: number;
   maxSpeed: number;
   surface: string;
+  highway: string;
 }
 
 interface WorkerNode {
@@ -131,6 +132,7 @@ function buildGraph(geojsonPath: string): Map<string, WorkerNode> {
         distance,
         maxSpeed,
         surface,
+        highway,
       });
 
       if (!isOneway) {
@@ -141,6 +143,7 @@ function buildGraph(geojsonPath: string): Map<string, WorkerNode> {
           distance,
           maxSpeed,
           surface,
+          highway,
         });
       }
     }
@@ -157,7 +160,8 @@ function findRoute(
   nodes: Map<string, WorkerNode>,
   startId: string,
   endId: string,
-  incidentEdges?: Record<string, number>
+  incidentEdges?: Record<string, number>,
+  restrictedHighways?: string[]
 ): { edgeIds: string[]; distance: number } | null {
   const startNode = nodes.get(startId);
   const endNode = nodes.get(endId);
@@ -234,6 +238,11 @@ function findRoute(
     for (const edge of currentNode.edges) {
       if (closedSet.has(edge.endNodeId)) continue;
 
+      // Skip edges on restricted road types for this vehicle
+      if (restrictedHighways && restrictedHighways.length > 0 && restrictedHighways.includes(edge.highway)) {
+        continue;
+      }
+
       // Apply incident-based edge cost penalties
       const incidentFactor = incidentEdges?.[edge.id];
       if (incidentFactor !== undefined && incidentFactor === 0) continue; // closure — skip edge
@@ -278,9 +287,14 @@ if (parentPort) {
       startId: string;
       endId: string;
       incidentEdges?: Record<string, number>;
+      restrictedHighways?: string[];
     }) => {
       if (msg.type === "findRoute") {
-        const route = findRoute(nodes, msg.startId, msg.endId, msg.incidentEdges);
+        let route = findRoute(nodes, msg.startId, msg.endId, msg.incidentEdges, msg.restrictedHighways);
+        // Fallback: if no route found with restrictions, retry without
+        if (!route && msg.restrictedHighways && msg.restrictedHighways.length > 0) {
+          route = findRoute(nodes, msg.startId, msg.endId, msg.incidentEdges);
+        }
         parentPort!.postMessage({ type: "result", id: msg.id, route });
       }
     }

--- a/apps/ui/src/Controls/Vehicles.module.css
+++ b/apps/ui/src/Controls/Vehicles.module.css
@@ -266,3 +266,16 @@
   opacity: 0.6;
   pointer-events: none;
 }
+
+/* Vehicle type badge */
+.typeBadge {
+  font-size: 0.65rem;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  background: var(--color-surface-2, rgba(255, 255, 255, 0.1));
+  color: var(--color-text-secondary, #999);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-left: 0.3rem;
+  font-weight: 500;
+}

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -182,6 +182,9 @@ export default function VehicleList({
                     />
                   )}
                   <span className={styles.name}>{vehicle.name}</span>
+                  {vehicle.type && vehicle.type !== "car" && (
+                    <span className={styles.typeBadge}>{vehicle.type}</span>
+                  )}
                 </span>
                 <span className={styles.speed}>
                   {Math.round(vehicle.speed)}

--- a/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
+++ b/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
@@ -7,6 +7,25 @@ import { vehicleStore } from "../../hooks/vehicleStore";
 const AX = [0, 2.5, 0, -2.5];
 const AY = [-4, 3, 1.5, 3];
 
+// Vehicle type → shape definitions (polygon points as [x,y] arrays, normalized)
+const VEHICLE_SHAPES: Record<string, { x: number[]; y: number[] }> = {
+  car:         { x: AX,                                                          y: AY },
+  truck:       { x: [0, 3, 3, -3, -3],                                          y: [-5, -1, 4, 4, -1] },
+  motorcycle:  { x: [0, 1.5, 0, -1.5],                                          y: [-5, 2, 0, 2] },
+  ambulance:   { x: [0, 2, 2, 0.8, 0.8, 2, 2, 0, -2, -2, -0.8, -0.8, -2, -2],
+                 y: [-4, -4, -0.8, -0.8, 0.8, 0.8, 4, 4, 4, 0.8, 0.8, -0.8, -0.8, -4] },
+  bus:         { x: [0, 3.5, 3.5, -3.5, -3.5],                                  y: [-5, -2, 5, 5, -2] },
+};
+
+// Type-specific default colors (used when no fleet color)
+const VEHICLE_TYPE_COLORS: Record<string, string> = {
+  car: "#dcdcdc",
+  truck: "#f59e0b",
+  motorcycle: "#8b5cf6",
+  ambulance: "#ef4444",
+  bus: "#3b82f6",
+};
+
 /** Default fallback colors matching CSS variables in tokens.css */
 const DEFAULT_FILL = "#dcdcdc";
 const DEFAULT_STROKE = "rgba(0,0,0,0.5)";
@@ -77,26 +96,28 @@ function resolveCSSColor(color: string): string {
 }
 
 /**
- * Draw an arrow (vehicle marker) on a 2D canvas context.
+ * Draw a vehicle shape on a 2D canvas context based on vehicle type.
  */
-function drawArrow(
+function drawShape(
   ctx: CanvasRenderingContext2D,
   x: number,
   y: number,
   heading: number,
   s: number,
+  vehicleType: string,
   fillColor: string,
   strokeColor: string,
   strokeWidth: number
 ) {
+  const shape = VEHICLE_SHAPES[vehicleType] || VEHICLE_SHAPES.car;
   ctx.save();
   ctx.translate(x, y);
   ctx.rotate(heading);
   ctx.beginPath();
-  ctx.moveTo(AX[0] * s, AY[0] * s);
-  ctx.lineTo(AX[1] * s, AY[1] * s);
-  ctx.lineTo(AX[2] * s, AY[2] * s);
-  ctx.lineTo(AX[3] * s, AY[3] * s);
+  ctx.moveTo(shape.x[0] * s, shape.y[0] * s);
+  for (let i = 1; i < shape.x.length; i++) {
+    ctx.lineTo(shape.x[i] * s, shape.y[i] * s);
+  }
   ctx.closePath();
   ctx.fillStyle = fillColor;
   ctx.fill();
@@ -107,14 +128,15 @@ function drawArrow(
 }
 
 /**
- * Draw a glow effect behind an arrow for selected/hovered vehicles.
+ * Draw a glow effect behind a vehicle shape for selected/hovered vehicles.
  */
-function drawGlowArrow(
+function drawGlowShape(
   ctx: CanvasRenderingContext2D,
   x: number,
   y: number,
   heading: number,
   s: number,
+  vehicleType: string,
   fillColor: string,
   glowColor: string,
   glowRadius: number
@@ -124,7 +146,7 @@ function drawGlowArrow(
   ctx.shadowBlur = glowRadius;
   ctx.shadowOffsetX = 0;
   ctx.shadowOffsetY = 0;
-  drawArrow(ctx, x, y, heading, s, fillColor, glowColor, 0.8);
+  drawShape(ctx, x, y, heading, s, vehicleType, fillColor, glowColor, 0.8);
   ctx.restore();
 }
 
@@ -357,10 +379,10 @@ export default function VehiclesLayer({
       // Collect vehicles for rendering
       const projected: ProjectedVehicle[] = [];
 
-      let selectedVehicle: { x: number; y: number; heading: number; color: string } | null = null;
-      let hoveredVehicle: { x: number; y: number; heading: number; color: string } | null = null;
+      let selectedVehicle: { x: number; y: number; heading: number; color: string; type: string } | null = null;
+      let hoveredVehicle: { x: number; y: number; heading: number; color: string; type: string } | null = null;
 
-      const colorBatches = new Map<string, Array<{ x: number; y: number; heading: number }>>();
+      const colorBatches = new Map<string, Array<{ x: number; y: number; heading: number; type: string }>>();
 
       for (const [, v] of store) {
         if (v.position[0] === 0 && v.position[1] === 0) continue;
@@ -393,41 +415,35 @@ export default function VehiclesLayer({
         projected.push({ id: v.id, x, y });
 
         if (v.id === currentSelectedId) {
-          selectedVehicle = { x, y, heading, color: fleet?.color ?? DEFAULT_FILL };
+          const vehicleType = v.type || "car";
+          const defaultColor = VEHICLE_TYPE_COLORS[vehicleType] || DEFAULT_FILL;
+          selectedVehicle = { x, y, heading, color: fleet?.color ?? defaultColor, type: vehicleType };
         } else if (v.id === currentHoveredId) {
-          hoveredVehicle = { x, y, heading, color: fleet?.color ?? DEFAULT_FILL };
+          const vehicleType = v.type || "car";
+          const defaultColor = VEHICLE_TYPE_COLORS[vehicleType] || DEFAULT_FILL;
+          hoveredVehicle = { x, y, heading, color: fleet?.color ?? defaultColor, type: vehicleType };
         } else {
-          const color = resolveCSSColor(fleet?.color ?? DEFAULT_FILL);
-          let batch = colorBatches.get(color);
+          const vehicleType = v.type || "car";
+          const defaultColor = VEHICLE_TYPE_COLORS[vehicleType] || DEFAULT_FILL;
+          const color = resolveCSSColor(fleet?.color ?? defaultColor);
+          const batchKey = `${color}|${vehicleType}`;
+          let batch = colorBatches.get(batchKey);
           if (!batch) {
             batch = [];
-            colorBatches.set(color, batch);
+            colorBatches.set(batchKey, batch);
           }
-          batch.push({ x, y, heading });
+          batch.push({ x, y, heading, type: vehicleType });
         }
       }
 
       projectedRef.current = projected;
 
-      // Draw regular vehicles grouped by color
-      for (const [color, vehicles] of colorBatches) {
-        ctx.fillStyle = color;
-        ctx.strokeStyle = DEFAULT_STROKE;
-        ctx.lineWidth = 0.5;
+      // Draw regular vehicles grouped by color and type
+      for (const [key, vehicles] of colorBatches) {
+        const [color, batchType] = key.split("|");
 
         for (const v of vehicles) {
-          ctx.save();
-          ctx.translate(v.x, v.y);
-          ctx.rotate(v.heading);
-          ctx.beginPath();
-          ctx.moveTo(AX[0] * s, AY[0] * s);
-          ctx.lineTo(AX[1] * s, AY[1] * s);
-          ctx.lineTo(AX[2] * s, AY[2] * s);
-          ctx.lineTo(AX[3] * s, AY[3] * s);
-          ctx.closePath();
-          ctx.fill();
-          ctx.stroke();
-          ctx.restore();
+          drawShape(ctx, v.x, v.y, v.heading, s, batchType, color, DEFAULT_STROKE, 0.5);
         }
       }
 
@@ -436,12 +452,13 @@ export default function VehiclesLayer({
       }
 
       if (hoveredVehicle) {
-        drawGlowArrow(
+        drawGlowShape(
           ctx,
           hoveredVehicle.x,
           hoveredVehicle.y,
           hoveredVehicle.heading,
           s,
+          hoveredVehicle.type,
           resolveCSSColor(hoveredVehicle.color),
           HOVER_STROKE,
           3
@@ -449,12 +466,13 @@ export default function VehiclesLayer({
       }
 
       if (selectedVehicle) {
-        drawGlowArrow(
+        drawGlowShape(
           ctx,
           selectedVehicle.x,
           selectedVehicle.y,
           selectedVehicle.heading,
           s,
+          selectedVehicle.type,
           resolveCSSColor(selectedVehicle.color),
           SELECTED_STROKE,
           4

--- a/apps/ui/src/test/mocks/types.ts
+++ b/apps/ui/src/test/mocks/types.ts
@@ -15,6 +15,7 @@ export function createVehicleDTO(overrides: Partial<VehicleDTO> = {}): VehicleDT
   return {
     id: "vehicle-1",
     name: "Test Vehicle",
+    type: "car",
     position: [-1.2921, 36.8219] as Position,
     speed: 50,
     heading: 90,

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -27,9 +27,12 @@ export interface Fleet {
   vehicleIds: string[];
 }
 
+export type VehicleType = "car" | "truck" | "motorcycle" | "ambulance" | "bus";
+
 export interface VehicleDTO {
   id: string;
   name: string;
+  type: VehicleType;
   position: Position;
   speed: number;
   heading: number;


### PR DESCRIPTION
## Vehicle Types with Differentiated Behavior

Implements `fleetsim-all-5rg` — adds 5 vehicle types (car, truck, motorcycle, ambulance, bus) with distinct behavior and visuals across all 3 apps.

### Simulator
- 5 vehicle profiles with per-type speed, acceleration, and size
- A* pathfinding with road restrictions (trucks/buses avoid residential) + automatic fallback
- Following distance scaled by vehicle size (small 15m, medium 20m, large 30m)
- `GET /vehicle-types` API endpoint; type distribution on spawn
- 34 new tests (596 total)

### Adapter
- `type` field flows through ExportVehicle/VehicleUpdate interfaces
- Static source assigns rotating vehicle types
- Redpanda + GraphQL sinks propagate type
- Simulator sync payload includes vehicle type

### UI
- 5 distinct canvas shapes (arrow, wide pentagon, diamond, cross, wide pentagon)
- Type-specific default colors (car=gray, truck=amber, motorcycle=violet, ambulance=red, bus=blue)
- Canvas batching by `color|type` for efficient rendering
- Type badges in vehicle list panel

All 1,055 tests pass (596 simulator + 171 adapter + 288 UI).