### PR TITLE
feat: vehicle breadcrumb trails on map

### DIFF
--- a/apps/ui/src/Controls/TogglesPanel.tsx
+++ b/apps/ui/src/Controls/TogglesPanel.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import type { Modifiers } from "@/types";
-import { Switch } from "@/components/Inputs";
+import { Switch, Range } from "@/components/Inputs";
 import { eValue } from "@/utils/form";
+import { vehicleStore } from "@/hooks/vehicleStore";
 import { PanelBody, PanelHeader } from "./PanelPrimitives";
 import styles from "./TogglesPanel.module.css";
 
@@ -16,9 +18,40 @@ const toggles: { key: keyof Modifiers; label: string }[] = [
   { key: "showHeatmap", label: "Heatmap" },
   { key: "showHeatzones", label: "Zones" },
   { key: "showPOIs", label: "POIs" },
+  { key: "showBreadcrumbs", label: "Trails" },
 ];
 
+function readStoredTrailLength(): number {
+  try {
+    const stored = localStorage.getItem("trailLength");
+    if (stored) {
+      const n = Number(stored);
+      if (n >= 10 && n <= 120) return n;
+    }
+  } catch {
+    // ignore localStorage errors
+  }
+  return 60;
+}
+
 export default function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPanelProps) {
+  const [trailLength, setTrailLength] = useState(() => {
+    const initial = readStoredTrailLength();
+    vehicleStore.setTrailCapacity(initial);
+    return initial;
+  });
+
+  const handleTrailLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    setTrailLength(value);
+    vehicleStore.setTrailCapacity(value);
+    try {
+      localStorage.setItem("trailLength", String(value));
+    } catch {
+      // ignore localStorage errors
+    }
+  };
+
   return (
     <>
       <PanelHeader
@@ -36,6 +69,18 @@ export default function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPa
             />
           </label>
         ))}
+        {modifiers.showBreadcrumbs && (
+          <div className={styles.row}>
+            <Range
+              label="Trail Length"
+              value={trailLength}
+              min={10}
+              max={120}
+              step={10}
+              onChange={handleTrailLengthChange}
+            />
+          </div>
+        )}
       </PanelBody>
     </>
   );

--- a/apps/ui/src/Controls/__tests__/TogglesPanel.test.tsx
+++ b/apps/ui/src/Controls/__tests__/TogglesPanel.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Modifiers } from "@/types";
+import { createModifiers } from "@/test/mocks/types";
+
+// ---------------------------------------------------------------------------
+// Mock vehicleStore for trail capacity calls
+// ---------------------------------------------------------------------------
+vi.mock("@/hooks/vehicleStore", () => ({
+  vehicleStore: {
+    setTrailCapacity: vi.fn(),
+    getTrail: vi.fn(() => []),
+    clearTrails: vi.fn(),
+  },
+}));
+
+import TogglesPanel from "../TogglesPanel";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function defaultModifiers(overrides: Partial<Modifiers> = {}): Modifiers {
+  return {
+    ...createModifiers(),
+    showTrafficOverlay: true,
+    showBreadcrumbs: false,
+    ...overrides,
+  } as Modifiers;
+}
+
+function renderPanel(modifiers: Modifiers, onChangeModifiers?: ReturnType<typeof vi.fn>) {
+  const changeFn = onChangeModifiers ?? vi.fn(() => vi.fn());
+  return render(<TogglesPanel modifiers={modifiers} onChangeModifiers={changeFn} />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("TogglesPanel", () => {
+  it("renders all toggle switches including Trails", () => {
+    renderPanel(defaultModifiers());
+
+    // Existing toggles
+    expect(screen.getByLabelText("Network")).toBeInTheDocument();
+    expect(screen.getByLabelText("Traffic Colours")).toBeInTheDocument();
+    expect(screen.getByLabelText("Vehicles")).toBeInTheDocument();
+    expect(screen.getByLabelText("Heatmap")).toBeInTheDocument();
+    expect(screen.getByLabelText("Zones")).toBeInTheDocument();
+    expect(screen.getByLabelText("POIs")).toBeInTheDocument();
+
+    // New Trails toggle
+    expect(screen.getByLabelText("Trails")).toBeInTheDocument();
+  });
+
+  it("trail length slider appears when showBreadcrumbs is true", () => {
+    renderPanel(defaultModifiers({ showBreadcrumbs: true } as Partial<Modifiers>));
+
+    // When trails are enabled, a trail length slider should be visible
+    expect(screen.getByLabelText(/trail length/i)).toBeInTheDocument();
+  });
+
+  it("trail length slider is hidden when showBreadcrumbs is false", () => {
+    renderPanel(defaultModifiers({ showBreadcrumbs: false } as Partial<Modifiers>));
+
+    // When trails are disabled, no trail length slider should be present
+    expect(screen.queryByLabelText(/trail length/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/Map/Breadcrumb/BreadcrumbLayer.tsx
+++ b/apps/ui/src/Map/Breadcrumb/BreadcrumbLayer.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useCallback } from "react";
+import type { Fleet, Position } from "@/types";
+import { useMapContext } from "@/components/Map/hooks";
+import { vehicleStore } from "@/hooks/vehicleStore";
+
+const DEFAULT_TRAIL_COLOR = "#39f";
+
+interface BreadcrumbLayerProps {
+  selectedId?: string;
+  showAll: boolean;
+  vehicleFleetMap: Map<string, Fleet>;
+  hiddenFleetIds: Set<string>;
+}
+
+/**
+ * SVG-based layer that renders vehicle position trails as polyline segments
+ * with an opacity gradient (newest = 1.0, oldest = 0.05).
+ *
+ * Reads directly from vehicleStore on every animation frame (fast path).
+ */
+export default function BreadcrumbLayer({
+  selectedId,
+  showAll,
+  vehicleFleetMap,
+  hiddenFleetIds,
+}: BreadcrumbLayerProps) {
+  const { projection, transform, map } = useMapContext();
+  const gRef = useRef<SVGGElement | null>(null);
+
+  // Keep mutable refs for values that change frequently
+  const selectedRef = useRef(selectedId);
+  selectedRef.current = selectedId;
+  const showAllRef = useRef(showAll);
+  showAllRef.current = showAll;
+  const fleetMapRef = useRef(vehicleFleetMap);
+  fleetMapRef.current = vehicleFleetMap;
+  const hiddenFleetsRef = useRef(hiddenFleetIds);
+  hiddenFleetsRef.current = hiddenFleetIds;
+  const transformRef = useRef(transform);
+  transformRef.current = transform;
+
+  const projectPosition = useCallback(
+    (pos: Position): [number, number] | null => {
+      if (!projection) return null;
+      // Positions in store are [lat, lng]; projection expects [lng, lat]
+      const result = projection([pos[1], pos[0]]);
+      if (!result || !isFinite(result[0]) || !isFinite(result[1])) return null;
+      return result as [number, number];
+    },
+    [projection]
+  );
+
+  useEffect(() => {
+    if (!projection || !map) return;
+
+    // Create the SVG <g> element inside the map's SVG
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    g.setAttribute("data-layer", "breadcrumbs");
+    map.appendChild(g);
+    gRef.current = g;
+
+    let rafId: number;
+    let lastVersion = -1;
+    let lastTransformK = -1;
+    let lastTransformX = NaN;
+    let lastTransformY = NaN;
+    let lastSelectedId: string | undefined;
+
+    const render = () => {
+      rafId = requestAnimationFrame(render);
+
+      const currentVersion = vehicleStore.getVersion();
+      const t = transformRef.current;
+      const k = t?.k ?? 1;
+      const tx = t?.x ?? 0;
+      const ty = t?.y ?? 0;
+      const currentSelectedId = selectedRef.current;
+
+      const positionsChanged = currentVersion !== lastVersion;
+      const zoomChanged = k !== lastTransformK || tx !== lastTransformX || ty !== lastTransformY;
+      const selectionChanged = currentSelectedId !== lastSelectedId;
+
+      if (!positionsChanged && !zoomChanged && !selectionChanged) return;
+
+      lastVersion = currentVersion;
+      lastTransformK = k;
+      lastTransformX = tx;
+      lastTransformY = ty;
+      lastSelectedId = currentSelectedId;
+
+      const fleetMap = fleetMapRef.current;
+      const hiddenFleets = hiddenFleetsRef.current;
+      const allTrails = vehicleStore.getAllTrails();
+      const showAllNow = showAllRef.current;
+      const strokeWidth = 2 / k;
+
+      // Clear previous content
+      g.textContent = "";
+
+      for (const [vehicleId, trail] of allTrails) {
+        if (trail.length < 2) continue;
+
+        // Only render for selected vehicle unless showAll
+        if (!showAllNow && vehicleId !== currentSelectedId) continue;
+
+        // Respect hidden fleets
+        const fleet = fleetMap.get(vehicleId);
+        if (fleet && hiddenFleets.has(fleet.id)) continue;
+
+        const color = fleet?.color ?? DEFAULT_TRAIL_COLOR;
+
+        // Project all positions
+        const projected: [number, number][] = [];
+        for (const pos of trail) {
+          const p = projectPosition(pos);
+          if (p) projected.push(p);
+        }
+        if (projected.length < 2) continue;
+
+        // Render as individual line segments with graduated opacity
+        const segmentCount = projected.length - 1;
+        for (let i = 0; i < segmentCount; i++) {
+          // Opacity: oldest (i=0) → 0.05, newest (i=segmentCount-1) → 1.0
+          const t = segmentCount === 1 ? 1 : i / (segmentCount - 1);
+          const opacity = 0.05 + t * 0.95;
+
+          const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+          line.setAttribute("x1", String(projected[i][0]));
+          line.setAttribute("y1", String(projected[i][1]));
+          line.setAttribute("x2", String(projected[i + 1][0]));
+          line.setAttribute("y2", String(projected[i + 1][1]));
+          line.setAttribute("stroke", color);
+          line.setAttribute("stroke-opacity", String(opacity));
+          line.setAttribute("stroke-width", String(strokeWidth));
+          line.setAttribute("stroke-linecap", "round");
+          g.appendChild(line);
+        }
+      }
+    };
+
+    rafId = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      g.remove();
+      gRef.current = null;
+    };
+  }, [projection, map, projectPosition]);
+
+  // This component renders nothing into React's tree — SVG is managed via DOM
+  return null;
+}

--- a/apps/ui/src/Map/Breadcrumb/__tests__/BreadcrumbLayer.test.tsx
+++ b/apps/ui/src/Map/Breadcrumb/__tests__/BreadcrumbLayer.test.tsx
@@ -129,7 +129,14 @@ describe("BreadcrumbLayer", () => {
 
   it("renders trail segments for selected vehicle", () => {
     const trails = new Map<string, Position[]>([
-      ["v1", [[36.82, -1.29], [36.83, -1.3], [36.84, -1.31]]],
+      [
+        "v1",
+        [
+          [36.82, -1.29],
+          [36.83, -1.3],
+          [36.84, -1.31],
+        ],
+      ],
     ]);
     mockGetAllTrails.mockReturnValue(trails);
 
@@ -147,8 +154,20 @@ describe("BreadcrumbLayer", () => {
 
   it("renders trails for all vehicles when showAll is true", () => {
     const trails = new Map<string, Position[]>([
-      ["v1", [[36.82, -1.29], [36.83, -1.3]]],
-      ["v2", [[36.84, -1.31], [36.85, -1.32]]],
+      [
+        "v1",
+        [
+          [36.82, -1.29],
+          [36.83, -1.3],
+        ],
+      ],
+      [
+        "v2",
+        [
+          [36.84, -1.31],
+          [36.85, -1.32],
+        ],
+      ],
     ]);
     mockGetAllTrails.mockReturnValue(trails);
 
@@ -166,7 +185,14 @@ describe("BreadcrumbLayer", () => {
 
   it("does not render trail for vehicles in hidden fleets", () => {
     const trails = new Map<string, Position[]>([
-      ["v1", [[36.82, -1.29], [36.83, -1.3], [36.84, -1.31]]],
+      [
+        "v1",
+        [
+          [36.82, -1.29],
+          [36.83, -1.3],
+          [36.84, -1.31],
+        ],
+      ],
     ]);
     mockGetAllTrails.mockReturnValue(trails);
 

--- a/apps/ui/src/Map/Breadcrumb/__tests__/BreadcrumbLayer.test.tsx
+++ b/apps/ui/src/Map/Breadcrumb/__tests__/BreadcrumbLayer.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import type { Fleet, Position } from "@/types";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mockGetTrail, mockGetAllTrails, mockGetVersion } = vi.hoisted(() => ({
+  mockGetTrail: vi.fn((_id: string) => [] as Position[]),
+  mockGetAllTrails: vi.fn(() => new Map<string, Position[]>()),
+  mockGetVersion: vi.fn(() => 1),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock vehicleStore
+// ---------------------------------------------------------------------------
+vi.mock("@/hooks/vehicleStore", () => ({
+  vehicleStore: {
+    getTrail: mockGetTrail,
+    getAllTrails: mockGetAllTrails,
+    getVersion: mockGetVersion,
+    getAll: vi.fn(() => new Map()),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock map element — BreadcrumbLayer appends SVG to this
+// ---------------------------------------------------------------------------
+let mockMapEl: SVGSVGElement;
+
+const mockProjection = vi.fn((pos: Position) => [pos[0] * 10, pos[1] * 10] as [number, number]);
+(mockProjection as unknown as { invert: unknown }).invert = vi.fn();
+
+vi.mock("@/components/Map/hooks", () => ({
+  useMapContext: () => ({
+    projection: mockProjection,
+    transform: { k: 1, x: 0, y: 0 },
+    map: mockMapEl,
+    getBoundingBox: () => [
+      [0, 0],
+      [0, 0],
+    ],
+    getZoom: () => 1,
+  }),
+}));
+
+// Import AFTER mocks
+import BreadcrumbLayer from "@/Map/Breadcrumb/BreadcrumbLayer";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeFleetMap(...entries: Array<[string, Partial<Fleet>]>): Map<string, Fleet> {
+  const map = new Map<string, Fleet>();
+  for (const [vehicleId, partial] of entries) {
+    map.set(vehicleId, {
+      id: partial.id ?? "fleet-1",
+      name: partial.name ?? "Fleet 1",
+      color: partial.color ?? "#ff0000",
+      source: partial.source ?? "local",
+      vehicleIds: partial.vehicleIds ?? [vehicleId],
+    });
+  }
+  return map;
+}
+
+const defaultProps = {
+  showAll: false,
+  vehicleFleetMap: new Map<string, Fleet>(),
+  hiddenFleetIds: new Set<string>(),
+};
+
+// ---------------------------------------------------------------------------
+// Setup: mock RAF to execute synchronously
+// ---------------------------------------------------------------------------
+let rafCallbacks: FrameRequestCallback[] = [];
+let rafId = 0;
+
+function flushRAF() {
+  const cbs = [...rafCallbacks];
+  rafCallbacks = [];
+  for (const cb of cbs) cb(performance.now());
+}
+
+beforeEach(() => {
+  mockGetTrail.mockReset();
+  mockGetTrail.mockReturnValue([]);
+  mockGetAllTrails.mockReset();
+  mockGetAllTrails.mockReturnValue(new Map());
+  mockGetVersion.mockReturnValue(1);
+  mockProjection.mockClear();
+  mockProjection.mockImplementation(
+    (pos: Position) => [pos[0] * 10, pos[1] * 10] as [number, number]
+  );
+
+  // Create a fresh SVG element for the map
+  mockMapEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+  // Mock RAF to capture callbacks
+  rafCallbacks = [];
+  rafId = 0;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+    rafCallbacks.push(cb);
+    return ++rafId;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("BreadcrumbLayer", () => {
+  it("renders nothing when no vehicle is selected and showAll is false", () => {
+    render(
+      <svg>
+        <BreadcrumbLayer {...defaultProps} />
+      </svg>
+    );
+    flushRAF();
+
+    const lines = mockMapEl.querySelectorAll("line");
+    expect(lines).toHaveLength(0);
+  });
+
+  it("renders trail segments for selected vehicle", () => {
+    const trails = new Map<string, Position[]>([
+      ["v1", [[36.82, -1.29], [36.83, -1.3], [36.84, -1.31]]],
+    ]);
+    mockGetAllTrails.mockReturnValue(trails);
+
+    render(
+      <svg>
+        <BreadcrumbLayer {...defaultProps} selectedId="v1" />
+      </svg>
+    );
+    flushRAF();
+
+    // 3 positions → 2 line segments
+    const lines = mockMapEl.querySelectorAll("line");
+    expect(lines.length).toBe(2);
+  });
+
+  it("renders trails for all vehicles when showAll is true", () => {
+    const trails = new Map<string, Position[]>([
+      ["v1", [[36.82, -1.29], [36.83, -1.3]]],
+      ["v2", [[36.84, -1.31], [36.85, -1.32]]],
+    ]);
+    mockGetAllTrails.mockReturnValue(trails);
+
+    render(
+      <svg>
+        <BreadcrumbLayer {...defaultProps} showAll />
+      </svg>
+    );
+    flushRAF();
+
+    // v1: 1 segment, v2: 1 segment = 2 total
+    const lines = mockMapEl.querySelectorAll("line");
+    expect(lines.length).toBe(2);
+  });
+
+  it("does not render trail for vehicles in hidden fleets", () => {
+    const trails = new Map<string, Position[]>([
+      ["v1", [[36.82, -1.29], [36.83, -1.3], [36.84, -1.31]]],
+    ]);
+    mockGetAllTrails.mockReturnValue(trails);
+
+    const fleetMap = makeFleetMap(["v1", { id: "fleet-1", color: "#ff0000" }]);
+    const hiddenFleetIds = new Set(["fleet-1"]);
+
+    render(
+      <svg>
+        <BreadcrumbLayer showAll vehicleFleetMap={fleetMap} hiddenFleetIds={hiddenFleetIds} />
+      </svg>
+    );
+    flushRAF();
+
+    const lines = mockMapEl.querySelectorAll("line");
+    expect(lines).toHaveLength(0);
+  });
+
+  it("renders nothing when trail is empty", () => {
+    mockGetAllTrails.mockReturnValue(new Map([["v1", []]]));
+
+    render(
+      <svg>
+        <BreadcrumbLayer {...defaultProps} selectedId="v1" />
+      </svg>
+    );
+    flushRAF();
+
+    const lines = mockMapEl.querySelectorAll("line");
+    expect(lines).toHaveLength(0);
+  });
+});

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -26,6 +26,7 @@ const Heatmap = lazy(() => import("./Heatmap"));
 const POIs = lazy(() => import("./POIs"));
 const TrafficZones = lazy(() => import("./TrafficZones"));
 const TrafficOverlay = lazy(() => import("./TrafficOverlay"));
+const BreadcrumbLayer = lazy(() => import("./Breadcrumb/BreadcrumbLayer"));
 
 interface MapProps {
   filters: Filters;
@@ -87,6 +88,16 @@ export default function Map({
       >
         {/* <Selection /> */}
         <Direction selected={filters.selected} hovered={filters.hovered} />
+        {modifiers.showBreadcrumbs && (
+          <Suspense fallback={null}>
+            <BreadcrumbLayer
+              selectedId={filters.selected}
+              showAll={false}
+              vehicleFleetMap={vehicleFleetMap}
+              hiddenFleetIds={hiddenFleetIds}
+            />
+          </Suspense>
+        )}
         {modifiers.showHeatzones && (
           <Suspense fallback={null}>
             <TrafficZones visible={modifiers.showHeatzones} />

--- a/apps/ui/src/hooks/useVehicles.test.ts
+++ b/apps/ui/src/hooks/useVehicles.test.ts
@@ -40,6 +40,7 @@ describe("useVehicles", () => {
       showVehicles: true,
       showPOIs: false,
       showTrafficOverlay: true,
+      showBreadcrumbs: false,
     });
   });
 
@@ -120,6 +121,7 @@ describe("useVehicles", () => {
       showVehicles: true,
       showPOIs: true,
       showTrafficOverlay: true,
+      showBreadcrumbs: false,
     });
   });
 });

--- a/apps/ui/src/hooks/useVehicles.ts
+++ b/apps/ui/src/hooks/useVehicles.ts
@@ -138,6 +138,7 @@ export function useVehicles(): UseVehicle {
     showVehicles: true,
     showPOIs: false,
     showTrafficOverlay: true,
+    showBreadcrumbs: false,
   });
 
   const lowerCaseFilter = useMemo(() => filters.filter.toLowerCase(), [filters.filter]);

--- a/apps/ui/src/hooks/vehicleStore.test.ts
+++ b/apps/ui/src/hooks/vehicleStore.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { vehicleStore } from "./vehicleStore";
+import { createVehicleDTO } from "@/test/mocks/types";
+
+beforeEach(() => {
+  vehicleStore.replace([]);
+  vehicleStore.setTrailCapacity(60);
+});
+
+describe("vehicleStore — trail buffer", () => {
+  it("getTrail returns empty array for unknown vehicle", () => {
+    expect(vehicleStore.getTrail("nonexistent")).toEqual([]);
+  });
+
+  it("set() appends position to vehicle trail", () => {
+    const dto = createVehicleDTO({ id: "v1", position: [-1.29, 36.82] });
+    vehicleStore.set(dto);
+
+    const trail = vehicleStore.getTrail("v1");
+    expect(trail).toEqual([[-1.29, 36.82]]);
+  });
+
+  it("set() maintains trail across multiple updates", () => {
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.29, 36.82] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.30, 36.83] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.31, 36.84] }));
+
+    const trail = vehicleStore.getTrail("v1");
+    expect(trail).toEqual([
+      [-1.29, 36.82],
+      [-1.30, 36.83],
+      [-1.31, 36.84],
+    ]);
+  });
+
+  it("trail respects capacity limit (drops oldest)", () => {
+    // Set a small capacity to make the test manageable
+    vehicleStore.setTrailCapacity(3);
+
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [1, 1] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [2, 2] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [3, 3] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [4, 4] }));
+
+    const trail = vehicleStore.getTrail("v1");
+    expect(trail).toHaveLength(3);
+    // Oldest position [1,1] should have been dropped
+    expect(trail).toEqual([
+      [2, 2],
+      [3, 3],
+      [4, 4],
+    ]);
+  });
+
+  it("setTrailCapacity changes buffer size", () => {
+    vehicleStore.setTrailCapacity(5);
+
+    for (let i = 0; i < 10; i++) {
+      vehicleStore.set(createVehicleDTO({ id: "v1", position: [i, i] }));
+    }
+
+    const trail = vehicleStore.getTrail("v1");
+    expect(trail).toHaveLength(5);
+    expect(trail[0]).toEqual([5, 5]);
+    expect(trail[4]).toEqual([9, 9]);
+  });
+
+  it("setTrailCapacity trims existing trails when reduced", () => {
+    // Start with default capacity, add several positions
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [1, 1] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [2, 2] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [3, 3] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [4, 4] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [5, 5] }));
+
+    expect(vehicleStore.getTrail("v1")).toHaveLength(5);
+
+    // Reduce capacity to 2 — should trim from front (oldest)
+    vehicleStore.setTrailCapacity(2);
+
+    const trail = vehicleStore.getTrail("v1");
+    expect(trail).toHaveLength(2);
+    expect(trail).toEqual([
+      [4, 4],
+      [5, 5],
+    ]);
+  });
+
+  it("replace() clears all trails", () => {
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [1, 1] }));
+    vehicleStore.set(createVehicleDTO({ id: "v2", position: [2, 2] }));
+
+    expect(vehicleStore.getTrail("v1")).toHaveLength(1);
+    expect(vehicleStore.getTrail("v2")).toHaveLength(1);
+
+    vehicleStore.replace([createVehicleDTO({ id: "v1", position: [3, 3] })]);
+
+    expect(vehicleStore.getTrail("v1")).toEqual([]);
+    expect(vehicleStore.getTrail("v2")).toEqual([]);
+  });
+
+  it("clearTrails() clears trails without affecting vehicles", () => {
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [1, 1] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [2, 2] }));
+
+    expect(vehicleStore.getTrail("v1")).toHaveLength(2);
+    expect(vehicleStore.getAll().has("v1")).toBe(true);
+
+    vehicleStore.clearTrails();
+
+    // Trails are gone
+    expect(vehicleStore.getTrail("v1")).toEqual([]);
+    // But the vehicle is still in the store
+    expect(vehicleStore.getAll().has("v1")).toBe(true);
+    expect(vehicleStore.getAll().get("v1")!.id).toBe("v1");
+  });
+
+  it("default trail capacity is 60", () => {
+    // Fill more than 60 positions for a vehicle
+    for (let i = 0; i < 70; i++) {
+      vehicleStore.set(createVehicleDTO({ id: "v1", position: [i, i] }));
+    }
+
+    const trail = vehicleStore.getTrail("v1");
+    expect(trail).toHaveLength(60);
+    // The first 10 positions (0-9) should have been dropped
+    expect(trail[0]).toEqual([10, 10]);
+    expect(trail[59]).toEqual([69, 69]);
+  });
+});

--- a/apps/ui/src/hooks/vehicleStore.test.ts
+++ b/apps/ui/src/hooks/vehicleStore.test.ts
@@ -22,13 +22,13 @@ describe("vehicleStore — trail buffer", () => {
 
   it("set() maintains trail across multiple updates", () => {
     vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.29, 36.82] }));
-    vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.30, 36.83] }));
+    vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.3, 36.83] }));
     vehicleStore.set(createVehicleDTO({ id: "v1", position: [-1.31, 36.84] }));
 
     const trail = vehicleStore.getTrail("v1");
     expect(trail).toEqual([
       [-1.29, 36.82],
-      [-1.30, 36.83],
+      [-1.3, 36.83],
       [-1.31, 36.84],
     ]);
   });

--- a/apps/ui/src/hooks/vehicleStore.ts
+++ b/apps/ui/src/hooks/vehicleStore.ts
@@ -5,7 +5,7 @@
  * - VehiclesLayer: reads directly from the store on every RAF frame (fast)
  * - React (control panel): subscribes to throttled snapshots (slow, 1s)
  */
-import type { VehicleDTO } from "@/types";
+import type { Position, VehicleDTO } from "@/types";
 
 type Listener = () => void;
 
@@ -13,16 +13,31 @@ class VehicleStore {
   private vehicles = new Map<string, VehicleDTO>();
   private listeners = new Set<Listener>();
   private version = 0;
+  private trails = new Map<string, Position[]>();
+  private trailCapacity = 60;
 
   /** Called from WS handler — fast, no React involvement. */
   set(vehicle: VehicleDTO): void {
     this.vehicles.set(vehicle.id, vehicle);
     this.version++;
+
+    // Append position to trail buffer (circular: drop oldest when at capacity)
+    const pos: Position = [vehicle.position[0], vehicle.position[1]];
+    let trail = this.trails.get(vehicle.id);
+    if (!trail) {
+      trail = [];
+      this.trails.set(vehicle.id, trail);
+    }
+    trail.push(pos);
+    if (trail.length > this.trailCapacity) {
+      trail.splice(0, trail.length - this.trailCapacity);
+    }
   }
 
   /** Bulk replace (e.g. on reset / initial load). */
   replace(vehicles: VehicleDTO[]): void {
     this.vehicles.clear();
+    this.trails.clear();
     for (const v of vehicles) this.vehicles.set(v.id, v);
     this.version++;
     this.notify();
@@ -40,6 +55,32 @@ class VehicleStore {
 
   getVersion(): number {
     return this.version;
+  }
+
+  /** Get trail positions for a specific vehicle. */
+  getTrail(vehicleId: string): Position[] {
+    return this.trails.get(vehicleId) ?? [];
+  }
+
+  /** Get all trails (direct access for rendering). */
+  getAllTrails(): Map<string, Position[]> {
+    return this.trails;
+  }
+
+  /** Set the maximum trail length (number of positions kept). */
+  setTrailCapacity(n: number): void {
+    this.trailCapacity = n;
+    // Trim existing trails that exceed the new capacity
+    for (const [, trail] of this.trails) {
+      if (trail.length > n) {
+        trail.splice(0, trail.length - n);
+      }
+    }
+  }
+
+  /** Remove all trail data. */
+  clearTrails(): void {
+    this.trails.clear();
   }
 
   subscribe(listener: Listener): () => void {

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -42,6 +42,7 @@ export interface Modifiers {
   showVehicles: boolean;
   showPOIs: boolean;
   showTrafficOverlay: boolean;
+  showBreadcrumbs: boolean;
 }
 
 interface VehicleUIFlags {


### PR DESCRIPTION
## Summary
- Adds position trail visualization for vehicles on the D3 SVG map
- Trails show as fading polylines (opacity gradient: newest=opaque, oldest=transparent)
- Uses vehicle fleet color, configurable trail length (10-120 positions)
- Works in both live and replay modes (same WS→store pipeline)

### Changes
- **vehicleStore**: Circular buffer of recent `[lat, lng]` positions per vehicle, configurable capacity
- **BreadcrumbLayer**: SVG renderer using `requestAnimationFrame` loop (fast path, no React re-renders)
- **TogglesPanel**: "Trails" toggle + trail length slider, persisted to localStorage
- **Map.tsx**: BreadcrumbLayer integrated between Direction and TrafficZones layers

### New tests (17 total)
- `vehicleStore.test.ts`: 9 tests for trail buffer (capacity, trimming, clearing)
- `BreadcrumbLayer.test.tsx`: 5 tests (rendering, selection, fleet visibility)
- `TogglesPanel.test.tsx`: 3 tests (toggle, slider visibility)

Closes fleetsim-all-8bj

## Test plan
- [x] All 452 UI tests pass
- [x] All 970 simulator tests pass
- [x] All 371 adapter tests pass
- [x] TypeScript type-check passes
- [x] Vite build succeeds
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)