### PR TITLE
feat(ui): migrate interactive components to react-aria-components

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -32,6 +32,7 @@
     "classnames": "^2.5.1",
     "d3": "^7.9.0",
     "react": "^19.2.4",
+    "react-aria-components": "^1.16.0",
     "react-dom": "^19.2.4",
     "the-new-css-reset": "^1.11.3"
   },

--- a/apps/ui/src/App.module.css
+++ b/apps/ui/src/App.module.css
@@ -25,8 +25,8 @@
   visibility: hidden;
   pointer-events: none;
   will-change: transform, opacity;
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
   transition:
     opacity 220ms ease,
     transform 280ms cubic-bezier(0.22, 1, 0.36, 1),

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -393,7 +393,6 @@ export default function App() {
             <BottomDock
               status={status}
               connected={connected}
-              vehicleCount={vehicles.length}
               replayStatus={replay.replayStatus}
               onPauseReplay={replay.pauseReplay}
               onResumeReplay={replay.resumeReplay}

--- a/apps/ui/src/Controls/Adapter/AdapterDrawer.module.css
+++ b/apps/ui/src/Controls/Adapter/AdapterDrawer.module.css
@@ -109,8 +109,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: var(--control-height);
-  height: var(--control-height);
+  min-width: var(--control);
+  height: var(--control);
   padding: 0 var(--space-4);
   border-radius: 999px;
   font-size: var(--text-xs);
@@ -397,8 +397,8 @@
   padding: 0 var(--space-3);
   border-radius: var(--radius-xs);
   font-size: var(--text-sm);
-  height: 24px;
-  line-height: 24px;
+  height: var(--control-xs);
+  line-height: var(--control-xs);
   color: var(--color-gray-lightest);
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -466,7 +466,7 @@ input[type="number"].input::-webkit-inner-spin-button {
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  height: 24px;
+  height: var(--control-xs);
   padding: 0 var(--space-3);
   border-radius: var(--radius-xs);
   background: rgba(255, 255, 255, 0.06);
@@ -500,7 +500,7 @@ input[type="number"].input::-webkit-inner-spin-button {
 .submitBtn {
   position: relative;
   width: 100%;
-  height: 24px;
+  height: var(--control-xs);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -690,8 +690,8 @@ input[type="number"].input::-webkit-inner-spin-button {
   padding: 0 var(--space-3);
   border-radius: var(--radius-xs);
   font-size: var(--text-sm);
-  height: 24px;
-  line-height: 24px;
+  height: var(--control-xs);
+  line-height: var(--control-xs);
   color: var(--color-gray-lightest);
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.08);

--- a/apps/ui/src/Controls/Adapter/AdapterDrawer.module.css
+++ b/apps/ui/src/Controls/Adapter/AdapterDrawer.module.css
@@ -169,7 +169,8 @@
     color var(--transition-fast);
 }
 
-.closeBtn:hover {
+.closeBtn:hover,
+.closeBtn[data-hovered] {
   background: var(--surface-bg-active);
   color: var(--color-gray-lightest);
 }
@@ -218,7 +219,8 @@
     border-color var(--transition-fast);
 }
 
-.tab:hover {
+.tab:hover,
+.tab[data-hovered] {
   color: var(--color-gray-lightest);
 }
 
@@ -515,16 +517,19 @@ input[type="number"].input::-webkit-inner-spin-button {
     border-color var(--transition-fast);
 }
 
-.submitBtn:hover:not(:disabled) {
+.submitBtn:hover:not(:disabled),
+.submitBtn[data-hovered]:not([data-disabled]) {
   background: rgba(57, 153, 255, 0.28);
   border-color: rgba(57, 153, 255, 0.45);
 }
 
-.submitBtn:active:not(:disabled) {
+.submitBtn:active:not(:disabled),
+.submitBtn[data-pressed] {
   background: rgba(57, 153, 255, 0.35);
 }
 
-.submitBtn:disabled {
+.submitBtn:disabled,
+.submitBtn[data-disabled] {
   opacity: 0.4;
   cursor: default;
 }
@@ -586,7 +591,8 @@ input[type="number"].input::-webkit-inner-spin-button {
     background var(--transition-fast);
 }
 
-.removeBtn:hover {
+.removeBtn:hover,
+.removeBtn[data-hovered] {
   color: var(--color-status-offline);
   background: var(--color-danger-bg);
 }
@@ -668,4 +674,109 @@ input[type="number"].input::-webkit-inner-spin-button {
   align-items: center;
   font-size: var(--text-base);
   color: var(--color-gray-lightest);
+}
+
+/* ── React Aria Select ── */
+
+.selectRoot {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.selectTrigger {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-xs);
+  font-size: var(--text-sm);
+  height: 24px;
+  line-height: 24px;
+  color: var(--color-gray-lightest);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-align: left;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.selectTrigger[data-hovered] {
+  border-color: rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.selectTrigger[data-focus-visible] {
+  outline: none;
+  border-color: rgba(57, 153, 255, 0.5);
+  box-shadow: 0 0 0 2px rgba(57, 153, 255, 0.1);
+}
+
+.selectTrigger[data-pressed] {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.selectValue {
+  flex: 1;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectChevron {
+  font-size: 10px;
+  color: var(--color-gray-light);
+  flex-shrink: 0;
+  margin-left: var(--space-2);
+}
+
+.selectPopover {
+  z-index: 1000;
+  background: rgba(12, 14, 18, 0.92);
+  backdrop-filter: blur(24px) saturate(140%);
+  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+
+.selectListBox {
+  list-style: none;
+  padding: var(--space-1);
+  margin: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  outline: none;
+}
+
+.selectItem {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-gray-lightest);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  outline: none;
+}
+
+.selectItem[data-focused],
+.selectItem[data-hovered] {
+  background: rgba(57, 153, 255, 0.15);
+}
+
+.selectItem[data-selected] {
+  background: rgba(57, 153, 255, 0.2);
+  color: var(--color-white);
+}
+
+.selectItem[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: -2px;
 }

--- a/apps/ui/src/Controls/Adapter/ConfigForm.tsx
+++ b/apps/ui/src/Controls/Adapter/ConfigForm.tsx
@@ -1,4 +1,14 @@
 import { useState } from "react";
+import {
+  TextField,
+  Input as AriaInput,
+  Select,
+  SelectValue,
+  Button,
+  Popover,
+  ListBox,
+  ListBoxItem,
+} from "react-aria-components";
 import { Switch } from "@/components/Inputs";
 import type { ConfigField } from "./adapterClient";
 import styles from "./AdapterDrawer.module.css";
@@ -93,40 +103,66 @@ function renderInput(
       );
     case "number":
       return (
-        <input
-          type="number"
-          className={cls}
-          value={value as number}
-          placeholder={field.placeholder}
-          required={field.required}
-          onChange={(e) => set(field.name, Number(e.target.value))}
-        />
+        <TextField
+          value={String(value as number)}
+          onChange={(val) => set(field.name, Number(val))}
+          aria-label={field.label}
+        >
+          <AriaInput
+            type="number"
+            className={cls}
+            placeholder={field.placeholder}
+            required={field.required}
+          />
+        </TextField>
       );
     case "password":
       return (
-        <input
-          type="password"
-          className={cls}
+        <TextField
           value={value as string}
-          placeholder={field.placeholder}
-          required={field.required}
-          onChange={(e) => set(field.name, e.target.value)}
-        />
+          onChange={(val) => set(field.name, val)}
+          aria-label={field.label}
+        >
+          <AriaInput
+            type="password"
+            className={cls}
+            placeholder={field.placeholder}
+            required={field.required}
+          />
+        </TextField>
       );
     case "select":
       return (
-        <select
-          className={cls}
-          value={value as string}
-          onChange={(e) => set(field.name, e.target.value)}
+        <Select
+          selectedKey={value as string}
+          onSelectionChange={(key) => set(field.name, String(key))}
+          className={styles.selectRoot}
+          aria-label={field.label}
         >
-          <option value="">--</option>
-          {field.options?.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
+          <Button className={styles.selectTrigger}>
+            <SelectValue className={styles.selectValue}>
+              {({ selectedText }) => selectedText || "--"}
+            </SelectValue>
+            <span aria-hidden className={styles.selectChevron}>▾</span>
+          </Button>
+          <Popover className={styles.selectPopover}>
+            <ListBox className={styles.selectListBox}>
+              <ListBoxItem id="" textValue="--" className={styles.selectItem}>
+                --
+              </ListBoxItem>
+              {field.options?.map((o) => (
+                <ListBoxItem
+                  key={o.value}
+                  id={o.value}
+                  textValue={o.label}
+                  className={styles.selectItem}
+                >
+                  {o.label}
+                </ListBoxItem>
+              ))}
+            </ListBox>
+          </Popover>
+        </Select>
       );
     case "json":
       return (
@@ -142,14 +178,18 @@ function renderInput(
       );
     default:
       return (
-        <input
-          type="text"
-          className={cls}
+        <TextField
           value={value as string}
-          placeholder={field.placeholder}
-          required={field.required}
-          onChange={(e) => set(field.name, e.target.value)}
-        />
+          onChange={(val) => set(field.name, val)}
+          aria-label={field.label}
+        >
+          <AriaInput
+            type="text"
+            className={cls}
+            placeholder={field.placeholder}
+            required={field.required}
+          />
+        </TextField>
       );
   }
 }

--- a/apps/ui/src/Controls/Adapter/ConfigForm.tsx
+++ b/apps/ui/src/Controls/Adapter/ConfigForm.tsx
@@ -143,7 +143,9 @@ function renderInput(
             <SelectValue className={styles.selectValue}>
               {({ selectedText }) => selectedText || "--"}
             </SelectValue>
-            <span aria-hidden className={styles.selectChevron}>▾</span>
+            <span aria-hidden className={styles.selectChevron}>
+              ▾
+            </span>
           </Button>
           <Popover className={styles.selectPopover}>
             <ListBox className={styles.selectListBox}>

--- a/apps/ui/src/Controls/Adapter/ConfigForm.tsx
+++ b/apps/ui/src/Controls/Adapter/ConfigForm.tsx
@@ -88,7 +88,7 @@ function renderInput(
       return (
         <span className={styles.switchField}>
           <span className={styles.switchLabel}>{value === true ? "Enabled" : "Disabled"}</span>
-          <Switch checked={Boolean(value)} onChange={(e) => set(field.name, e.target.checked)} />
+          <Switch isSelected={Boolean(value)} onChange={(selected) => set(field.name, selected)} />
         </span>
       );
     case "number":

--- a/apps/ui/src/Controls/Adapter/SinksTab.tsx
+++ b/apps/ui/src/Controls/Adapter/SinksTab.tsx
@@ -1,12 +1,5 @@
 import { useState } from "react";
-import {
-  Button,
-  Select,
-  SelectValue,
-  Popover,
-  ListBox,
-  ListBoxItem,
-} from "react-aria-components";
+import { Button, Select, SelectValue, Popover, ListBox, ListBoxItem } from "react-aria-components";
 import type { HealthResponse, ConfigResponse } from "./adapterClient";
 import ConfigForm from "./ConfigForm";
 import styles from "./AdapterDrawer.module.css";
@@ -81,7 +74,9 @@ export default function SinksTab({ health, config, loading, onAdd, onRemove }: S
               <SelectValue className={styles.selectValue}>
                 {({ selectedText }) => selectedText || "-- select type --"}
               </SelectValue>
-              <span aria-hidden className={styles.selectChevron}>▾</span>
+              <span aria-hidden className={styles.selectChevron}>
+                ▾
+              </span>
             </Button>
             <Popover className={styles.selectPopover}>
               <ListBox className={styles.selectListBox}>

--- a/apps/ui/src/Controls/Adapter/SinksTab.tsx
+++ b/apps/ui/src/Controls/Adapter/SinksTab.tsx
@@ -1,4 +1,12 @@
 import { useState } from "react";
+import {
+  Button,
+  Select,
+  SelectValue,
+  Popover,
+  ListBox,
+  ListBoxItem,
+} from "react-aria-components";
 import type { HealthResponse, ConfigResponse } from "./adapterClient";
 import ConfigForm from "./ConfigForm";
 import styles from "./AdapterDrawer.module.css";
@@ -43,13 +51,13 @@ export default function SinksTab({ health, config, loading, onAdd, onRemove }: S
                   <span className={styles.sinkName}>{sink.type}</span>
                 </div>
                 <span className={styles.statusText}>{sink.healthy ? "Healthy" : "Unhealthy"}</span>
-                <button
+                <Button
                   className={styles.removeBtn}
-                  onClick={() => onRemove(sink.type)}
-                  title={`Remove ${sink.type}`}
+                  onPress={() => onRemove(sink.type)}
+                  aria-label={`Remove ${sink.type}`}
                 >
                   &times;
-                </button>
+                </Button>
               </div>
             ))}
           </div>
@@ -63,18 +71,36 @@ export default function SinksTab({ health, config, loading, onAdd, onRemove }: S
             <span className={styles.sectionLabel}>Add sink</span>
             <span className={styles.fieldHint}>Attach another downstream target.</span>
           </div>
-          <select
-            className={styles.input}
-            value={addingType}
-            onChange={(e) => setAddingType(e.target.value)}
+          <Select
+            selectedKey={addingType}
+            onSelectionChange={(key) => setAddingType(String(key))}
+            className={styles.selectRoot}
+            aria-label="Sink Type"
           >
-            <option value="">-- select type --</option>
-            {availableToAdd.map((s) => (
-              <option key={s.type} value={s.type}>
-                {s.type}
-              </option>
-            ))}
-          </select>
+            <Button className={styles.selectTrigger}>
+              <SelectValue className={styles.selectValue}>
+                {({ selectedText }) => selectedText || "-- select type --"}
+              </SelectValue>
+              <span aria-hidden className={styles.selectChevron}>▾</span>
+            </Button>
+            <Popover className={styles.selectPopover}>
+              <ListBox className={styles.selectListBox}>
+                <ListBoxItem id="" textValue="-- select type --" className={styles.selectItem}>
+                  -- select type --
+                </ListBoxItem>
+                {availableToAdd.map((s) => (
+                  <ListBoxItem
+                    key={s.type}
+                    id={s.type}
+                    textValue={s.type}
+                    className={styles.selectItem}
+                  >
+                    {s.type}
+                  </ListBoxItem>
+                ))}
+              </ListBox>
+            </Popover>
+          </Select>
 
           {addPlugin && addPlugin.configSchema.length > 0 && (
             <>
@@ -97,16 +123,16 @@ export default function SinksTab({ health, config, loading, onAdd, onRemove }: S
           )}
 
           {addPlugin && addPlugin.configSchema.length === 0 && (
-            <button
+            <Button
               className={styles.submitBtn}
-              disabled={loading}
-              onClick={() => {
+              isDisabled={loading}
+              onPress={() => {
                 onAdd(addingType);
                 setAddingType("");
               }}
             >
               {loading ? "Adding..." : "Add sink"}
-            </button>
+            </Button>
           )}
         </section>
       )}

--- a/apps/ui/src/Controls/Adapter/SourceTab.tsx
+++ b/apps/ui/src/Controls/Adapter/SourceTab.tsx
@@ -1,12 +1,5 @@
 import { useState } from "react";
-import {
-  Button,
-  Select,
-  SelectValue,
-  Popover,
-  ListBox,
-  ListBoxItem,
-} from "react-aria-components";
+import { Button, Select, SelectValue, Popover, ListBox, ListBoxItem } from "react-aria-components";
 import type { HealthResponse, ConfigResponse } from "./adapterClient";
 import ConfigForm from "./ConfigForm";
 import styles from "./AdapterDrawer.module.css";
@@ -51,7 +44,9 @@ export default function SourceTab({ health, config, loading, onConnect }: Source
               <SelectValue className={styles.selectValue}>
                 {({ selectedText }) => selectedText || "-- select --"}
               </SelectValue>
-              <span aria-hidden className={styles.selectChevron}>▾</span>
+              <span aria-hidden className={styles.selectChevron}>
+                ▾
+              </span>
             </Button>
             <Popover className={styles.selectPopover}>
               <ListBox className={styles.selectListBox}>

--- a/apps/ui/src/Controls/Adapter/SourceTab.tsx
+++ b/apps/ui/src/Controls/Adapter/SourceTab.tsx
@@ -1,4 +1,12 @@
 import { useState } from "react";
+import {
+  Button,
+  Select,
+  SelectValue,
+  Popover,
+  ListBox,
+  ListBoxItem,
+} from "react-aria-components";
 import type { HealthResponse, ConfigResponse } from "./adapterClient";
 import ConfigForm from "./ConfigForm";
 import styles from "./AdapterDrawer.module.css";
@@ -30,23 +38,41 @@ export default function SourceTab({ health, config, loading, onConnect }: Source
       </section>
 
       <section className={styles.sectionCard}>
-        <label className={styles.field}>
+        <div className={styles.field}>
           <span className={styles.fieldLabel}>Source Type</span>
           <span className={styles.fieldHint}>Select the upstream vehicle feed.</span>
-          <select
-            className={styles.input}
-            value={selectedType}
-            onChange={(e) => setSelectedType(e.target.value)}
+          <Select
+            selectedKey={selectedType}
+            onSelectionChange={(key) => setSelectedType(String(key))}
+            className={styles.selectRoot}
+            aria-label="Source Type"
           >
-            <option value="">-- select --</option>
-            {health.availableSources.map((s) => (
-              <option key={s.type} value={s.type}>
-                {s.type}
-                {health.source?.type === s.type ? " (active)" : ""}
-              </option>
-            ))}
-          </select>
-        </label>
+            <Button className={styles.selectTrigger}>
+              <SelectValue className={styles.selectValue}>
+                {({ selectedText }) => selectedText || "-- select --"}
+              </SelectValue>
+              <span aria-hidden className={styles.selectChevron}>▾</span>
+            </Button>
+            <Popover className={styles.selectPopover}>
+              <ListBox className={styles.selectListBox}>
+                <ListBoxItem id="" textValue="-- select --" className={styles.selectItem}>
+                  -- select --
+                </ListBoxItem>
+                {health.availableSources.map((s) => (
+                  <ListBoxItem
+                    key={s.type}
+                    id={s.type}
+                    textValue={s.type}
+                    className={styles.selectItem}
+                  >
+                    {s.type}
+                    {health.source?.type === s.type ? " (active)" : ""}
+                  </ListBoxItem>
+                ))}
+              </ListBox>
+            </Popover>
+          </Select>
+        </div>
       </section>
 
       {plugin && plugin.configSchema.length > 0 && (
@@ -68,13 +94,13 @@ export default function SourceTab({ health, config, loading, onConnect }: Source
 
       {plugin && plugin.configSchema.length === 0 && (
         <section className={styles.sectionCard}>
-          <button
+          <Button
             className={styles.submitBtn}
-            disabled={loading}
-            onClick={() => onConnect(selectedType)}
+            isDisabled={loading}
+            onPress={() => onConnect(selectedType)}
           >
             {loading ? "Connecting..." : "Connect source"}
-          </button>
+          </Button>
         </section>
       )}
 

--- a/apps/ui/src/Controls/AnalyticsPanel.module.css
+++ b/apps/ui/src/Controls/AnalyticsPanel.module.css
@@ -172,6 +172,11 @@
 
 /* ─── Reset Button ─────────────────────────────────── */
 
+.controlRow {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .resetButton {
   height: var(--control-sm);
   padding: 0 var(--space-4);

--- a/apps/ui/src/Controls/AnalyticsPanel.tsx
+++ b/apps/ui/src/Controls/AnalyticsPanel.tsx
@@ -175,13 +175,13 @@ export default function AnalyticsPanel({
       <PanelHeader
         title="Analytics"
         subtitle={`${summary.activeVehicles} of ${summary.totalVehicles} vehicles active`}
-        actions={
+      />
+      <PanelBody className={styles.body}>
+        <div className={styles.controlRow}>
           <Button className={styles.resetButton} onClick={handleReset} type="button">
             Reset
           </Button>
-        }
-      />
-      <PanelBody className={styles.body}>
+        </div>
         <div className={styles.summary}>
           <KpiCard label="Vehicles" value={summary.activeVehicles} total={summary.totalVehicles} />
           <KpiCard label="Avg Speed" value={formatSpeed(summary.avgSpeed)} unit="km/h" />

--- a/apps/ui/src/Controls/BottomDock.module.css
+++ b/apps/ui/src/Controls/BottomDock.module.css
@@ -20,16 +20,17 @@
 .group {
   display: flex;
   align-items: center;
-  gap: 1px;
-  border-radius: var(--radius-sm);
-  overflow: hidden;
+  gap: var(--space-1);
 }
 
-.divider {
-  width: 1px;
-  height: var(--control-sm);
-  background: var(--color-overlay-1);
-  flex-shrink: 0;
+.chips {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.dockBtn {
+  border-color: transparent !important;
 }
 
 .btnIcon {
@@ -43,8 +44,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  height: var(--control-sm);
-  padding: 0 var(--space-3);
+  padding: 0 var(--space-2);
   font-size: var(--text-xs);
   color: var(--color-gray-light);
 }

--- a/apps/ui/src/Controls/BottomDock.module.css
+++ b/apps/ui/src/Controls/BottomDock.module.css
@@ -93,8 +93,13 @@
   transition: background var(--transition-fast);
 }
 
-.recordBtn:hover {
+.recordBtn:hover,
+.recordBtn[data-hovered] {
   background: var(--surface-bg-hover);
+}
+
+.recordBtn[data-pressed]:not(.recordBtnActive) {
+  background: var(--surface-bg-active, var(--surface-bg-hover));
 }
 
 .recordIcon {
@@ -108,7 +113,12 @@
   background: var(--color-danger-bg);
 }
 
-.recordBtnActive:hover {
+.recordBtnActive:hover,
+.recordBtnActive[data-hovered] {
+  background: var(--color-danger-bg-hover);
+}
+
+.recordBtnActive[data-pressed] {
   background: var(--color-danger-bg-hover);
 }
 
@@ -232,8 +242,13 @@
     color var(--transition-fast);
 }
 
-.speedBtn:hover {
+.speedBtn:hover,
+.speedBtn[data-hovered] {
   background: var(--surface-bg-hover);
+}
+
+.speedBtn[data-pressed] {
+  background: var(--surface-bg-active, var(--surface-bg-hover));
 }
 
 .speedBtnActive {

--- a/apps/ui/src/Controls/BottomDock.module.css
+++ b/apps/ui/src/Controls/BottomDock.module.css
@@ -9,10 +9,10 @@
   gap: var(--space-5);
   height: var(--control-xl);
   padding: 0 var(--space-6);
-  background: var(--panel-surface-strong);
+  background: var(--glass-bg);
   backdrop-filter: var(--glass-blur);
   -webkit-backdrop-filter: var(--glass-blur);
-  border: var(--panel-border);
+  border: var(--glass-border);
   border-radius: var(--radius-xl);
   box-shadow: var(--glass-shadow);
 }

--- a/apps/ui/src/Controls/BottomDock.module.css
+++ b/apps/ui/src/Controls/BottomDock.module.css
@@ -233,7 +233,7 @@
   border: none;
   background: var(--surface-bg);
   color: var(--color-gray-light);
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   font-family: inherit;
   font-weight: 500;
   cursor: pointer;

--- a/apps/ui/src/Controls/BottomDock.tsx
+++ b/apps/ui/src/Controls/BottomDock.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import classNames from "classnames";
+import { Button } from "react-aria-components";
 import client from "@/utils/client";
 import type { ReplayStatus, SimulationStatus } from "@/types";
 import { Flame, Pause, Play, Record, Reset, Stop } from "@/components/Icons";
@@ -139,16 +140,15 @@ function ReplayDock({
 
       <div className={styles.speedGroup}>
         {SPEEDS.map((s) => (
-          <button
+          <Button
             key={s}
-            type="button"
             className={classNames(styles.speedBtn, {
               [styles.speedBtnActive]: (replayStatus.speed ?? 1) === s,
             })}
-            onClick={() => handleSpeedChange(s)}
+            onPress={() => handleSpeedChange(s)}
           >
             {s}x
-          </button>
+          </Button>
         ))}
       </div>
     </div>
@@ -259,15 +259,14 @@ export default function BottomDock({
 
       <div className={styles.divider} />
 
-      <button
-        type="button"
+      <Button
         className={classNames(styles.recordBtn, { [styles.recordBtnActive]: isRecording })}
-        onClick={isRecording ? onStopRecording : onStartRecording}
+        onPress={isRecording ? onStopRecording : onStartRecording}
         aria-label={isRecording ? "Stop recording" : "Start recording"}
       >
         <Record className={styles.recordIcon} />
         {isRecording && <span className={styles.recordTime}>{formatTime(elapsed)}</span>}
-      </button>
+      </Button>
 
       <div className={styles.divider} />
 

--- a/apps/ui/src/Controls/BottomDock.tsx
+++ b/apps/ui/src/Controls/BottomDock.tsx
@@ -268,7 +268,6 @@ export default function BottomDock({
           </span>
         ))}
       </div>
-
     </div>
   );
 }

--- a/apps/ui/src/Controls/BottomDock.tsx
+++ b/apps/ui/src/Controls/BottomDock.tsx
@@ -124,8 +124,6 @@ function ReplayDock({
         />
       </div>
 
-      <div className={styles.divider} />
-
       <div ref={progressRef} className={styles.progressWrap} onClick={handleProgressClick}>
         <div className={styles.progressTrack}>
           <div className={styles.progressFill} style={{ width: `${progress * 100}%` }} />
@@ -135,8 +133,6 @@ function ReplayDock({
       <span className={styles.time}>
         {formatTime(displayTime / 1000)} / {formatTime(duration / 1000)}
       </span>
-
-      <div className={styles.divider} />
 
       <div className={styles.speedGroup}>
         {SPEEDS.map((s) => (
@@ -257,8 +253,6 @@ export default function BottomDock({
         />
       </div>
 
-      <div className={styles.divider} />
-
       <Button
         className={classNames(styles.recordBtn, { [styles.recordBtnActive]: isRecording })}
         onPress={isRecording ? onStopRecording : onStartRecording}
@@ -268,9 +262,7 @@ export default function BottomDock({
         {isRecording && <span className={styles.recordTime}>{formatTime(elapsed)}</span>}
       </Button>
 
-      <div className={styles.divider} />
-
-      <div className={styles.group}>
+      <div className={styles.chips}>
         {statusChips.map(({ key, label, active }) => (
           <span key={key} className={classNames(styles.chip, { [styles.chipActive]: active })}>
             <span className={classNames(styles.led, { [styles.ledOn]: active })} />
@@ -278,8 +270,6 @@ export default function BottomDock({
           </span>
         ))}
       </div>
-
-      <div className={styles.divider} />
 
       <span className={styles.vehicleCount}>
         <span className={styles.vehicleCountValue}>{vehicleCount}</span>

--- a/apps/ui/src/Controls/BottomDock.tsx
+++ b/apps/ui/src/Controls/BottomDock.tsx
@@ -156,7 +156,6 @@ function ReplayDock({
 interface BottomDockProps {
   status: SimulationStatus;
   connected: boolean;
-  vehicleCount: number;
   replayStatus: ReplayStatus;
   onPauseReplay: () => Promise<void>;
   onResumeReplay: () => Promise<void>;
@@ -171,7 +170,6 @@ interface BottomDockProps {
 export default function BottomDock({
   status,
   connected,
-  vehicleCount,
   replayStatus,
   onPauseReplay,
   onResumeReplay,
@@ -271,10 +269,6 @@ export default function BottomDock({
         ))}
       </div>
 
-      <span className={styles.vehicleCount}>
-        <span className={styles.vehicleCountValue}>{vehicleCount}</span>
-        <span className={styles.vehicleCountLabel}>fleet</span>
-      </span>
     </div>
   );
 }

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -80,37 +80,52 @@
 
 .slider {
   width: 100%;
-  height: 4px;
-  -webkit-appearance: none;
-  appearance: none;
-  background: var(--surface-bg-active);
-  border-radius: var(--radius-full);
-  outline: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.sliderTrack {
+  position: relative;
+  height: 20px;
+  width: 100%;
+  display: flex;
+  align-items: center;
   cursor: pointer;
 }
 
-.slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
+.sliderTrack::before {
+  content: "";
+  display: block;
+  position: absolute;
+  background: var(--surface-bg-active);
+  height: 4px;
+  width: 100%;
+  border-radius: var(--radius-full);
+  left: 0;
+}
+
+.sliderThumb {
   width: 16px;
   height: 16px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
   background: var(--color-accent);
-  cursor: pointer;
+  cursor: grab;
   transition: background var(--transition-fast);
 }
 
-.slider::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--color-accent);
-  border: none;
-  cursor: pointer;
+.sliderThumb[data-hovered] {
+  background: var(--color-white);
 }
 
-.slider:hover::-webkit-slider-thumb {
+.sliderThumb[data-dragging] {
   background: var(--color-white);
+  cursor: grabbing;
+}
+
+.sliderThumb[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: 2px;
+  box-shadow: var(--focus-ring);
 }
 
 .speedSummary {
@@ -172,9 +187,19 @@
     border-color var(--transition-fast);
 }
 
-.presetBtn:hover {
+.presetBtn:hover,
+.presetBtn[data-hovered] {
   background: var(--surface-bg-hover);
   color: var(--color-text-primary);
+}
+
+.presetBtn[data-pressed] {
+  background: var(--surface-bg-active);
+}
+
+.presetBtn[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: 2px;
 }
 
 .presetBtnActive {
@@ -183,6 +208,7 @@
   color: var(--color-accent);
 }
 
-.presetBtnActive:hover {
+.presetBtnActive:hover,
+.presetBtnActive[data-hovered] {
   background: rgba(51, 153, 255, 0.22);
 }

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -91,34 +91,36 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  padding: 0 6px;
+  box-sizing: border-box;
 }
 
 .sliderTrack::before {
   content: "";
   display: block;
   position: absolute;
-  background: var(--surface-bg-active);
+  background: var(--color-overlay-2);
   height: 4px;
-  width: 100%;
+  width: calc(100% - 12px);
   border-radius: var(--radius-full);
-  left: 0;
+  left: 6px;
 }
 
 .sliderThumb {
-  width: 16px;
-  height: 16px;
+  width: 12px;
+  height: 12px;
   border-radius: var(--radius-full);
-  background: var(--color-accent);
+  background: var(--color-gray-light);
   cursor: grab;
   transition: background var(--transition-fast);
 }
 
 .sliderThumb[data-hovered] {
-  background: var(--color-white);
+  background: var(--color-gray-lightest);
 }
 
 .sliderThumb[data-dragging] {
-  background: var(--color-white);
+  background: var(--color-accent);
   cursor: grabbing;
 }
 

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -1,6 +1,6 @@
 /* ── Clock header (custom, not using PanelHeader) ───── */
 .clockHeader {
-  padding: var(--space-5) var(--space-5) 0;
+  padding: var(--space-4) var(--space-5) 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-1);

--- a/apps/ui/src/Controls/ClockPanel.tsx
+++ b/apps/ui/src/Controls/ClockPanel.tsx
@@ -2,6 +2,7 @@ import type { TimeOfDay } from "@/types";
 import { useClock } from "@/hooks/useClock";
 import { PanelBody } from "./PanelPrimitives";
 import styles from "./ClockPanel.module.css";
+import { Slider, SliderTrack, SliderThumb, Button } from "react-aria-components";
 
 const TIME_OF_DAY_LABELS: Record<TimeOfDay, string> = {
   morning_rush: "Morning Rush",
@@ -51,8 +52,8 @@ export default function ClockPanel() {
   const sliderValue = multiplierToSlider(clock.speedMultiplier);
   const isRealTime = clock.speedMultiplier === 1;
 
-  function handleSliderChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setSpeedMultiplier(sliderToMultiplier(Number(e.target.value)));
+  function handleSliderChange(value: number) {
+    setSpeedMultiplier(sliderToMultiplier(value));
   }
 
   return (
@@ -67,15 +68,18 @@ export default function ClockPanel() {
       <PanelBody className={styles.body}>
         <div className={styles.speedSection}>
           <span className={styles.sectionLabel}>SIMULATION SPEED</span>
-          <input
-            type="range"
+          <Slider
             className={styles.slider}
-            min={0}
-            max={100}
+            minValue={0}
+            maxValue={100}
             value={sliderValue}
             onChange={handleSliderChange}
             aria-label="Speed multiplier"
-          />
+          >
+            <SliderTrack className={styles.sliderTrack}>
+              <SliderThumb className={styles.sliderThumb} aria-label="Speed multiplier" />
+            </SliderTrack>
+          </Slider>
           <div className={styles.speedSummary}>
             <span className={isRealTime ? styles.speedValueNeutral : styles.speedValueAccent}>
               {clock.speedMultiplier}×
@@ -87,14 +91,13 @@ export default function ClockPanel() {
 
         <div className={styles.presets}>
           {SPEED_PRESETS.map(({ label, value }) => (
-            <button
+            <Button
               key={value}
-              type="button"
               className={`${styles.presetBtn} ${clock.speedMultiplier === value ? styles.presetBtnActive : ""}`}
-              onClick={() => setSpeedMultiplier(value)}
+              onPress={() => setSpeedMultiplier(value)}
             >
               {label}
-            </button>
+            </Button>
           ))}
         </div>
       </PanelBody>

--- a/apps/ui/src/Controls/DispatchFooter.module.css
+++ b/apps/ui/src/Controls/DispatchFooter.module.css
@@ -39,12 +39,18 @@
     border-color var(--transition-fast);
 }
 
-.primaryButton:hover:not(:disabled) {
+.primaryButton:hover:not(:disabled),
+.primaryButton[data-hovered]:not([data-disabled]) {
   background: var(--color-accent);
   border-color: rgba(57, 153, 255, 0.8);
 }
 
-.primaryButton:disabled {
+.primaryButton[data-pressed]:not([data-disabled]) {
+  transform: scale(0.98);
+}
+
+.primaryButton:disabled,
+.primaryButton[data-disabled] {
   opacity: 0.4;
   cursor: not-allowed;
 }
@@ -63,12 +69,18 @@
     color var(--transition-fast);
 }
 
-.secondaryButton:hover:not(:disabled) {
+.secondaryButton:hover:not(:disabled),
+.secondaryButton[data-hovered]:not([data-disabled]) {
   background: var(--surface-bg-hover);
   color: var(--color-white);
 }
 
-.secondaryButton:disabled {
+.secondaryButton[data-pressed]:not([data-disabled]) {
+  background: var(--surface-bg-active);
+}
+
+.secondaryButton:disabled,
+.secondaryButton[data-disabled] {
   opacity: 0.4;
   cursor: not-allowed;
 }

--- a/apps/ui/src/Controls/DispatchFooter.module.css
+++ b/apps/ui/src/Controls/DispatchFooter.module.css
@@ -25,7 +25,8 @@
 }
 
 .primaryButton {
-  padding: var(--space-2) var(--space-4);
+  height: var(--control-sm);
+  padding: 0 var(--space-4);
   font-size: var(--text-sm);
   font-weight: 600;
   font-family: inherit;
@@ -56,7 +57,8 @@
 }
 
 .secondaryButton {
-  padding: var(--space-2) var(--space-4);
+  height: var(--control-sm);
+  padding: 0 var(--space-4);
   font-size: var(--text-sm);
   font-family: inherit;
   color: var(--color-gray-light);

--- a/apps/ui/src/Controls/DispatchFooter.tsx
+++ b/apps/ui/src/Controls/DispatchFooter.tsx
@@ -1,3 +1,4 @@
+import { Button } from "react-aria-components";
 import type { DispatchAssignment, DirectionResult } from "@/types";
 import { DispatchState } from "@/hooks/useDispatchState";
 import styles from "./DispatchFooter.module.css";
@@ -36,9 +37,9 @@ export default function DispatchFooter({
             : "Select vehicles to dispatch"}
         </span>
         <div className={styles.buttons}>
-          <button type="button" className={styles.secondaryButton} onClick={onClear}>
+          <Button className={styles.secondaryButton} onPress={onClear}>
             Exit
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -55,17 +56,16 @@ export default function DispatchFooter({
           {stopCount !== 1 ? "s" : ""}
         </span>
         <div className={styles.buttons}>
-          <button type="button" className={styles.secondaryButton} onClick={onClear}>
+          <Button className={styles.secondaryButton} onPress={onClear}>
             Clear
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
             className={styles.primaryButton}
-            onClick={onDispatch}
-            disabled={assignments.length === 0}
+            onPress={onDispatch}
+            isDisabled={assignments.length === 0}
           >
             Dispatch
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -79,12 +79,12 @@ export default function DispatchFooter({
           Dispatching...
         </span>
         <div className={styles.buttons}>
-          <button type="button" className={styles.secondaryButton} disabled>
+          <Button className={styles.secondaryButton} isDisabled>
             Clear
-          </button>
-          <button type="button" className={styles.primaryButton} disabled>
+          </Button>
+          <Button className={styles.primaryButton} isDisabled>
             Dispatch
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -101,13 +101,13 @@ export default function DispatchFooter({
         <span className={styles.text}>{text}</span>
         <div className={styles.buttons}>
           {failures > 0 && (
-            <button type="button" className={styles.secondaryButton} onClick={onRetryFailed}>
+            <Button className={styles.secondaryButton} onPress={onRetryFailed}>
               Retry Failed
-            </button>
+            </Button>
           )}
-          <button type="button" className={styles.primaryButton} onClick={onDone}>
+          <Button className={styles.primaryButton} onPress={onDone}>
             Done
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/apps/ui/src/Controls/Fleets.module.css
+++ b/apps/ui/src/Controls/Fleets.module.css
@@ -85,12 +85,14 @@
   color: var(--color-gray);
 }
 
-.newFleetInput:hover {
+.newFleetInput:hover,
+.newFleetInput[data-hovered] {
   background: var(--surface-bg-hover);
   border-color: rgba(255, 255, 255, 0.14);
 }
 
-.newFleetInput:focus {
+.newFleetInput:focus,
+.newFleetInput[data-focused] {
   border-color: var(--focus-border);
   box-shadow: var(--focus-ring);
   background: var(--focus-bg);

--- a/apps/ui/src/Controls/Fleets.module.css
+++ b/apps/ui/src/Controls/Fleets.module.css
@@ -2,6 +2,11 @@
   gap: var(--space-3);
 }
 
+.controlRow {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .addButton {
   height: var(--control-sm);
   padding: 0 var(--space-4);

--- a/apps/ui/src/Controls/Fleets.tsx
+++ b/apps/ui/src/Controls/Fleets.tsx
@@ -50,7 +50,7 @@ export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsP
         {fleets.length < 10 ? (
           <div className={styles.controlRow}>
             <Button className={styles.addButton} onClick={() => setIsAdding(true)} type="button">
-              + New fleet
+              + New
             </Button>
           </div>
         ) : null}

--- a/apps/ui/src/Controls/Fleets.tsx
+++ b/apps/ui/src/Controls/Fleets.tsx
@@ -44,16 +44,16 @@ export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsP
             : `${fleets.length} fleet ${fleets.length === 1 ? "group" : "groups"} available`
         }
         badge={<PanelBadge>{fleets.length}</PanelBadge>}
-        actions={
-          fleets.length < 10 ? (
-            <Button className={styles.addButton} onClick={() => setIsAdding(true)} type="button">
-              + New
-            </Button>
-          ) : null
-        }
       />
 
       <PanelBody className={styles.body}>
+        {fleets.length < 10 ? (
+          <div className={styles.controlRow}>
+            <Button className={styles.addButton} onClick={() => setIsAdding(true)} type="button">
+              + New fleet
+            </Button>
+          </div>
+        ) : null}
         {fleets.length === 0 && !isAdding ? (
           <PanelEmptyState>No fleets defined</PanelEmptyState>
         ) : null}

--- a/apps/ui/src/Controls/Fleets.tsx
+++ b/apps/ui/src/Controls/Fleets.tsx
@@ -84,12 +84,7 @@ export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsP
         </div>
 
         {isAdding ? (
-          <TextField
-            value={newName}
-            onChange={setNewName}
-            aria-label="New fleet name"
-            autoFocus
-          >
+          <TextField value={newName} onChange={setNewName} aria-label="New fleet name" autoFocus>
             <Input
               className={styles.newFleetInput}
               onKeyDown={handleKeyDown}

--- a/apps/ui/src/Controls/Fleets.tsx
+++ b/apps/ui/src/Controls/Fleets.tsx
@@ -3,6 +3,7 @@ import type { Fleet } from "@/types";
 import { Button, SquaredButton } from "@/components/Inputs";
 import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
 import styles from "./Fleets.module.css";
+import { TextField, Input } from "react-aria-components";
 
 interface FleetsProps {
   fleets: Fleet[];
@@ -83,17 +84,21 @@ export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsP
         </div>
 
         {isAdding ? (
-          <input
-            className={styles.newFleetInput}
+          <TextField
             value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onBlur={() => {
-              if (!newName.trim()) setIsAdding(false);
-            }}
-            placeholder="Fleet name..."
+            onChange={setNewName}
+            aria-label="New fleet name"
             autoFocus
-          />
+          >
+            <Input
+              className={styles.newFleetInput}
+              onKeyDown={handleKeyDown}
+              onBlur={() => {
+                if (!newName.trim()) setIsAdding(false);
+              }}
+              placeholder="Fleet name..."
+            />
+          </TextField>
         ) : null}
       </PanelBody>
     </>

--- a/apps/ui/src/Controls/Incidents.module.css
+++ b/apps/ui/src/Controls/Incidents.module.css
@@ -2,6 +2,12 @@
   gap: var(--space-3);
 }
 
+.controlRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .autoLabel {
   display: inline-flex;
   align-items: center;

--- a/apps/ui/src/Controls/Incidents.tsx
+++ b/apps/ui/src/Controls/Incidents.tsx
@@ -64,28 +64,26 @@ export default function Incidents({ incidents, createRandom, remove }: Incidents
             : `${incidents.length} active disruptions on the network`
         }
         badge={<PanelBadge>{incidents.length}</PanelBadge>}
-        actions={
-          <>
-            <label className={styles.autoLabel}>
-              <Switch
-                isSelected={autoGenerate}
-                onChange={toggleAutoGenerate}
-                aria-label="Auto-generate incidents"
-              />
-              <span className={styles.autoText}>Auto</span>
-            </label>
-            <SquaredButton
-              icon={<span aria-hidden="true">+</span>}
-              variant="surface"
-              aria-label="Create incident"
-              title="Create incident"
-              onClick={createRandom}
-            />
-          </>
-        }
       />
 
       <PanelBody className={styles.body}>
+        <div className={styles.controlRow}>
+          <label className={styles.autoLabel}>
+            <Switch
+              isSelected={autoGenerate}
+              onChange={toggleAutoGenerate}
+              aria-label="Auto-generate incidents"
+            />
+            <span className={styles.autoText}>Auto</span>
+          </label>
+          <SquaredButton
+            icon={<span aria-hidden="true">+</span>}
+            variant="surface"
+            aria-label="Create incident"
+            title="Create incident"
+            onClick={createRandom}
+          />
+        </div>
         {incidents.length === 0 ? <PanelEmptyState>No active incidents</PanelEmptyState> : null}
 
         <div className={styles.list}>

--- a/apps/ui/src/Controls/Incidents.tsx
+++ b/apps/ui/src/Controls/Incidents.tsx
@@ -32,7 +32,7 @@ export default function Incidents({ incidents, createRandom, remove }: Incidents
   const [, setTick] = useState(0);
   const [autoGenerate, setAutoGenerate] = useState(false);
 
-  const toggleAutoGenerate = useCallback(() => setAutoGenerate((prev) => !prev), []);
+  const toggleAutoGenerate = useCallback((selected: boolean) => setAutoGenerate(selected), []);
 
   useEffect(() => {
     if (incidents.length === 0) return;
@@ -68,7 +68,7 @@ export default function Incidents({ incidents, createRandom, remove }: Incidents
           <>
             <label className={styles.autoLabel}>
               <Switch
-                checked={autoGenerate}
+                isSelected={autoGenerate}
                 onChange={toggleAutoGenerate}
                 aria-label="Auto-generate incidents"
               />

--- a/apps/ui/src/Controls/PanelPrimitives.module.css
+++ b/apps/ui/src/Controls/PanelPrimitives.module.css
@@ -10,7 +10,7 @@
 }
 
 .panelHeader {
-  padding: var(--space-5) var(--space-5) var(--space-4);
+  padding: var(--space-4) var(--space-5) var(--space-4);
   border-bottom: var(--panel-border);
   background: var(--panel-header-bg);
   flex-shrink: 0;

--- a/apps/ui/src/Controls/PanelPrimitives.tsx
+++ b/apps/ui/src/Controls/PanelPrimitives.tsx
@@ -15,12 +15,10 @@ export function PanelShell({ children, className, ...props }: PanelShellProps) {
 }
 
 interface PanelHeaderProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
-  children?: ReactNode;
   eyebrow?: ReactNode;
   title: ReactNode;
   subtitle?: ReactNode;
   badge?: ReactNode;
-  actions?: ReactNode;
   titleAs?: "h2" | "h3";
 }
 
@@ -29,8 +27,6 @@ export function PanelHeader({
   title,
   subtitle,
   badge,
-  actions,
-  children,
   titleAs = "h2",
   className,
   ...props
@@ -39,18 +35,12 @@ export function PanelHeader({
 
   return (
     <div {...props} className={classNames(styles.panelHeader, className)}>
-      <div className={styles.headerRow}>
-        <div className={styles.headerCopy}>
-          {eyebrow ? <div className={styles.eyebrow}>{eyebrow}</div> : null}
-          <div className={styles.headingRow}>
-            <TitleTag className={styles.panelTitle}>{title}</TitleTag>
-            {badge ? <div className={styles.headerMeta}>{badge}</div> : null}
-          </div>
-          {subtitle ? <p className={styles.panelSubtitle}>{subtitle}</p> : null}
-        </div>
-        {actions ? <div className={styles.headerActions}>{actions}</div> : null}
+      {eyebrow ? <div className={styles.eyebrow}>{eyebrow}</div> : null}
+      <div className={styles.headingRow}>
+        <TitleTag className={styles.panelTitle}>{title}</TitleTag>
+        {badge ? <div className={styles.headerMeta}>{badge}</div> : null}
       </div>
-      {children ? <div className={styles.headerContent}>{children}</div> : null}
+      {subtitle ? <p className={styles.panelSubtitle}>{subtitle}</p> : null}
     </div>
   );
 }

--- a/apps/ui/src/Controls/RecordReplay.module.css
+++ b/apps/ui/src/Controls/RecordReplay.module.css
@@ -33,9 +33,14 @@
     border-color var(--transition-fast);
 }
 
-.recordButton:hover {
+.recordButton:hover,
+.recordButton[data-hovered] {
   background: var(--surface-bg-hover);
   color: var(--color-white);
+}
+
+.recordButton[data-pressed] {
+  background: var(--surface-bg-active);
 }
 
 .recordButtonActive {
@@ -44,7 +49,8 @@
   color: var(--color-white);
 }
 
-.recordButtonActive:hover {
+.recordButtonActive:hover,
+.recordButtonActive[data-hovered] {
   background: rgba(255, 68, 68, 0.14);
 }
 
@@ -109,9 +115,14 @@
     border-color var(--transition-fast);
 }
 
-.recordingItem:hover {
+.recordingItem:hover,
+.recordingItem[data-hovered] {
   background: var(--surface-bg-hover);
   border-color: rgba(255, 255, 255, 0.14);
+}
+
+.recordingItem[data-pressed] {
+  background: var(--surface-bg-active);
 }
 
 .recordingItemActive {
@@ -120,7 +131,8 @@
   cursor: default;
 }
 
-.recordingItemActive:hover {
+.recordingItemActive:hover,
+.recordingItemActive[data-hovered] {
   background: rgba(57, 153, 255, 0.08);
   border-color: rgba(57, 153, 255, 0.25);
 }

--- a/apps/ui/src/Controls/RecordReplay.module.css
+++ b/apps/ui/src/Controls/RecordReplay.module.css
@@ -19,11 +19,12 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  height: var(--control-sm);
   background: none;
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: var(--color-gray-light);
   font-size: var(--text-sm);
-  padding: var(--space-2) var(--space-3);
+  padding: 0 var(--space-3);
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-family: inherit;

--- a/apps/ui/src/Controls/RecordReplay.tsx
+++ b/apps/ui/src/Controls/RecordReplay.tsx
@@ -10,6 +10,7 @@ import {
   PanelSectionLabel,
 } from "./PanelPrimitives";
 import styles from "./RecordReplay.module.css";
+import { Button } from "react-aria-components";
 
 interface RecordingHook {
   isRecording: boolean;
@@ -128,12 +129,11 @@ export default function RecordReplay({
 
       <PanelBody className={styles.body}>
         <div className={styles.recordRow}>
-          <button
-            type="button"
+          <Button
             className={classNames(styles.recordButton, {
               [styles.recordButtonActive]: isRecording,
             })}
-            onClick={handleRecordToggle}
+            onPress={handleRecordToggle}
             aria-label={isRecording ? "Stop recording" : "Start recording"}
           >
             {isRecording ? (
@@ -149,7 +149,7 @@ export default function RecordReplay({
                 Record
               </>
             )}
-          </button>
+          </Button>
           {isRecording && <span className={styles.elapsed}>{formatTime(elapsed)}</span>}
         </div>
 
@@ -165,19 +165,14 @@ export default function RecordReplay({
               const isActive = isReplayMode && activeFile === file.fileName;
 
               return (
-                <div
+                <Button
                   key={file.fileName}
                   className={classNames(styles.recordingItem, {
                     [styles.recordingItemActive]: isActive,
                   })}
-                  onClick={() => !isActive && handleFileClick(file)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      if (!isActive) handleFileClick(file);
-                    }
-                  }}
+                  onPress={() => !isActive && handleFileClick(file)}
+                  isDisabled={isActive}
+                  aria-label={`Play recording ${formatLabel(file)}`}
                 >
                   <div className={styles.recordingInfo}>
                     <div className={styles.recordingName} title={file.fileName}>
@@ -192,7 +187,7 @@ export default function RecordReplay({
                       )}
                     </div>
                   </div>
-                </div>
+                </Button>
               );
             })}
           </div>

--- a/apps/ui/src/Controls/SpeedPanel.tsx
+++ b/apps/ui/src/Controls/SpeedPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { memo, useEffect } from "react";
 import type { StartOptions } from "@/types";
 import { Range } from "@/components/Inputs";
 import { useOptions } from "@/hooks/useOptions";
@@ -22,7 +22,7 @@ interface SpeedPanelProps {
   maxSpeedRef: React.MutableRefObject<number>;
 }
 
-export default function SpeedPanel({ maxSpeedRef }: SpeedPanelProps) {
+export default memo(function SpeedPanel({ maxSpeedRef }: SpeedPanelProps) {
   const { options, updateOption } = useOptions(300);
 
   useEffect(() => {
@@ -54,4 +54,4 @@ export default function SpeedPanel({ maxSpeedRef }: SpeedPanelProps) {
       </PanelBody>
     </>
   );
-}
+});

--- a/apps/ui/src/Controls/SpeedPanel.tsx
+++ b/apps/ui/src/Controls/SpeedPanel.tsx
@@ -29,8 +29,8 @@ export default function SpeedPanel({ maxSpeedRef }: SpeedPanelProps) {
     maxSpeedRef.current = options.maxSpeed;
   }, [options.maxSpeed, maxSpeedRef]);
 
-  const handleChange = (field: keyof StartOptions) => (e: React.ChangeEvent<HTMLInputElement>) => {
-    updateOption(field, Number(e.target.value) as StartOptions[typeof field]);
+  const handleChange = (field: keyof StartOptions) => (value: number) => {
+    updateOption(field, value as StartOptions[typeof field]);
   };
 
   return (

--- a/apps/ui/src/Controls/TogglesPanel.module.css
+++ b/apps/ui/src/Controls/TogglesPanel.module.css
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-2) var(--space-2);
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background 150ms ease;
@@ -17,6 +17,6 @@
 }
 
 .label {
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   color: var(--color-text-secondary);
 }

--- a/apps/ui/src/Controls/TogglesPanel.tsx
+++ b/apps/ui/src/Controls/TogglesPanel.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { Modifiers } from "@/types";
 import { Switch, Range } from "@/components/Inputs";
-import { eValue } from "@/utils/form";
 import { vehicleStore } from "@/hooks/vehicleStore";
 import { PanelBody, PanelHeader } from "./PanelPrimitives";
 import styles from "./TogglesPanel.module.css";
@@ -41,8 +40,7 @@ export default function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPa
     return initial;
   });
 
-  const handleTrailLengthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = Number(e.target.value);
+  const handleTrailLengthChange = (value: number) => {
     setTrailLength(value);
     vehicleStore.setTrailCapacity(value);
     try {
@@ -63,8 +61,8 @@ export default function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPa
           <label key={key} className={styles.row}>
             <span className={styles.label}>{label}</span>
             <Switch
-              checked={modifiers[key]}
-              onChange={eValue(onChangeModifiers(key))}
+              isSelected={modifiers[key]}
+              onChange={onChangeModifiers(key)}
               aria-label={label}
             />
           </label>

--- a/apps/ui/src/Controls/TogglesPanel.tsx
+++ b/apps/ui/src/Controls/TogglesPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { Modifiers } from "@/types";
 import { Switch, Range } from "@/components/Inputs";
 import { vehicleStore } from "@/hooks/vehicleStore";
@@ -33,7 +33,7 @@ function readStoredTrailLength(): number {
   return 60;
 }
 
-export default function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPanelProps) {
+export default memo(function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPanelProps) {
   const [trailLength, setTrailLength] = useState(() => {
     const initial = readStoredTrailLength();
     vehicleStore.setTrailCapacity(initial);
@@ -82,4 +82,4 @@ export default function TogglesPanel({ modifiers, onChangeModifiers }: TogglesPa
       </PanelBody>
     </>
   );
-}
+});

--- a/apps/ui/src/Controls/Vehicles.module.css
+++ b/apps/ui/src/Controls/Vehicles.module.css
@@ -16,8 +16,8 @@
 .filterInput {
   width: 100%;
   box-sizing: border-box;
-  height: var(--control-lg);
-  padding: 0 44px 0 40px;
+  height: var(--control);
+  padding: 0 40px 0 36px;
   font-size: var(--text-base);
   font-weight: 400;
   color: var(--color-gray-lightest);
@@ -90,14 +90,14 @@
     "name speed"
     "route route"
     "bar bar";
-  row-gap: var(--space-3);
-  column-gap: var(--space-4);
+  row-gap: var(--space-1);
+  column-gap: var(--space-3);
   border: var(--surface-border);
   border-radius: var(--radius-md);
   cursor: pointer;
   flex-shrink: 0;
   width: 100%;
-  padding: var(--space-4) var(--space-4) var(--space-3);
+  padding: var(--space-3) var(--space-3) var(--space-2);
   text-align: left;
   color: inherit;
   background: rgba(255, 255, 255, 0.03);

--- a/apps/ui/src/Controls/Vehicles.module.css
+++ b/apps/ui/src/Controls/Vehicles.module.css
@@ -36,12 +36,14 @@
   color: var(--color-gray);
 }
 
-.filterInput:hover {
+.filterInput:hover,
+.filterInputWrapper[data-hovered] .filterInput {
   border-color: rgba(255, 255, 255, 0.14);
   background: var(--surface-bg-hover);
 }
 
-.filterInput:focus {
+.filterInput:focus,
+.filterInputWrapper[data-focus-within] .filterInput {
   border-color: var(--focus-border);
   background: var(--focus-bg);
   box-shadow: var(--focus-ring);
@@ -69,7 +71,8 @@
     color var(--transition-fast);
 }
 
-.filterClear:hover {
+.filterClear:hover,
+.filterClear[data-hovered] {
   background: var(--surface-bg-active);
   border-color: rgba(255, 255, 255, 0.14);
   color: var(--color-gray-lightest);

--- a/apps/ui/src/Controls/Vehicles.module.css
+++ b/apps/ui/src/Controls/Vehicles.module.css
@@ -272,13 +272,13 @@
 
 /* Vehicle type badge */
 .typeBadge {
-  font-size: 0.65rem;
-  padding: 0.05rem 0.3rem;
-  border-radius: 3px;
-  background: var(--color-surface-2, rgba(255, 255, 255, 0.1));
-  color: var(--color-text-secondary, #999);
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-xs);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  margin-left: 0.3rem;
+  margin-left: var(--space-2);
   font-weight: 500;
 }

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -5,6 +5,7 @@ import { useDirectionContext } from "@/data/useData";
 import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
 import styles from "./Vehicles.module.css";
 import { Search } from "@/components/Icons";
+import { SearchField, Input, Button } from "react-aria-components";
 
 function SpeedBar({ speed, maxSpeed }: { speed: number; maxSpeed: number }) {
   const width = maxSpeed > 0 ? Math.min((speed / maxSpeed) * 100, 100) : 0;
@@ -108,26 +109,21 @@ export default function VehicleList({
         }
         badge={<PanelBadge>{visibleVehicles.length}</PanelBadge>}
       >
-        <div className={styles.filterInputWrapper}>
+        <SearchField
+          value={filter}
+          onChange={onFilterChange}
+          onClear={() => onFilterChange("")}
+          className={styles.filterInputWrapper}
+          aria-label="Search vehicles"
+        >
           <Search className={styles.filterIcon} aria-hidden="true" />
-          <input
-            type="text"
-            value={filter}
-            onChange={(e) => onFilterChange(e.target.value)}
-            placeholder="Search vehicles…"
-            className={styles.filterInput}
-          />
-          {filter ? (
-            <button
-              className={styles.filterClear}
-              onClick={() => onFilterChange("")}
-              aria-label="Clear search"
-              type="button"
-            >
+          <Input placeholder="Search vehicles…" className={styles.filterInput} />
+          {filter && (
+            <Button slot="clear" className={styles.filterClear} aria-label="Clear search">
               ×
-            </button>
-          ) : null}
-        </div>
+            </Button>
+          )}
+        </SearchField>
       </PanelHeader>
 
       <PanelBody

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -108,6 +108,11 @@ export default function VehicleList({
             : `${vehicles.length} tracked units`
         }
         badge={<PanelBadge>{visibleVehicles.length}</PanelBadge>}
+      />
+
+      <PanelBody
+        padded={false}
+        className={classNames(styles.vehicles, { [styles.dimmed]: isDispatch })}
       >
         <SearchField
           value={filter}
@@ -124,12 +129,6 @@ export default function VehicleList({
             </Button>
           )}
         </SearchField>
-      </PanelHeader>
-
-      <PanelBody
-        padded={false}
-        className={classNames(styles.vehicles, { [styles.dimmed]: isDispatch })}
-      >
         {visibleVehicles.length === 0 ? (
           <PanelEmptyState>
             {filter ? `No vehicles match "${filter}"` : "No vehicles"}

--- a/apps/ui/src/Controls/__tests__/TogglesPanel.test.tsx
+++ b/apps/ui/src/Controls/__tests__/TogglesPanel.test.tsx
@@ -56,13 +56,13 @@ describe("TogglesPanel", () => {
     renderPanel(defaultModifiers({ showBreadcrumbs: true } as Partial<Modifiers>));
 
     // When trails are enabled, a trail length slider should be visible
-    expect(screen.getByLabelText(/trail length/i)).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: /trail length/i })).toBeInTheDocument();
   });
 
   it("trail length slider is hidden when showBreadcrumbs is false", () => {
     renderPanel(defaultModifiers({ showBreadcrumbs: false } as Partial<Modifiers>));
 
     // When trails are disabled, no trail length slider should be present
-    expect(screen.queryByLabelText(/trail length/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("slider", { name: /trail length/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/SearchBar/SearchBar.module.css
+++ b/apps/ui/src/SearchBar/SearchBar.module.css
@@ -1,112 +1,260 @@
+/* ── Container ── */
+
 .searchBar {
-  background: var(--glass-bg); /* elevated glass — lighter than map */
-  left: 50%;
-  transform: translateX(-50%);
-  width: min(640px, calc(100% - 56px));
-  height: var(--control-xl);
   position: absolute;
   top: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(640px, calc(100% - 72px));
+  z-index: 50;
   display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  gap: 0;
-  border: var(--glass-border);
+  flex-direction: column;
   border-radius: var(--radius-lg);
-  box-shadow: var(--glass-shadow);
+  border: var(--glass-border);
   backdrop-filter: var(--glass-blur);
   -webkit-backdrop-filter: var(--glass-blur);
-  transition: border-color var(--transition-fast);
+  box-shadow: var(--glass-shadow);
+  transition:
+    border-radius 120ms ease,
+    box-shadow 120ms ease;
 }
 
-.searchBar:focus-within {
-  border-color: var(--focus-border);
+.searchBar.open {
+  border-radius: var(--radius-lg) var(--radius-lg) var(--radius-md) var(--radius-md);
+  box-shadow:
+    var(--glass-shadow),
+    0 0 0 1px rgba(57, 153, 255, 0.1);
 }
 
-.searchBar label {
-  flex: 1;
-  min-width: 0;
+/* ── Input row ── */
+
+.inputRow {
+  height: var(--control-xl);
   display: flex;
   align-items: stretch;
+  background: var(--glass-bg);
+  border-radius: inherit;
+  flex-shrink: 0;
+  overflow: hidden;
 }
 
-/* Override Inputs.module.css .input when used inside the search bar */
-.typeahead,
-.typeahead:hover,
-.typeahead:focus {
-  height: 100%;
+.searchBar.open .inputRow {
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.inputWrap {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.searchIcon {
+  position: absolute;
+  left: var(--space-5);
+  width: 16px;
+  height: 16px;
+  color: var(--color-gray);
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.input {
   width: 100%;
-  padding: 0 var(--space-6);
+  height: 100%;
+  padding: 0 var(--space-7) 0 44px;
   font-size: var(--text-md);
-  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
-  margin-right: 0;
+  font-family: inherit;
   background: transparent;
   border: none;
-  box-shadow: none;
-  backdrop-filter: none;
   color: var(--color-gray-lightest);
-  font-family: inherit;
   outline: none;
+  caret-color: var(--color-accent);
 }
 
-.typeahead::placeholder {
+.input::placeholder {
   color: var(--color-gray);
 }
 
-/* Override Inputs.module.css .squaredButton when used as the destination button */
-.destinationButton,
-.destinationButton:hover,
-.destinationButton:focus {
-  height: 100%;
-  width: 56px;
-  flex: 0 0 56px;
-  color: var(--color-text-primary);
-  align-self: stretch;
-  border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
-  background: rgba(255, 255, 255, 0.02);
+.clearBtn {
+  position: absolute;
+  right: var(--space-4);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.07);
   border: none;
-  border-left: 1px solid var(--color-overlay-1);
-  box-shadow: none;
-  backdrop-filter: none;
+  border-radius: 50%;
+  color: var(--color-gray);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.clearBtn:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--color-gray-lightest);
+}
+
+.clearBtn svg {
+  width: 8px;
+  height: 8px;
+  fill: none;
+}
+
+/* ── Directions button ── */
+
+.directionsBtn {
+  flex: 0 0 56px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.025);
+  border: none;
+  border-left: 1px solid rgba(255, 255, 255, 0.07);
+  color: var(--color-text-secondary);
   cursor: pointer;
   outline: none;
-  transition: background var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 
-.destinationButton:hover,
-.destinationButton[data-hovered] {
-  background: rgba(255, 255, 255, 0.06);
+.directionsBtn:hover,
+.directionsBtn[data-hovered] {
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--color-text-primary);
 }
 
-.destinationButton:active,
-.destinationButton[data-pressed] {
-  background: rgba(57, 153, 255, 0.1);
+.directionsBtn[data-pressed] {
+  background: rgba(57, 153, 255, 0.12);
+  color: var(--color-accent);
 }
 
-.destinationButton:disabled,
-.destinationButton[data-disabled] {
-  opacity: 0.4;
+.directionsBtn[data-disabled] {
+  opacity: 0.3;
   cursor: default;
 }
 
-.destinationButton:disabled:hover,
-.destinationButton[data-disabled][data-hovered] {
-  background: rgba(255, 255, 255, 0.02);
+.directionsBtn[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: -2px;
 }
 
-.destinationButton svg {
-  width: 20px;
-  height: 20px;
+.directionsBtn svg {
+  width: 18px;
+  height: 18px;
 }
 
-.option {
+/* ── Results dropdown ── */
+
+.results {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2);
+  background: rgba(16, 20, 32, 0.94);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  overflow-y: auto;
+  max-height: 380px;
+}
+
+.results::-webkit-scrollbar {
+  width: 4px;
+}
+
+.results::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.results::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+}
+
+/* ── Result item ── */
+
+.result {
   display: flex;
   align-items: center;
   gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--transition-fast);
+  min-height: 36px;
 }
 
-.option svg {
-  fill: var(--color-gray-light);
-  height: 14px;
+.result:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.resultActive {
+  background: rgba(57, 153, 255, 0.1) !important;
+}
+
+.resultIcon {
   width: 14px;
+  height: 14px;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-gray);
+  transition: color var(--transition-fast);
+}
+
+.resultIcon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+.resultActive .resultIcon {
+  color: var(--color-accent);
+}
+
+.resultName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-base);
+  color: var(--color-gray-lighter);
+  line-height: 1.3;
+}
+
+.resultActive .resultName {
+  color: var(--color-white);
+}
+
+/* Fuzzy match highlights */
+.hl {
+  background: none;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.resultBadge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--color-gray);
+  opacity: 0.7;
+}
+
+.resultActive .resultBadge {
+  opacity: 1;
+  color: rgba(57, 153, 255, 0.7);
 }

--- a/apps/ui/src/SearchBar/SearchBar.module.css
+++ b/apps/ui/src/SearchBar/SearchBar.module.css
@@ -1,5 +1,5 @@
 .searchBar {
-  background: var(--glass-bg);
+  background: var(--glass-bg); /* elevated glass — lighter than map */
   left: 50%;
   transform: translateX(-50%);
   width: min(640px, calc(100% - 56px));
@@ -10,11 +10,11 @@
   flex-direction: row;
   align-items: stretch;
   gap: 0;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: var(--glass-border);
   border-radius: var(--radius-lg);
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
   transition: border-color var(--transition-fast);
 }
 

--- a/apps/ui/src/SearchBar/SearchBar.module.css
+++ b/apps/ui/src/SearchBar/SearchBar.module.css
@@ -72,20 +72,24 @@
   transition: background var(--transition-fast);
 }
 
-.destinationButton:hover {
+.destinationButton:hover,
+.destinationButton[data-hovered] {
   background: rgba(255, 255, 255, 0.06);
 }
 
-.destinationButton:active {
+.destinationButton:active,
+.destinationButton[data-pressed] {
   background: rgba(57, 153, 255, 0.1);
 }
 
-.destinationButton:disabled {
+.destinationButton:disabled,
+.destinationButton[data-disabled] {
   opacity: 0.4;
   cursor: default;
 }
 
-.destinationButton:disabled:hover {
+.destinationButton:disabled:hover,
+.destinationButton[data-disabled][data-hovered] {
   background: rgba(255, 255, 255, 0.02);
 }
 

--- a/apps/ui/src/SearchBar/index.tsx
+++ b/apps/ui/src/SearchBar/index.tsx
@@ -22,7 +22,8 @@ function score(name: string, q: string): Match | null {
   if (!query) return null;
 
   // Exact
-  if (n === query) return { score: 1000, positions: Array.from({ length: query.length }, (_, i) => i) };
+  if (n === query)
+    return { score: 1000, positions: Array.from({ length: query.length }, (_, i) => i) };
 
   // Starts with
   if (n.startsWith(query)) {
@@ -30,7 +31,9 @@ function score(name: string, q: string): Match | null {
   }
 
   // Word boundary start
-  const wordMatch = n.match(new RegExp(`(^|\\s|-)(?=${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`));
+  const wordMatch = n.match(
+    new RegExp(`(^|\\s|-)(?=${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`)
+  );
   if (wordMatch !== null && wordMatch.index !== undefined) {
     const start = wordMatch.index + wordMatch[1].length;
     return {
@@ -60,7 +63,10 @@ function score(name: string, q: string): Match | null {
   if (qi === query.length) {
     const spread = pos[pos.length - 1] - pos[0] + 1;
     const coverage = query.length / spread;
-    const consecutiveBonus = pos.reduce((acc, p, i) => acc + (i > 0 && p === pos[i - 1] + 1 ? 10 : 0), 0);
+    const consecutiveBonus = pos.reduce(
+      (acc, p, i) => acc + (i > 0 && p === pos[i - 1] + 1 ? 10 : 0),
+      0
+    );
     return { score: 200 * coverage + consecutiveBonus - pos[0], positions: pos };
   }
 
@@ -137,7 +143,11 @@ interface SearchBarProps {
   onItemUnselect: () => void;
 }
 
-export default function SearchBar({ selectedItem, onDestinationClick, onItemSelect }: SearchBarProps) {
+export default function SearchBar({
+  selectedItem,
+  onDestinationClick,
+  onItemSelect,
+}: SearchBarProps) {
   const { roads } = useRoads();
   const { pois } = usePois();
 
@@ -242,7 +252,12 @@ export default function SearchBar({ selectedItem, onDestinationClick, onItemSele
               aria-label="Clear"
             >
               <svg viewBox="0 0 12 12" fill="currentColor">
-                <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                <path
+                  d="M2 2l8 8M10 2l-8 8"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
               </svg>
             </button>
           )}
@@ -260,7 +275,12 @@ export default function SearchBar({ selectedItem, onDestinationClick, onItemSele
 
       {/* ── Results ── */}
       {showResults && (
-        <ul id="search-results" className={styles.results} role="listbox" aria-label="Search results">
+        <ul
+          id="search-results"
+          className={styles.results}
+          role="listbox"
+          aria-label="Search results"
+        >
           {results.map((r, i) => {
             const road = isRoad(r.item);
             return (

--- a/apps/ui/src/SearchBar/index.tsx
+++ b/apps/ui/src/SearchBar/index.tsx
@@ -6,6 +6,7 @@ import { Typeahead } from "@/components/Inputs";
 import styles from "./SearchBar.module.css";
 import { isRoad } from "@/utils/typeGuards";
 import { useCallback } from "react";
+import { Button } from "react-aria-components";
 
 function Option({ item }: { item: Road | POI }) {
   const icon = isRoad(item) ? <RoadIcon /> : <POIIcon />;
@@ -48,15 +49,14 @@ export default function SearchBar({
         placeholder="Search..."
       />
 
-      <button
-        type="button"
-        onClick={onDestinationClick}
-        disabled={!selectedItem}
+      <Button
+        onPress={onDestinationClick}
+        isDisabled={!selectedItem}
         className={styles.destinationButton}
         aria-label="Get directions"
       >
         <Directions />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/ui/src/SearchBar/index.tsx
+++ b/apps/ui/src/SearchBar/index.tsx
@@ -1,22 +1,134 @@
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import type { POI, Road } from "@/types";
 import { Directions, POI as POIIcon, Road as RoadIcon } from "@/components/Icons";
 import { useRoads } from "@/hooks/useRoads";
 import { usePois } from "@/hooks/usePois";
-import { Typeahead } from "@/components/Inputs";
-import styles from "./SearchBar.module.css";
 import { isRoad } from "@/utils/typeGuards";
-import { useCallback } from "react";
 import { Button } from "react-aria-components";
+import styles from "./SearchBar.module.css";
 
-function Option({ item }: { item: Road | POI }) {
-  const icon = isRoad(item) ? <RoadIcon /> : <POIIcon />;
+const MAX_RESULTS = 12;
+
+// ── Fuzzy search ──────────────────────────────────────────────────────────────
+
+interface Match {
+  score: number;
+  positions: number[];
+}
+
+function score(name: string, q: string): Match | null {
+  const n = name.toLowerCase();
+  const query = q.toLowerCase().trim();
+  if (!query) return null;
+
+  // Exact
+  if (n === query) return { score: 1000, positions: Array.from({ length: query.length }, (_, i) => i) };
+
+  // Starts with
+  if (n.startsWith(query)) {
+    return { score: 800, positions: Array.from({ length: query.length }, (_, i) => i) };
+  }
+
+  // Word boundary start
+  const wordMatch = n.match(new RegExp(`(^|\\s|-)(?=${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`));
+  if (wordMatch !== null && wordMatch.index !== undefined) {
+    const start = wordMatch.index + wordMatch[1].length;
+    return {
+      score: 700 - start,
+      positions: Array.from({ length: query.length }, (_, i) => start + i),
+    };
+  }
+
+  // Contains
+  const idx = n.indexOf(query);
+  if (idx !== -1) {
+    return {
+      score: 500 - idx,
+      positions: Array.from({ length: query.length }, (_, i) => idx + i),
+    };
+  }
+
+  // Fuzzy (chars in order)
+  const pos: number[] = [];
+  let qi = 0;
+  for (let i = 0; i < n.length && qi < query.length; i++) {
+    if (n[i] === query[qi]) {
+      pos.push(i);
+      qi++;
+    }
+  }
+  if (qi === query.length) {
+    const spread = pos[pos.length - 1] - pos[0] + 1;
+    const coverage = query.length / spread;
+    const consecutiveBonus = pos.reduce((acc, p, i) => acc + (i > 0 && p === pos[i - 1] + 1 ? 10 : 0), 0);
+    return { score: 200 * coverage + consecutiveBonus - pos[0], positions: pos };
+  }
+
+  return null;
+}
+
+interface Result {
+  item: Road | POI;
+  score: number;
+  positions: number[];
+}
+
+function fuzzySearch(roads: Road[], pois: POI[], query: string): Result[] {
+  if (!query.trim()) return [];
+  const results: Result[] = [];
+
+  for (const r of roads) {
+    if (!r.name) continue;
+    const m = score(r.name, query);
+    if (m) results.push({ item: r, score: m.score, positions: m.positions });
+  }
+  for (const p of pois) {
+    if (!p.name) continue;
+    const m = score(p.name, query);
+    if (m) results.push({ item: p, score: m.score, positions: m.positions });
+  }
+
+  return results.sort((a, b) => b.score - a.score).slice(0, MAX_RESULTS);
+}
+
+// ── Highlight ─────────────────────────────────────────────────────────────────
+
+function Highlight({ text, positions }: { text: string; positions: number[] }) {
+  if (!positions.length) return <>{text}</>;
+
+  const set = new Set(positions);
+  const parts: { t: string; hl: boolean }[] = [];
+  let cur = "";
+  let curHl = set.has(0);
+
+  for (let i = 0; i < text.length; i++) {
+    const hl = set.has(i);
+    if (hl !== curHl) {
+      if (cur) parts.push({ t: cur, hl: curHl });
+      cur = text[i];
+      curHl = hl;
+    } else {
+      cur += text[i];
+    }
+  }
+  if (cur) parts.push({ t: cur, hl: curHl });
+
   return (
-    <div className={styles.option}>
-      {icon}
-      <span>{item.name}</span>
-    </div>
+    <>
+      {parts.map((p, i) =>
+        p.hl ? (
+          <mark key={i} className={styles.hl}>
+            {p.t}
+          </mark>
+        ) : (
+          <span key={i}>{p.t}</span>
+        )
+      )}
+    </>
   );
 }
+
+// ── SearchBar ─────────────────────────────────────────────────────────────────
 
 interface SearchBarProps {
   selectedItem: Road | POI | null;
@@ -25,38 +137,155 @@ interface SearchBarProps {
   onItemUnselect: () => void;
 }
 
-export default function SearchBar({
-  selectedItem,
-  onDestinationClick,
-  onItemSelect,
-}: SearchBarProps) {
+export default function SearchBar({ selectedItem, onDestinationClick, onItemSelect }: SearchBarProps) {
   const { roads } = useRoads();
   const { pois } = usePois();
-  const renderLabel = useCallback((item: Road | POI) => item.name || "not sure", []);
-  const renderOption = (item: Road | POI) => <Option item={item} />;
+
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const results = useMemo(() => fuzzySearch(roads, pois, query), [roads, pois, query]);
+  const showResults = open && results.length > 0;
+
+  useEffect(() => setActiveIdx(0), [results]);
+
+  const commit = useCallback(
+    (item: Road | POI) => {
+      onItemSelect(item);
+      setQuery(item.name ?? "");
+      setOpen(false);
+      inputRef.current?.blur();
+    },
+    [onItemSelect]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        if (!query) inputRef.current?.blur();
+        return;
+      }
+      if (!showResults) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIdx((i) => (i + 1) % results.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIdx((i) => (i - 1 + results.length) % results.length);
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const r = results[activeIdx];
+        if (r) commit(r.item);
+      }
+    },
+    [showResults, results, activeIdx, commit, query]
+  );
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
 
   return (
-    <div className={styles.searchBar}>
-      <Typeahead
-        className={styles.typeahead}
-        options={[...roads, ...pois]}
-        value={selectedItem}
-        onChange={onItemSelect}
-        // onOptionHover={onItemSelect}
-        // onOptionLeave={onItemUnselect}
-        renderLabel={renderLabel}
-        renderOption={renderOption}
-        placeholder="Search..."
-      />
+    <div
+      ref={containerRef}
+      className={`${styles.searchBar} ${showResults ? styles.open : ""}`}
+      role="combobox"
+      aria-expanded={showResults}
+      aria-haspopup="listbox"
+    >
+      {/* ── Input row ── */}
+      <div className={styles.inputRow}>
+        <div className={styles.inputWrap}>
+          <svg className={styles.searchIcon} viewBox="0 0 16 16" fill="none">
+            <circle cx="6.5" cy="6.5" r="4.5" stroke="currentColor" strokeWidth="1.5" />
+            <path d="M10 10L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <input
+            ref={inputRef}
+            className={styles.input}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOpen(true);
+            }}
+            onFocus={() => {
+              if (query) setOpen(true);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Search roads and places…"
+            aria-label="Search"
+            aria-autocomplete="list"
+            aria-controls="search-results"
+            aria-activedescendant={showResults ? `result-${activeIdx}` : undefined}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {query && (
+            <button
+              className={styles.clearBtn}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                setQuery("");
+                setOpen(false);
+                inputRef.current?.focus();
+              }}
+              tabIndex={-1}
+              aria-label="Clear"
+            >
+              <svg viewBox="0 0 12 12" fill="currentColor">
+                <path d="M2 2l8 8M10 2l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          )}
+        </div>
 
-      <Button
-        onPress={onDestinationClick}
-        isDisabled={!selectedItem}
-        className={styles.destinationButton}
-        aria-label="Get directions"
-      >
-        <Directions />
-      </Button>
+        <Button
+          onPress={onDestinationClick}
+          isDisabled={!selectedItem}
+          className={styles.directionsBtn}
+          aria-label="Get directions"
+        >
+          <Directions />
+        </Button>
+      </div>
+
+      {/* ── Results ── */}
+      {showResults && (
+        <ul id="search-results" className={styles.results} role="listbox" aria-label="Search results">
+          {results.map((r, i) => {
+            const road = isRoad(r.item);
+            return (
+              <li
+                key={`${r.item.name}-${i}`}
+                id={`result-${i}`}
+                className={`${styles.result} ${i === activeIdx ? styles.resultActive : ""}`}
+                role="option"
+                aria-selected={i === activeIdx}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  commit(r.item);
+                }}
+                onMouseEnter={() => setActiveIdx(i)}
+              >
+                <span className={styles.resultIcon}>{road ? <RoadIcon /> : <POIIcon />}</span>
+                <span className={styles.resultName}>
+                  <Highlight text={r.item.name ?? ""} positions={r.positions} />
+                </span>
+                <span className={styles.resultBadge}>{road ? "road" : "place"}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/components/ContextMenu.module.css
+++ b/apps/ui/src/components/ContextMenu.module.css
@@ -1,0 +1,16 @@
+.menu {
+  background: rgba(12, 14, 18, 0.72);
+  backdrop-filter: blur(24px) saturate(140%);
+  -webkit-backdrop-filter: blur(24px) saturate(140%);
+  padding: var(--space-2);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow:
+    0 20px 44px rgba(0, 0, 0, 0.35),
+    0 1px 0 rgba(255, 255, 255, 0.06) inset;
+  outline: none;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}

--- a/apps/ui/src/components/ContextMenu.tsx
+++ b/apps/ui/src/components/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { FocusScope } from "@react-aria/focus";
 import styles from "./ContextMenu.module.css";
 
 export default function ContextMenu({
@@ -13,72 +14,6 @@ export default function ContextMenu({
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Focus first item on open
-  useEffect(() => {
-    const menu = menuRef.current;
-    if (!menu) return;
-    const first = menu.querySelector<HTMLElement>(
-      '[role="menuitem"]:not([disabled]), button:not([disabled])'
-    );
-    first?.focus();
-  }, []);
-
-  // Keyboard handling: Escape closes, Arrow keys navigate
-  useEffect(() => {
-    const menu = menuRef.current;
-    if (!menu) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose?.();
-        return;
-      }
-
-      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        e.preventDefault();
-        const items = Array.from(
-          menu.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])')
-        );
-        if (items.length === 0) return;
-        const current = document.activeElement as HTMLElement;
-        const idx = items.indexOf(current);
-        if (e.key === "ArrowDown") {
-          items[(idx + 1) % items.length]?.focus();
-        } else {
-          items[(idx - 1 + items.length) % items.length]?.focus();
-        }
-        return;
-      }
-
-      // Tab cycles through items
-      if (e.key === "Tab") {
-        const items = Array.from(
-          menu.querySelectorAll<HTMLElement>(
-            'button, [href], input, [tabindex]:not([tabindex="-1"])'
-          )
-        );
-        if (items.length === 0) return;
-        const first = items[0];
-        const last = items[items.length - 1];
-        if (e.shiftKey) {
-          if (document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          }
-        } else {
-          if (document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [onClose]);
-
   // Close on outside click
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -90,23 +25,32 @@ export default function ContextMenu({
     return () => document.removeEventListener("mousedown", handleClick);
   }, [onClose]);
 
+  // Close on Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose?.();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
   if (!position) return null;
 
   return createPortal(
-    <div
-      ref={menuRef}
-      role="menu"
-      aria-label="Context menu"
-      className={styles.menu}
-      style={{
-        position: "fixed",
-        top: position.y,
-        left: position.x,
-        zIndex: 1000,
-      }}
-    >
-      {children}
-    </div>,
+    <FocusScope autoFocus contain restoreFocus>
+      <div
+        ref={menuRef}
+        role="menu"
+        aria-label="Context menu"
+        className={styles.menu}
+        style={{ position: "fixed", top: position.y, left: position.x, zIndex: 1000 }}
+      >
+        {children}
+      </div>
+    </FocusScope>,
     document.body
   );
 }

--- a/apps/ui/src/components/ContextMenu.tsx
+++ b/apps/ui/src/components/ContextMenu.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import styles from "./ContextMenu.module.css";
 
 export default function ContextMenu({
   position,
@@ -12,26 +13,54 @@ export default function ContextMenu({
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
+  // Focus first item on open
+  useEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+    const first = menu.querySelector<HTMLElement>(
+      '[role="menuitem"]:not([disabled]), button:not([disabled])'
+    );
+    first?.focus();
+  }, []);
+
+  // Keyboard handling: Escape closes, Arrow keys navigate
+  useEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
         onClose?.();
         return;
       }
 
-      if (e.key === "Tab") {
-        const menu = menuRef.current;
-        if (!menu) return;
-
-        const focusable = menu.querySelectorAll<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const items = Array.from(
+          menu.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])')
         );
-        if (focusable.length === 0) return;
+        if (items.length === 0) return;
+        const current = document.activeElement as HTMLElement;
+        const idx = items.indexOf(current);
+        if (e.key === "ArrowDown") {
+          items[(idx + 1) % items.length]?.focus();
+        } else {
+          items[(idx - 1 + items.length) % items.length]?.focus();
+        }
+        return;
+      }
 
-        const first = focusable[0];
-        const last = focusable[focusable.length - 1];
-
+      // Tab cycles through items
+      if (e.key === "Tab") {
+        const items = Array.from(
+          menu.querySelectorAll<HTMLElement>(
+            'button, [href], input, [tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (items.length === 0) return;
+        const first = items[0];
+        const last = items[items.length - 1];
         if (e.shiftKey) {
           if (document.activeElement === first) {
             e.preventDefault();
@@ -44,34 +73,31 @@ export default function ContextMenu({
           }
         }
       }
-    },
-    [onClose]
-  );
-
-  // Focus the first focusable element when the menu opens
-  useEffect(() => {
-    const menu = menuRef.current;
-    if (!menu) return;
-
-    const focusable = menu.querySelectorAll<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    if (focusable.length > 0) {
-      focusable[0].focus();
-    }
+    };
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose?.();
+      }
     };
-  }, [handleKeyDown]);
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onClose]);
 
   if (!position) return null;
-  const portal = createPortal(
+
+  return createPortal(
     <div
       ref={menuRef}
       role="menu"
       aria-label="Context menu"
+      className={styles.menu}
       style={{
         position: "fixed",
         top: position.y,
@@ -83,6 +109,4 @@ export default function ContextMenu({
     </div>,
     document.body
   );
-
-  return portal;
 }

--- a/apps/ui/src/components/Inputs/Button.tsx
+++ b/apps/ui/src/components/Inputs/Button.tsx
@@ -1,7 +1,34 @@
-import React from "react";
+import { useRef, useEffect } from "react";
+import { Button as AriaButton, type ButtonProps } from "react-aria-components";
 import classNames from "classnames";
 import styles from "./Inputs.module.css";
 
-export function Button({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return <button className={classNames(styles.button, className)} {...props} />;
+// Omit React Aria's onClick/isDisabled to replace with standard React/HTML attrs
+type ExtendedButtonProps = Omit<ButtonProps, "onClick" | "isDisabled"> & {
+  /** ARIA role — applied via ref since React Aria filters out role from DOM props */
+  role?: React.AriaRole;
+  onClick?: React.MouseEventHandler<Element>;
+  /** Standard HTML disabled attribute — mapped to React Aria's isDisabled */
+  disabled?: boolean;
+  isDisabled?: boolean;
+};
+
+export function Button({ className, disabled, isDisabled, role, ...props }: ExtendedButtonProps) {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  // React Aria's filterDOMProps strips 'role', so apply it manually via ref
+  useEffect(() => {
+    if (ref.current && role) {
+      ref.current.setAttribute("role", role);
+    }
+  }, [role]);
+
+  return (
+    <AriaButton
+      ref={ref}
+      className={classNames(styles.button, className)}
+      isDisabled={isDisabled ?? disabled}
+      {...(props as ButtonProps)}
+    />
+  );
 }

--- a/apps/ui/src/components/Inputs/Input.tsx
+++ b/apps/ui/src/components/Inputs/Input.tsx
@@ -10,12 +10,7 @@ interface InputProps extends Omit<TextFieldProps, "onChange"> {
 
 export function Input({ label, value, onChange, type = "number", ...props }: InputProps) {
   return (
-    <TextField
-      className={styles.label}
-      value={String(value ?? "")}
-      onChange={onChange}
-      {...props}
-    >
+    <TextField className={styles.label} value={String(value ?? "")} onChange={onChange} {...props}>
       {label && <Label>{label}</Label>}
       <AriaInput type={type} className={styles.input} />
     </TextField>

--- a/apps/ui/src/components/Inputs/Input.tsx
+++ b/apps/ui/src/components/Inputs/Input.tsx
@@ -1,15 +1,23 @@
-import React from "react";
+import { TextField, Label, Input as AriaInput, type TextFieldProps } from "react-aria-components";
 import styles from "./Inputs.module.css";
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends Omit<TextFieldProps, "onChange"> {
   label?: string;
+  onChange?: (value: string) => void;
+  /** Input type — defaults to "number". Pass "text" to render as textbox. */
+  type?: React.HTMLInputTypeAttribute;
 }
 
-export function Input({ label, value, onChange, ...props }: InputProps) {
+export function Input({ label, value, onChange, type = "number", ...props }: InputProps) {
   return (
-    <label className={styles.label}>
-      {label}
-      <input type="number" value={value} onChange={onChange} className={styles.input} {...props} />
-    </label>
+    <TextField
+      className={styles.label}
+      value={String(value ?? "")}
+      onChange={onChange}
+      {...props}
+    >
+      {label && <Label>{label}</Label>}
+      <AriaInput type={type} className={styles.input} />
+    </TextField>
   );
 }

--- a/apps/ui/src/components/Inputs/Inputs.module.css
+++ b/apps/ui/src/components/Inputs/Inputs.module.css
@@ -370,7 +370,11 @@
 
 .option[data-focused] {
   background: var(--color-active-bg);
-  outline: none;
+}
+
+.option[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: -2px;
 }
 
 .option[data-selected] {

--- a/apps/ui/src/components/Inputs/Inputs.module.css
+++ b/apps/ui/src/components/Inputs/Inputs.module.css
@@ -322,3 +322,48 @@
 .option:hover {
   background: var(--color-active-bg);
 }
+
+/* ComboBox (Typeahead) — React Aria */
+.comboBoxRoot {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.comboLabel {
+  font-size: var(--text-base);
+  color: var(--color-gray-lighter);
+  margin-bottom: var(--space-1);
+}
+
+.listBox {
+  list-style: none;
+  padding: var(--space-2);
+  margin: 0;
+  max-height: 400px;
+  overflow-y: auto;
+  outline: none;
+}
+
+.listBox::-webkit-scrollbar {
+  width: 5px;
+}
+
+.listBox::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.listBox::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+.option[data-focused] {
+  background: var(--color-active-bg);
+  outline: none;
+}
+
+.option[data-selected] {
+  background: var(--color-active-bg);
+  color: var(--color-white);
+}

--- a/apps/ui/src/components/Inputs/Inputs.module.css
+++ b/apps/ui/src/components/Inputs/Inputs.module.css
@@ -15,15 +15,22 @@
     border-color var(--transition-fast);
 }
 
-.button:hover {
+.button:hover,
+.button[data-hovered] {
   background: var(--surface-bg-hover);
   border-color: rgba(255, 255, 255, 0.14);
 }
 
-.button:focus-visible {
+.button:focus-visible,
+.button[data-focus-visible] {
   outline: none;
   border-color: var(--focus-border);
   box-shadow: var(--focus-ring);
+}
+
+.button[data-pressed] {
+  background: var(--surface-bg-active);
+  transform: scale(0.98);
 }
 
 .squaredButton {
@@ -79,16 +86,22 @@
   color: var(--color-gray-light);
 }
 
-.squaredButton:hover {
+.squaredButton:hover,
+.squaredButton[data-hovered] {
   background: var(--surface-bg-hover);
   border-color: rgba(255, 255, 255, 0.14);
   color: var(--color-white);
 }
 
-.squaredButton:focus-visible {
+.squaredButton:focus-visible,
+.squaredButton[data-focus-visible] {
   outline: none;
   border-color: var(--focus-border);
   box-shadow: var(--focus-ring);
+}
+
+.squaredButton[data-pressed] {
+  transform: scale(0.95);
 }
 
 .squaredButtonActive.squaredButtonToneActive {
@@ -115,7 +128,8 @@
   color: var(--color-danger);
 }
 
-.squaredButton:disabled {
+.squaredButton:disabled,
+.squaredButton[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/apps/ui/src/components/Inputs/Inputs.module.css
+++ b/apps/ui/src/components/Inputs/Inputs.module.css
@@ -198,55 +198,61 @@
   box-shadow: var(--focus-ring);
 }
 
-/* Range slider */
-.range {
-  -webkit-appearance: none;
-  appearance: none;
+/* Range slider — React Aria */
+.rangeRoot {
+  display: flex;
+  flex-direction: column;
   width: 100%;
+}
+
+.rangeTrack {
+  position: relative;
   height: 20px;
-  padding: 0;
-  background: transparent;
+  width: 100%;
+  display: flex;
+  align-items: center;
   cursor: pointer;
 }
 
-.range::-webkit-slider-runnable-track {
-  height: 4px;
+.rangeTrack::before {
+  content: "";
+  display: block;
+  position: absolute;
   background: var(--color-overlay-2);
+  height: 4px;
+  width: 100%;
   border-radius: 2px;
+  left: 0;
 }
 
-.range::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
+.rangeThumb {
   width: 12px;
   height: 12px;
   border-radius: var(--radius-full);
   background: var(--color-gray-light);
-  margin-top: -4px;
-  cursor: pointer;
+  cursor: grab;
+  transition: background var(--transition-fast);
 }
 
-.range::-webkit-slider-thumb:hover {
+.rangeThumb[data-hovered] {
   background: var(--color-gray-lightest);
 }
 
-.range::-webkit-slider-thumb:active {
+.rangeThumb[data-dragging] {
   background: var(--color-accent);
+  cursor: grabbing;
 }
 
-.range:focus {
-  outline: none;
-}
-
-.range:focus::-webkit-slider-thumb {
+.rangeThumb[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: 2px;
   box-shadow: var(--focus-ring);
 }
 
-/* Switch toggle */
+/* Switch — React Aria renders: label[data-selected] > hidden input + .switchIndicator */
 .switch {
-  appearance: none;
-  -webkit-appearance: none;
-  position: relative;
+  display: inline-flex;
+  align-items: center;
   width: 28px;
   height: 16px;
   background-color: var(--color-overlay-2);
@@ -254,30 +260,34 @@
   cursor: pointer;
   transition: background-color var(--transition-fast);
   flex-shrink: 0;
+  position: relative;
 }
 
-.switch:disabled {
+.switch[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.switch::before {
-  content: "";
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  border-radius: var(--radius-full);
-  top: 2px;
-  left: 2px;
-  background-color: var(--color-gray-lighter);
-  transition: transform var(--transition-fast);
-}
-
-.switch:checked {
+.switch[data-selected] {
   background-color: var(--color-accent-dark);
 }
 
-.switch:checked::before {
+.switch[data-focus-visible] {
+  outline: 2px solid var(--focus-border);
+  outline-offset: 2px;
+}
+
+.switchIndicator {
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-gray-lighter);
+  margin-left: 2px;
+  transition: transform var(--transition-fast);
+  pointer-events: none;
+}
+
+.switch[data-selected] .switchIndicator {
   transform: translateX(12px);
 }
 

--- a/apps/ui/src/components/Inputs/Inputs.module.css
+++ b/apps/ui/src/components/Inputs/Inputs.module.css
@@ -155,8 +155,8 @@
 .label {
   display: flex;
   flex-direction: column;
-  font-size: var(--text-base);
-  color: var(--color-gray-lighter);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
 }
 
 .label span {
@@ -167,10 +167,14 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  margin-bottom: var(--space-1);
 }
 
 .rangeValue {
   font-variant-numeric: tabular-nums;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-gray-lightest);
   min-width: 2.5ch;
   text-align: right;
 }

--- a/apps/ui/src/components/Inputs/Inputs.test.tsx
+++ b/apps/ui/src/components/Inputs/Inputs.test.tsx
@@ -66,46 +66,60 @@ describe("Input", () => {
 });
 
 describe("Switch", () => {
-  it("renders as checkbox", () => {
-    render(<Switch checked={false} onChange={() => {}} />);
-    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  it("renders as switch role", () => {
+    render(<Switch isSelected={false} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
   });
 
-  it("reflects checked state", () => {
-    render(<Switch checked={true} onChange={() => {}} />);
-    expect(screen.getByRole("checkbox")).toBeChecked();
+  it("reflects selected state", () => {
+    render(<Switch isSelected={true} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).toBeChecked();
   });
 
-  it("reflects unchecked state", () => {
-    render(<Switch checked={false} onChange={() => {}} />);
-    expect(screen.getByRole("checkbox")).not.toBeChecked();
+  it("reflects unselected state", () => {
+    render(<Switch isSelected={false} onChange={() => {}} />);
+    expect(screen.getByRole("switch")).not.toBeChecked();
   });
 
-  it("calls onChange when clicked", async () => {
+  it("calls onChange with boolean when clicked", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(<Switch checked={false} onChange={onChange} />);
-    await user.click(screen.getByRole("checkbox"));
-    expect(onChange).toHaveBeenCalledOnce();
+    render(<Switch isSelected={false} onChange={onChange} />);
+    await user.click(screen.getByRole("switch"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not call onChange when disabled", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Switch isSelected={false} onChange={onChange} isDisabled />);
+    await user.click(screen.getByRole("switch"));
+    expect(onChange).not.toHaveBeenCalled();
   });
 });
 
 describe("Range", () => {
-  it("renders range input with label", () => {
+  it("renders slider with label", () => {
     render(<Range label="Accel:" value={5} min={1} max={10} onChange={() => {}} />);
     expect(screen.getByText("Accel:")).toBeInTheDocument();
     expect(screen.getByRole("slider")).toBeInTheDocument();
   });
 
-  it("displays the current value", () => {
+  it("has correct aria-valuenow", () => {
     render(<Range label="Speed:" value={7} min={0} max={10} onChange={() => {}} />);
-    expect(screen.getByRole("slider")).toHaveValue("7");
+    expect(screen.getByRole("slider")).toHaveAttribute("value", "7");
   });
 
-  it("respects min and max attributes", () => {
+  it("has correct aria-valuemin and aria-valuemax", () => {
     render(<Range label="Speed:" value={5} min={1} max={10} onChange={() => {}} />);
     const slider = screen.getByRole("slider");
     expect(slider).toHaveAttribute("min", "1");
     expect(slider).toHaveAttribute("max", "10");
+  });
+
+  it("shows the current value as text", () => {
+    render(<Range label="Speed:" value={7} min={0} max={10} onChange={() => {}} />);
+    // The range value is displayed as text next to the label
+    expect(screen.getByText("7")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/components/Inputs/Range.tsx
+++ b/apps/ui/src/components/Inputs/Range.tsx
@@ -25,7 +25,7 @@ export function Range({ label, value, min = 0, max = 100, step = 1, onChange }: 
         <span className={styles.rangeValue}>{value}</span>
       </div>
       <SliderTrack className={styles.rangeTrack}>
-        <SliderThumb className={styles.rangeThumb} />
+        <SliderThumb className={styles.rangeThumb} aria-label={label} />
       </SliderTrack>
     </Slider>
   );

--- a/apps/ui/src/components/Inputs/Range.tsx
+++ b/apps/ui/src/components/Inputs/Range.tsx
@@ -1,26 +1,32 @@
-import React from "react";
+import { Slider, SliderTrack, SliderThumb, Label } from "react-aria-components";
 import styles from "./Inputs.module.css";
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface RangeProps {
   label?: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (value: number) => void;
 }
 
-export function Range({ label, value, min, max, step, onChange }: InputProps) {
+export function Range({ label, value, min = 0, max = 100, step = 1, onChange }: RangeProps) {
   return (
-    <label className={styles.label}>
-      <span className={styles.rangeHeader}>
-        <span>{label}</span>
+    <Slider
+      value={value}
+      minValue={min}
+      maxValue={max}
+      step={step}
+      onChange={onChange}
+      className={styles.rangeRoot}
+    >
+      <div className={styles.rangeHeader}>
+        <Label className={styles.label}>{label}</Label>
         <span className={styles.rangeValue}>{value}</span>
-      </span>
-      <input
-        type="range"
-        value={value}
-        min={min}
-        max={max}
-        step={step}
-        onChange={onChange}
-        className={styles.range}
-      />
-    </label>
+      </div>
+      <SliderTrack className={styles.rangeTrack}>
+        <SliderThumb className={styles.rangeThumb} />
+      </SliderTrack>
+    </Slider>
   );
 }

--- a/apps/ui/src/components/Inputs/SquaredButton.tsx
+++ b/apps/ui/src/components/Inputs/SquaredButton.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
+import { Button as AriaButton, type ButtonProps } from "react-aria-components";
 import styles from "./Inputs.module.css";
 import classNames from "classnames";
 
@@ -6,14 +7,23 @@ type SquaredButtonTone = "neutral" | "active" | "success" | "danger";
 type SquaredButtonVariant = "surface" | "ghost";
 type SquaredButtonSize = "md" | "lg";
 
-interface SquaredButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+// Omit React Aria's onClick/isDisabled to replace with standard React/HTML attrs
+type SquaredButtonProps = Omit<ButtonProps, "className" | "children" | "onClick" | "isDisabled"> & {
   icon: React.ReactNode;
   tone?: SquaredButtonTone;
   variant?: SquaredButtonVariant;
   size?: SquaredButtonSize;
   active?: boolean;
+  className?: string;
   iconClassName?: string;
-}
+  children?: React.ReactNode;
+  /** title attribute — applied via ref since React Aria filters it from DOM props */
+  title?: string;
+  onClick?: React.MouseEventHandler<Element>;
+  /** Standard HTML disabled attribute — mapped to React Aria's isDisabled */
+  disabled?: boolean;
+  isDisabled?: boolean;
+};
 
 export function SquaredButton({
   icon,
@@ -24,8 +34,20 @@ export function SquaredButton({
   className,
   iconClassName,
   children,
+  title,
+  disabled,
+  isDisabled,
   ...props
 }: SquaredButtonProps) {
+  const ref = useRef<HTMLButtonElement>(null);
+
+  // React Aria's filterDOMProps strips 'title', so apply it manually via ref
+  useEffect(() => {
+    if (ref.current && title) {
+      ref.current.setAttribute("title", title);
+    }
+  }, [title]);
+
   const iconNode = React.isValidElement<{ className?: string }>(icon)
     ? React.cloneElement(icon, {
         className: classNames(styles.squaredButtonIcon, icon.props.className, iconClassName),
@@ -33,9 +55,11 @@ export function SquaredButton({
     : icon;
 
   return (
-    <button
+    <AriaButton
+      ref={ref}
       type="button"
-      {...props}
+      isDisabled={isDisabled ?? disabled}
+      {...(props as ButtonProps)}
       className={classNames(
         styles.squaredButton,
         styles[`squaredButton${size === "lg" ? "Lg" : "Md"}`],
@@ -59,6 +83,6 @@ export function SquaredButton({
     >
       {iconNode}
       {children}
-    </button>
+    </AriaButton>
   );
 }

--- a/apps/ui/src/components/Inputs/Switch.tsx
+++ b/apps/ui/src/components/Inputs/Switch.tsx
@@ -1,6 +1,10 @@
-import React from "react";
+import { Switch as AriaSwitch, type SwitchProps } from "react-aria-components";
 import styles from "./Inputs.module.css";
 
-export function Switch(props: React.InputHTMLAttributes<HTMLInputElement>) {
-  return <input type="checkbox" className={styles.switch} {...props} />;
+export function Switch(props: Omit<SwitchProps, "children">) {
+  return (
+    <AriaSwitch {...props} className={styles.switch}>
+      <div className={styles.switchIndicator} />
+    </AriaSwitch>
+  );
 }

--- a/apps/ui/src/components/Inputs/Typeahead.test.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.test.tsx
@@ -49,13 +49,7 @@ describe("Typeahead", () => {
 
   it("supports renderLabel for display text", () => {
     const items = [{ name: "Nairobi" }, { name: "Mombasa" }];
-    render(
-      <Typeahead
-        options={items}
-        onChange={() => {}}
-        renderLabel={(item) => item.name}
-      />
-    );
+    render(<Typeahead options={items} onChange={() => {}} renderLabel={(item) => item.name} />);
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/components/Inputs/Typeahead.test.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Typeahead } from "./Typeahead";
+
+const options = ["Nairobi", "Mombasa", "Kisumu"];
+
+describe("Typeahead", () => {
+  it("renders a combobox input", () => {
+    render(<Typeahead options={options} onChange={() => {}} />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("renders label when provided", () => {
+    render(<Typeahead label="City:" options={options} onChange={() => {}} />);
+    expect(screen.getByText("City:")).toBeInTheDocument();
+  });
+
+  it("shows options on focus", async () => {
+    const user = userEvent.setup();
+    render(<Typeahead options={options} onChange={() => {}} />);
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByText("Nairobi")).toBeInTheDocument();
+  });
+
+  it("calls onChange when option selected via click", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Typeahead options={options} onChange={onChange} />);
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText("Mombasa"));
+    expect(onChange).toHaveBeenCalledWith("Mombasa");
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    render(<Typeahead options={options} onChange={() => {}} />);
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("renders with placeholder", () => {
+    render(<Typeahead options={options} onChange={() => {}} placeholder="Search..." />);
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+  });
+
+  it("supports renderLabel for display text", () => {
+    const items = [{ name: "Nairobi" }, { name: "Mombasa" }];
+    render(
+      <Typeahead
+        options={items}
+        onChange={() => {}}
+        renderLabel={(item) => item.name}
+      />
+    );
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -57,8 +57,8 @@ export function Typeahead<T>({
     <ComboBox<TypeaheadItem<T>>
       className={styles.comboBoxRoot}
       defaultItems={items}
-      selectedKey={selectedKey}
-      onSelectionChange={(key) => {
+      value={selectedKey}
+      onChange={(key) => {
         const found = items.find((item) => item.key === key);
         if (found) onChange(found.option);
       }}

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import {
   ComboBox,
   Input,
@@ -19,7 +19,7 @@ interface TypeaheadProps<T> {
   label?: string;
   value?: T | null;
   options: T[];
-  renderOption?: (option: T) => React.ReactNode;
+  renderOption?: (option: T) => ReactNode;
   renderLabel?: (option: T) => string;
   onChange: (option: T) => void;
   onOptionHover?: (option: T) => void;
@@ -50,10 +50,8 @@ export function Typeahead<T>({
     [options, getLabel]
   );
 
-  const selectedKey =
-    value != null
-      ? `${getLabel(value)}-${options.indexOf(value)}`
-      : null;
+  const selectedIdx = value != null ? options.indexOf(value) : -1;
+  const selectedKey = selectedIdx !== -1 ? `${getLabel(value!)}-${selectedIdx}` : null;
 
   return (
     <ComboBox<TypeaheadItem<T>>

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -1,12 +1,21 @@
-import React, { useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useMemo } from "react";
+import {
+  ComboBox,
+  Input,
+  Label,
+  ListBox,
+  ListBoxItem,
+  Popover,
+} from "react-aria-components";
 import styles from "./Inputs.module.css";
 import classNames from "classnames";
 
-interface TypeaheadProps<T> extends Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "onChange" | "value"
-> {
+interface TypeaheadItem<T> {
+  key: string;
+  option: T;
+}
+
+interface TypeaheadProps<T> {
   label?: string;
   value?: T | null;
   options: T[];
@@ -15,107 +24,68 @@ interface TypeaheadProps<T> extends Omit<
   onChange: (option: T) => void;
   onOptionHover?: (option: T) => void;
   onOptionLeave?: () => void;
+  className?: string;
+  placeholder?: string;
 }
 
 export function Typeahead<T>({
-  label = "",
+  label,
   options,
   renderLabel,
   renderOption,
   value,
   onChange,
-  onOptionHover = () => {},
-  onOptionLeave = () => {},
-  ...props
+  onOptionHover,
+  onOptionLeave,
+  className,
+  placeholder,
 }: TypeaheadProps<T>) {
-  const getLabel = React.useCallback(
+  const getLabel = useCallback(
     (option: T) => (renderLabel ? renderLabel(option) : String(option)),
     [renderLabel]
   );
-  const [inputValue, setInputValue] = React.useState(value ? getLabel(value) : "");
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [dropdownStyle, setDropdownStyle] = React.useState<React.CSSProperties>({});
-  const labelRef = useRef<HTMLLabelElement>(null);
 
-  const hasValue = !!value;
-
-  useEffect(() => {
-    if (!hasValue && !isOpen) {
-      setInputValue("");
-    }
-  }, [hasValue, isOpen]);
-
-  useEffect(() => {
-    if (value) {
-      setInputValue(getLabel(value));
-    }
-  }, [value, getLabel]);
-
-  useEffect(() => {
-    if (isOpen && labelRef.current) {
-      const rect = labelRef.current.getBoundingClientRect();
-      setDropdownStyle({
-        position: "fixed",
-        top: rect.bottom + 6,
-        left: rect.left,
-        width: rect.width,
-      });
-    }
-  }, [isOpen]);
-
-  const filtered = React.useMemo(
-    () => options.filter((o) => getLabel(o).toLowerCase().includes(inputValue.toLowerCase())),
-    [options, inputValue, getLabel]
+  const items = useMemo<TypeaheadItem<T>[]>(
+    () => options.map((option, i) => ({ key: `${getLabel(option)}-${i}`, option })),
+    [options, getLabel]
   );
 
-  const handleSelect = (option: T) => {
-    setInputValue(getLabel(option));
-    onChange(option);
-    setIsOpen(false);
-  };
+  const selectedKey =
+    value != null
+      ? `${getLabel(value)}-${options.indexOf(value)}`
+      : null;
 
   return (
-    <label className={styles.label} ref={labelRef}>
-      {label}
-      <input
-        {...props}
-        value={inputValue}
-        onFocus={() => setIsOpen(true)}
-        onChange={(e) => setInputValue(e.target.value)}
-        onBlur={() => setIsOpen(false)}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            setIsOpen(false);
-            (e.target as HTMLElement).blur();
-          }
-        }}
-        aria-expanded={isOpen}
-        aria-haspopup="listbox"
-        autoComplete="off"
-        className={classNames([styles.input, props.className])}
+    <ComboBox<TypeaheadItem<T>>
+      className={styles.comboBoxRoot}
+      defaultItems={items}
+      selectedKey={selectedKey}
+      onSelectionChange={(key) => {
+        const found = items.find((item) => item.key === key);
+        if (found) onChange(found.option);
+      }}
+      menuTrigger="focus"
+    >
+      {label && <Label className={styles.comboLabel}>{label}</Label>}
+      <Input
+        className={classNames(styles.input, className)}
+        placeholder={placeholder}
       />
-      {isOpen &&
-        filtered.length > 0 &&
-        createPortal(
-          <ul className={styles.dropdown} style={dropdownStyle} role="listbox">
-            {filtered.slice(0, 30).map((option, i) => (
-              <li
-                key={`${getLabel(option)}-${i}`}
-                role="option"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handleSelect(option);
-                }}
-                onMouseEnter={() => onOptionHover(option)}
-                onMouseLeave={() => onOptionLeave()}
-                className={styles.option}
-              >
-                {renderOption ? renderOption(option) : String(option)}
-              </li>
-            ))}
-          </ul>,
-          document.body
-        )}
-    </label>
+      <Popover className={styles.dropdown}>
+        <ListBox<TypeaheadItem<T>> className={styles.listBox}>
+          {(item) => (
+            <ListBoxItem
+              id={item.key}
+              textValue={getLabel(item.option)}
+              className={styles.option}
+              onHoverStart={() => onOptionHover?.(item.option)}
+              onHoverEnd={() => onOptionLeave?.()}
+            >
+              {renderOption ? renderOption(item.option) : getLabel(item.option)}
+            </ListBoxItem>
+          )}
+        </ListBox>
+      </Popover>
+    </ComboBox>
   );
 }

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -65,7 +65,7 @@ export function Typeahead<T>({
         const found = items.find((item) => item.key === key);
         if (found) onChange(found.option);
       }}
-      menuTrigger="focus"
+      menuTrigger="input"
     >
       {label && <Label className={styles.comboLabel}>{label}</Label>}
       <Input

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -58,7 +58,7 @@ export function Typeahead<T>({
         const found = items.find((item) => item.key === key);
         if (found) onChange(found.option);
       }}
-      menuTrigger="input"
+      menuTrigger="focus"
     >
       {label && <Label className={styles.comboLabel}>{label}</Label>}
       <Input className={classNames(styles.input, className)} placeholder={placeholder} />

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -1,12 +1,5 @@
 import { useCallback, useMemo, type ReactNode } from "react";
-import {
-  ComboBox,
-  Input,
-  Label,
-  ListBox,
-  ListBoxItem,
-  Popover,
-} from "react-aria-components";
+import { ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from "react-aria-components";
 import styles from "./Inputs.module.css";
 import classNames from "classnames";
 
@@ -68,10 +61,7 @@ export function Typeahead<T>({
       menuTrigger="input"
     >
       {label && <Label className={styles.comboLabel}>{label}</Label>}
-      <Input
-        className={classNames(styles.input, className)}
-        placeholder={placeholder}
-      />
+      <Input className={classNames(styles.input, className)} placeholder={placeholder} />
       <Popover className={styles.dropdown}>
         <ListBox<TypeaheadItem<T>> className={styles.listBox}>
           {(item) => (

--- a/apps/ui/src/components/Inputs/Typeahead.tsx
+++ b/apps/ui/src/components/Inputs/Typeahead.tsx
@@ -17,6 +17,7 @@ interface TypeaheadItem<T> {
 
 interface TypeaheadProps<T> {
   label?: string;
+  "aria-label"?: string;
   value?: T | null;
   options: T[];
   renderOption?: (option: T) => ReactNode;
@@ -30,6 +31,7 @@ interface TypeaheadProps<T> {
 
 export function Typeahead<T>({
   label,
+  "aria-label": ariaLabel,
   options,
   renderLabel,
   renderOption,
@@ -56,6 +58,7 @@ export function Typeahead<T>({
   return (
     <ComboBox<TypeaheadItem<T>>
       className={styles.comboBoxRoot}
+      aria-label={ariaLabel ?? (!label ? "Search" : undefined)}
       defaultItems={items}
       value={selectedKey}
       onChange={(key) => {

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -1,4 +1,5 @@
 @import "./styles/tokens.css";
+@import "./styles/theme.css";
 
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/apps/ui/src/styles/theme.css
+++ b/apps/ui/src/styles/theme.css
@@ -1,0 +1,52 @@
+/**
+ * React Aria component theme — maps the variable names used in React Aria's
+ * documented CSS examples to the project's design tokens.
+ *
+ * Usage: @import "./theme.css" at the top of any component CSS that uses
+ * React Aria's example styles verbatim.
+ */
+
+:root {
+  /* Spacing (React Aria uses multiples of a 4px base unit) */
+  --spacing: 4px;
+  --spacing-1: var(--space-2); /* 4px */
+  --spacing-2: var(--space-4); /* 8px */
+  --spacing-3: var(--space-5); /* 12px */
+  --spacing-4: var(--space-6); /* 16px */
+  --spacing-5: 20px;
+  --spacing-6: var(--space-7); /* 24px */
+  --spacing-8: var(--space-8); /* 32px */
+
+  /* Border radius */
+  --radius: var(--radius-md); /* 6px */
+
+  /* Typography */
+  --font-size: var(--text-base); /* 13px */
+  --font-size-sm: var(--text-sm); /* 12px */
+  --font-size-lg: var(--text-md); /* 14px */
+
+  /* Text */
+  --text-color: var(--color-text);
+  --text-color-disabled: var(--color-text-secondary);
+
+  /* Borders */
+  --border-color: rgba(255, 255, 255, 0.12);
+
+  /* Backgrounds */
+  --overlay-background: var(--glass-bg);
+
+  /* Selection / highlight */
+  --highlight-background: var(--color-accent); /* #39f */
+  --highlight-foreground: #fff;
+  --highlight-hover: var(--surface-bg-hover);
+  --highlight-overlay: rgba(57, 153, 255, 0.08);
+
+  /* Focus */
+  --focus-ring-color: var(--color-accent);
+
+  /* Grays (used for subtle dividers) */
+  --gray-300: rgba(255, 255, 255, 0.18);
+
+  /* Validation */
+  --invalid-color: var(--color-danger);
+}

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -56,6 +56,7 @@
   --space-8: 32px;
 
   /* Interactive element heights — unified scale */
+  --control-xs: 24px;
   --control-sm: 28px;
   --control: 32px;
   --control-lg: 40px;

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -1,8 +1,8 @@
 :root {
   /* Neutrals */
-  --color-bg-app: #242424;
-  --color-bg-dark: #111;
-  --color-bg-dark-2: #222;
+  --color-bg-app: #080a10;
+  --color-bg-dark: #060810;
+  --color-bg-dark-2: #0e1018;
   --color-bg-dark-3: #333;
   --color-bg-dark-4: #444;
   --color-gray: #666;
@@ -33,8 +33,8 @@
   --color-poi-default: #666;
 
   /* Map */
-  --color-map-road-highway: #222;
-  --color-map-road-default: #444;
+  --color-map-road-highway: #1a1d28;
+  --color-map-road-default: #2a2e3e;
   --color-map-polyline: #4488ff;
   --color-map-polyline-hovered: #f93;
   --color-map-polyline-selected: #39f;
@@ -88,18 +88,19 @@
   --text-xl: 17px;
   --text-2xl: 21px;
 
-  /* Glass surfaces */
-  --glass-bg: rgba(7, 9, 13, 0.88);
-  --glass-blur: blur(16px);
-  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  /* Glass surfaces — elevated elements (dock, search bar) */
+  --glass-bg: rgba(26, 32, 50, 0.78);
+  --glass-border: 1px solid rgba(255, 255, 255, 0.13);
+  --glass-blur: blur(28px);
+  --glass-shadow: 0 16px 48px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.08);
 
-  /* Panel surfaces */
-  --panel-surface: rgba(7, 9, 13, 0.74);
-  --panel-surface-strong: rgba(7, 9, 13, 0.88);
-  --panel-border: 1px solid var(--color-overlay-1);
-  --panel-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+  /* Panel surfaces — sidebar & rail (darker, more anchored) */
+  --panel-surface: rgba(10, 14, 22, 0.85);
+  --panel-surface-strong: rgba(16, 20, 32, 0.92);
+  --panel-border: 1px solid rgba(255, 255, 255, 0.09);
+  --panel-shadow: 0 24px 60px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.04);
   --panel-header-bg:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0)),
     var(--panel-surface-strong);
 
   /* Status colors */

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
         "classnames": "^2.5.1",
         "d3": "^7.9.0",
         "react": "^19.2.4",
+        "react-aria-components": "^1.16.0",
         "react-dom": "^19.2.4",
         "the-new-css-reset": "^1.11.3"
       },
@@ -209,6 +210,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -333,6 +335,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1011,6 +1014,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1059,6 +1063,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1582,7 +1587,6 @@
       "version": "0.23.3",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
       "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^3.0.3",
@@ -1597,7 +1601,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
       "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.1.1"
@@ -1610,7 +1613,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
       "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1643,7 +1645,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
       "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1653,7 +1654,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
       "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.1.1",
@@ -1681,6 +1681,57 @@
         }
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
@@ -1694,7 +1745,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -1704,7 +1754,6 @@
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -1718,7 +1767,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -1732,7 +1780,6 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -1740,6 +1787,43 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
+      "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -2201,6 +2285,1804 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@react-aria/autocomplete": {
+      "version": "3.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-rc.6.tgz",
+      "integrity": "sha512-uymUNJ8NW+dX7lmgkHE+SklAbxwktycAJcI5lBBw6KPZyc0EdMHC+/Fc5CUz3enIAhNwd2oxxogcSHknquMzQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/combobox": "^3.15.0",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/searchfield": "^3.8.12",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/autocomplete": "3.0.0-beta.4",
+        "@react-stately/combobox": "^3.13.0",
+        "@react-types/autocomplete": "3.0.0-alpha.38",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.32.tgz",
+      "integrity": "sha512-S61vh5DJ2PXiXUwD7gk+pvS/b4VPrc3ZJOUZ0yVRLHkVESr5LhIZH+SAVgZkm1lzKyMRG+BH+fiRH/DZRSs7SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/link": "^3.8.9",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/breadcrumbs": "^3.7.19",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.5.tgz",
+      "integrity": "sha512-ZuLx+wQj9VQhH9BYe7t0JowmKnns2XrFHFNvIVBb5RwxL+CIycIOL7brhWKg2rGdxvlOom7jhVbcjSmtAaSyaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/toolbar": "3.0.0-beta.24",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.5.tgz",
+      "integrity": "sha512-k0kvceYdZZu+DoeqephtlmIvh1CxqdFyoN52iqVzTz9O0pe5Xfhq7zxPGbeCp4pC61xzp8Lu/6uFA/YNfQQNag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/calendar": "^3.9.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.16.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.5.tgz",
+      "integrity": "sha512-ZhUT7ELuD52hb+Zpzw0ElLQiVOd5sKYahrh+PK3vq13Wk5TedBscALpjuXetI4pwFfdmAM1Lhgcsrd8+6AmyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/toggle": "^3.12.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/checkbox": "^3.7.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/collections": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.3.tgz",
+      "integrity": "sha512-lbC5DEbHeVFvVr4ke9y8D9Nynnr8G8UjVEBoFGRylpAaScU7SX1TN84QI+EjMbsdZ0/5P2H7gUTS+MYd+6U3Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/color": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.1.5.tgz",
+      "integrity": "sha512-eysWdBRzE8WDhBzh1nfjyUgzseMokXGHjIoJo880T7IPJ8tTavfQni49pU1B2qWrNOWPyrwx4Bd9pzHyboxJSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/numberfield": "^3.12.5",
+        "@react-aria/slider": "^3.8.5",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/color": "^3.9.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/color": "^3.1.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.15.0.tgz",
+      "integrity": "sha512-qSjQTFwKl3x1jCP2NRSJ6doZqAp6c2GTfoiFwWjaWg1IewwLsglaW6NnzqRDFiqFbDGgXPn4MqtC1VYEJ3NEjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/combobox": "^3.13.0",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-6BltCVWt09yefTkGjb2gViGCwoddx9HKJiZbY9u6Es/Q+VhwNJQRtczbnZ3K32p262hIknukNf/5nZaCOI1AKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/datepicker": "^3.16.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.34.tgz",
+      "integrity": "sha512-/x53Q5ynpW5Kv9637WYu7SrDfj3woSp6jJRj8l6teGnWW/iNZWYJETgzHfbxx+HPKYATCZesRoIeO2LnYIXyEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/dialog": "^3.5.24",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/disclosure": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.1.3.tgz",
+      "integrity": "sha512-S3k7Wqrj+x0sWcP88Z1stSr5TIZmKEmx2rU7RB1O1/jPpbw5mgKnjtiriOlTh+kwdK11FkeqgxyHzAcBAR+FMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/disclosure": "^3.0.11",
+        "@react-types/button": "^3.15.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dnd": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.11.6.tgz",
+      "integrity": "sha512-4YLHUeYJleF+moAYaYt8UZqujudPvpoaHR+QMkWIFzhfridVUhCr6ZjGWrzpSZY3r68k46TG7YCsi4IEiNnysw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/dnd": "^3.7.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.5.tgz",
+      "integrity": "sha512-V18fwCyf8zqgJdpLQeDU5ZRNd9TeOfBbhLgmX77Zr5ae9XwaoJ1R3SFJG1wCJX60t34AW+aLZSEEK+saQElf3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.5.tgz",
+      "integrity": "sha512-BWlONgHn8hmaMkcS6AgMSLQeNqVBwqPNLhdqjDO/PCfzvV7O8NZw/dFeIzJwfG4aBfSpbHHRdXGdfrk3d8dylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.8.tgz",
+      "integrity": "sha512-X6rRFKDu/Kh6Sv8FBap3vjcb+z4jXkSOwkYnexIJp5kMTo5/Dqo55cCBio5B70Tanfv32Ev/6SpzYG7ryxnM9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/gridlist": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.14.4.tgz",
+      "integrity": "sha512-C/SbwC0qagZatoBrCjx8iZUex9apaJ8o8iRJ9eVHz0cpj7mXg6HuuotYGmDy9q67A2hve4I693RM1Cuwqwm+PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/grid": "^3.14.8",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.16.tgz",
+      "integrity": "sha512-Km2CAz6MFQOUEaattaW+2jBdWOHUF8WX7VQoNbjlqElCP58nSaqi9yxTWUDRhAcn8/xFUnkFh4MFweNgtrHuEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.27.1.tgz",
+      "integrity": "sha512-M3wLpTTmDflI0QGNK0PJNUaBXXfeBXue8ZxLMngfc1piHNiH4G5lUvWd9W14XVbqrSCVY8i8DfGrNYpyyZu0tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.25.tgz",
+      "integrity": "sha512-oNK3Pqj4LDPwEbQaoM/uCip4QvQmmwGOh08VeW+vzSi6TAwf+KoWTyH/tiAeB0CHWNDK0k3e1iTygTAt4wzBmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.10.tgz",
+      "integrity": "sha512-GpNjJaI8/a6WxYDZgzTCLYSzPM6xp2pxCIQ4udiGbTCtxx13Trmm0cPABvPtzELidgolCf05em9Phr+3G0eE8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.9.tgz",
+      "integrity": "sha512-UaAFBfs84/Qq6TxlMWkREqqNY6SFLukot+z2Aa1kC+VyStv1kWG6sE5QLjm4SBn1Q3CGRsefhB/5+taaIbB4Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.15.3.tgz",
+      "integrity": "sha512-C6YgiyrHS5sbS5UBdxGMhEs+EKJYotJgGVtl9l0ySXpBUXERiHJWLOyV7a8PwkUOmepbB4FaLD7Y9EUzGkrGlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/listbox": "^3.7.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
+      "integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.21.0.tgz",
+      "integrity": "sha512-CKTVZ4izSE1eKIti6TbTtzJAUo+WT8O4JC0XZCYDBpa0f++lD19Kz9aY+iY1buv5xGI20gAfpO474E9oEd4aQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/menu": "^3.9.11",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/button": "^3.15.1",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/meter": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.30.tgz",
+      "integrity": "sha512-ZmANKW7s/Z4QGylHi46nhwtQ47T1bfMsU9MysBu7ViXXNJ03F4b6JXCJlKL5o2goQ3NbfZ68GeWamIT0BWSgtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.30",
+        "@react-types/meter": "^3.4.15",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.5.tgz",
+      "integrity": "sha512-Fi41IUWXEHLFIeJ/LHuZ9Azs8J/P563fZi37GSBkIq5P1pNt1rPgJJng5CNn4KsHxwqadTRUlbbZwbZraWDtRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/spinbutton": "^3.7.2",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/numberfield": "^3.11.0",
+        "@react-types/button": "^3.15.1",
+        "@react-types/numberfield": "^3.8.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.31.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.31.2.tgz",
+      "integrity": "sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/button": "^3.15.1",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.30.tgz",
+      "integrity": "sha512-S6OWVGgluSWYSd/A6O8CVjz83eeMUfkuWSra0ewAV9bmxZ7TP9pUmD3bGdqHZEl97nt5vHGjZ3eq/x8eCmzKhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/progress": "^3.5.18",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.5.tgz",
+      "integrity": "sha512-8CCJKJzfozEiWBPO9QAATG1rBGJEJ+xoqvHf9LKU2sPFGsA2/SRnLs6LB9fCG5R3spvaK1xz0any1fjWPl7x8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/radio": "^3.11.5",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/searchfield": {
+      "version": "3.8.12",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.12.tgz",
+      "integrity": "sha512-kYlUHD/+mWzNroHoR8ojUxYBoMviRZn134WaKPFjfNUGZDOEuh4XzOoj+cjdJfe6N3mwTaYu6rJQtunSHIAfhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/searchfield": "^3.5.19",
+        "@react-types/button": "^3.15.1",
+        "@react-types/searchfield": "^3.6.8",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/select": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.17.3.tgz",
+      "integrity": "sha512-u0UFWw0S7q9oiSbjetDpRoLLIcC+L89uYlm+YfCrdT8ntbQgABNiJRxdVvxnhR0fR6MC9ASTTvuQnNHNn52+1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/select": "^3.9.2",
+        "@react-types/button": "^3.15.1",
+        "@react-types/select": "^3.12.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.27.2.tgz",
+      "integrity": "sha512-GbUSSLX/ciXix95KW1g+SLM9np7iXpIZrFDSXkC6oNx1uhy18eAcuTkeZE25+SY5USVUmEzjI3m/3JoSUcebbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/separator": {
+      "version": "3.4.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.16.tgz",
+      "integrity": "sha512-RCUtQhDGnPxKzyG8KM79yOB0fSiEf8r/rxShidOVnGLiBW2KFmBa22/Gfc4jnqg/keN3dxvkSGoqmeXgctyp6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.5.tgz",
+      "integrity": "sha512-gqkJxznk141mE0JamXF5CXml9PDbPkBz8dyKlihtWHWX4yhEbVYdC9J0otE7iCR3zx69Bm7WHoTGL0BsdpKzVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/slider": "^3.7.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.7.2.tgz",
+      "integrity": "sha512-adjE1wNCWlugvAtVXlXWPtIG9JWurEgYVn1Eeyh19x038+oXGvOsOAoKCXM+SnGleTWQ9J7pEZITFoEI3cVfAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.11.tgz",
+      "integrity": "sha512-dYVX71HiepBsKyeMaQgHbhqI+MQ3MVoTd5EnTbUjefIBnmQZavYj1/e4NUiUI4Ix+/C0HxL8ibDAv4NlSW3eLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.12.5",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/switch": "^3.5.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.11.tgz",
+      "integrity": "sha512-GkYmWPiW3OM+FUZxdS33teHXHXde7TjHuYgDDaG9phvg6cQTQjGilJozrzA3OfftTOq5VB8XcKTIQW3c0tpYsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/grid": "^3.14.8",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.15.4",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.11.1.tgz",
+      "integrity": "sha512-3Ppz7yaEDW9L7p9PE9yNOl5caLwNnnLQqI+MX/dwbWlw9HluHS7uIjb21oswNl6UbSxAWyENOka45+KN4Fkh7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tabs": "^3.8.9",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.8.1.tgz",
+      "integrity": "sha512-VonpO++F8afXGDWc9VUxAc2wefyJpp1n9OGpbnB7zmqWiuPwO/RixjUdcH7iJkiC4vADwx9uLnhyD6kcwGV2ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.14.4",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/list": "^3.13.4",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.5.tgz",
+      "integrity": "sha512-ttwVSuwoV3RPaG2k2QzEXKeQNQ3mbdl/2yy6I4Tjrn1ZNkYHfVyJJ26AjenfSmj1kkTQoSAfZ8p+7rZp4n0xoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/textfield": "^3.12.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.11.tgz",
+      "integrity": "sha512-2DjZjBAvm8/CWbnZ6s7LjkYCkULKtjMve6GvhPTq98AthuEDLEiBvM1wa3xdecCRhZyRT1g6DXqVca0EfZ9fJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/landmark": "^3.0.10",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toast": "^3.1.3",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.5.tgz",
+      "integrity": "sha512-XXVFLzcV8fr9mz7y/wfxEAhWvaBZ9jSfhCMuxH2bsivO7nTcMJ1jb4g2xJNwZgne17bMWNc7mKvW5dbsdlI6BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.24.tgz",
+      "integrity": "sha512-B2Rmpko7Ghi2RbNfsGdbR7I+RQBDhPGVE4bU3/EwHz+P/vNe5LyGPTeSwqaOMsQTF9lKNCkY8424dVTCr6RUMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.9.2.tgz",
+      "integrity": "sha512-VrgkPwHiEnAnBhoQ4W7kfry/RfVuRWrUPaJSp0+wKM6u0gg2tmn7OFRDXTxBAm/omQUguIdIjRWg7sf3zHH82A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tooltip": "^3.5.11",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tooltip": "^3.5.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tree": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.7.tgz",
+      "integrity": "sha512-C54yH5NmsOFa2Q+cg6B1BPr5KUlU9vLIoBnVrgrH237FRSXQPIbcM4VpmITAHq1VR7w6ayyS1hgTwFxo67ykWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.14.4",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/button": "^3.15.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.33.1.tgz",
+      "integrity": "sha512-kIx1Sj6bbAT0pdqCegHuPanR9zrLn5zMRiM7LN12rgRf55S19ptd9g3ncahArifYTRkfEU9VIn+q0HjfMqS9/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/virtualizer": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.13.tgz",
+      "integrity": "sha512-d5KS+p8GXGNRbGPRE/N6jtth3et3KssQIz52h2+CAoAh7C3vvR64kkTaGdeywClvM+fSo8FxJuBrdfQvqC2ktQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-stately/virtualizer": "^4.4.6",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.31",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.31.tgz",
+      "integrity": "sha512-RTOHHa4n56a9A3criThqFHBifvZoV71+MCkSuNP2cKO662SUWjqKkd0tJt/mBRMEJPkys8K7Eirp6T8Wt5FFRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/utils": "^3.33.1",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/autocomplete": {
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.4.tgz",
+      "integrity": "sha512-K2Uy7XEdseFvgwRQ8CyrYEHMupjVKEszddOapP8deNz4hntYvT1aRm0m+sKa5Kl/4kvg9c/3NZpQcrky/vRZIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.9.3.tgz",
+      "integrity": "sha512-uw7fCZXoypSBBUsVkbNvJMQWTihZReRbyLIGG3o/ZM630N3OCZhb/h4Uxke4pNu7n527H0V1bAnZgAldIzOYqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.5.tgz",
+      "integrity": "sha512-K5R5ted7AxLB3sDkuVAazUdyRMraFT1imVqij2GuAiOUFvsZvbuocnDuFkBVKojyV3GpqLBvViV8IaCMc4hNIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.10.tgz",
+      "integrity": "sha512-wmF9VxJDyBujBuQ76vXj2g/+bnnj8fx5DdXgRmyfkkYhPB46+g2qnjbVGEvipo7bJuGxDftCUC4SN7l7xqUWfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/color": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.9.5.tgz",
+      "integrity": "sha512-8pZxzXWDRuglzDwyTG7mLw2LQMCHIVNbVc9YmbsxbOjAL+lOqszo60KzyaFKVxeDQczSvrNTHcQZqlbNIC0eyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/numberfield": "^3.11.0",
+        "@react-stately/slider": "^3.7.5",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/color": "^3.1.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.13.0.tgz",
+      "integrity": "sha512-dX9g/cK1hjLRjcbWVF6keHxTQDGhKGB2QAgPhWcBmOK3qJv+2dQqsJ6YCGWn/Y2N2acoEseLrAA7+Qe4HWV9cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/data": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.15.2.tgz",
+      "integrity": "sha512-BsmeeGgFwOGwo0g9Waprdyt+846n3KhKggZfpEnp5+sC4dE4uW1VIYpdyupMfr3bQcmX123q6TegfNP3eszrUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.16.1.tgz",
+      "integrity": "sha512-BtAMDvxd1OZxkxjqq5tN5TYmp6Hm8+o3+IDA4qmem2/pfQfVbOZeWS2WitcPBImj4n4T+W1A5+PI7mT/6DUBVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/datepicker": "^3.13.5",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/disclosure": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.11.tgz",
+      "integrity": "sha512-/KjB/0HkxGWbhFAPztCP411LUKZCx9k8cKukrlGqrUWyvrcXlmza90j0g/CuxACBoV+DJP9V+4q+8ide0x750A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/dnd": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.7.4.tgz",
+      "integrity": "sha512-YD0TVR5JkvTqskc1ouBpVKs6t/QS4RYCIyu8Ug8RgO122iIizuf2pfKnRLjYMdu5lXzBXGaIgd49dvnLzEXHIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.4.tgz",
+      "integrity": "sha512-qNBzun8SbLdgahryhKLqL1eqP+MXY6as82sVXYOOvUYLzgU5uuN8mObxYlxJgMI5akSdQJQV3RzyfVobPRE7Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.9.tgz",
+      "integrity": "sha512-qQY6F+27iZRn30dt0ZOrSetUmbmNJ0pLe9Weuqw3+XDVSuWT+2O/rO1UUYeK+mO0Acjzdv+IWiYbu9RKf2wS9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/layout": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.6.0.tgz",
+      "integrity": "sha512-kBenEsP03nh5rKgfqlVMPcoKTJv0v92CTvrAb5gYY8t9g8LOwzdL89Yannq7f5xv8LFck/MmRQlotpMt2InETg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/table": "^3.15.4",
+        "@react-stately/virtualizer": "^4.4.6",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.13.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.4.tgz",
+      "integrity": "sha512-HHYSjA9VG7FPSAtpXAjQyM/V7qFHWGg88WmMrDt5QDlTBexwPuH0oFLnW0qaVZpAIxuWIsutZfxRAnme/NhhAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.11.tgz",
+      "integrity": "sha512-vYkpO9uV2OUecsIkrOc+Urdl/s1xw/ibNH/UXsp4PtjMnS6mK9q2kXZTM3WvMAKoh12iveUO+YkYCZQshmFLHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/menu": "^3.10.7",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.11.0.tgz",
+      "integrity": "sha512-rxfC047vL0LP4tanjinfjKAriAvdVL57Um5RUL5nHML8IOWCB3TBxegQkJ6to6goScC/oZhd0/Y2LSaiRuKbNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/numberfield": "^3.8.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.23.tgz",
+      "integrity": "sha512-RzWxots9A6gAzQMP4s8hOAHV7SbJRTFSlQbb6ly1nkWQXacOSZSFNGsKOaS0eIatfNPlNnW4NIkgtGws5UYzfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/overlays": "^3.9.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.5.tgz",
+      "integrity": "sha512-QxA779S4ea5icQ0ja7CeiNzY1cj7c9G9TN0m7maAIGiTSinZl2Ia8naZJ0XcbRRp+LBll7RFEdekne15TjvS/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/radio": "^3.9.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/searchfield": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.19.tgz",
+      "integrity": "sha512-URllgjbtTQEaOCfddbHpJSPKOzG3pE3ajQHJ7Df8qCoHTjKfL6hnm/vp7X5sxPaZaN7VLZ5kAQxTE8hpo6s0+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/searchfield": "^3.6.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.9.2.tgz",
+      "integrity": "sha512-oWn0bijuusp8YI7FRM/wgtPVqiIrgU/ZUfLKe/qJUmT8D+JFaMAJnyrAzKpx98TrgamgtXynF78ccpopPhgrKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/select": "^3.12.2",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.9.tgz",
+      "integrity": "sha512-RhxRR5Wovg9EVi3pq7gBPK2BoKmP59tOXDMh2r1PbnGevg/7TNdR67DCEblcmXwHuBNS46ELfKdd0XGHqmS8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.5.tgz",
+      "integrity": "sha512-OrQMNR5xamLYH52TXtvTgyw3EMwv+JI+1istQgEj1CHBjC9eZZqn5iNCN20tzm+uDPTH0EIGULFjjPIumqYUQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.4.tgz",
+      "integrity": "sha512-fGaNyw3wv7JgRCNzgyDzpaaTFuSy5f4Qekch4UheMXDJX7dOeaMhUXeOfvnXCVg+BGM4ey/D82RvDOGvPy1Nww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.9",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.9.tgz",
+      "integrity": "sha512-AQ4Xrn6YzIolaVShCV9cnwOjBKPAOGP/PTp7wpSEtQbQ0HZzUDG2RG/M4baMeUB2jZ33b7ifXyPcK78o0uOftg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.13.4",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/tabs": "^3.3.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.3.tgz",
+      "integrity": "sha512-mT9QJKmD523lqFpOp0VWZ6QHZENFK7HrodnNJDVc7g616s5GNmemdlkITV43fSY3tHeThCVvPu+Uzh7RvQ9mpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.5.tgz",
+      "integrity": "sha512-PVzXc788q3jH98Kvw1LYDL+wpVC14dCEKjOku8cSaqhEof6AJGaLR9yq+EF1yYSL2dxI6z8ghc0OozY8WrcFcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/checkbox": "^3.10.4",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.11.tgz",
+      "integrity": "sha512-o8PnFXbvDCuVZ4Ht9ahfS6KHwIZjXopvoQ2vUPxv920irdgWEeC+4omgDOnJ/xFvcpmmJAmSsrQsTQrTguDUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.23",
+        "@react-types/tooltip": "^3.5.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.6.tgz",
+      "integrity": "sha512-JCuhGyX2A+PAMsx2pRSwArfqNFZJ9JSPkDaOQJS8MFPAsBe5HemvXsdmv9aBIMzlbCYcVq6EsrFnzbVVTBt/6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/utils": "^3.11.0",
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.11.0.tgz",
+      "integrity": "sha512-8LZpYowJ9eZmmYLpudbo/eclIRnbhWIJZ994ncmlKlouNzKohtM8qTC6B1w1pwUbiwGdUoyzLuQbeaIor5Dvcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.6.tgz",
+      "integrity": "sha512-9SfXgLFB61/8SXNLfg5ARx9jAK4m03Aw6/Cg8mdZN24SYarL4TKNRpfw8K/HHVU/bi6WHSJypk6Z/z19o/ztrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/autocomplete": {
+      "version": "3.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.38.tgz",
+      "integrity": "sha512-0XrlVC8drzcrCNzybbkZdLcTofXEzBsHuaFevt5awW1J0xBJ+SMLIQMDeUYrvKjjwXUBlCtjJJpOvitGt4Z+KA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/combobox": "^3.14.0",
+        "@react-types/searchfield": "^3.6.8",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.19.tgz",
+      "integrity": "sha512-AnkyYYmzaM2QFi/N0P/kQLM8tHOyFi7p397B/jEMucXDfwMw5Ny1ObCXeIEqbh8KrIa2Xp8SxmQlCV+8FPs4LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.7",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.15.1.tgz",
+      "integrity": "sha512-M1HtsKreJkigCnqceuIT22hDJBSStbPimnpmQmsl7SNyqCFY3+DHS7y/Sl3GvqCkzxF7j9UTL0dG38lGQ3K4xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-fpH6WNXotzH0TlKHXXxtjeLZ7ko0sbyHmwDAwmDFyP7T0Iwn1YQZ+lhceLifvynlxuOgX6oBItyUKmkHQ0FouQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.4.tgz",
+      "integrity": "sha512-tYCG0Pd1usEz5hjvBEYcqcA0youx930Rss1QBIse9TgMekA1c2WmPDNupYV8phpO8Zuej3DL1WfBeXcgavK8aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/color": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.1.4.tgz",
+      "integrity": "sha512-s+Xj4pvNBlJPpQ1Gr7bO1j4/tuwMUfdS9xIVFuiW5RvDsSybKTUJ/gqPzTxms94VDCRhLFocVn2STNdD2Erf6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@react-types/slider": "^3.8.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.14.0.tgz",
+      "integrity": "sha512-zmSSS7BcCOD8rGT8eGbVy7UlL5qq1vm88fFn4WgFe+lfK33ne+E7yTzTxcPY2TCGSo5fY6xMj3OG79FfVNGbSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.5.tgz",
+      "integrity": "sha512-j28Vz+xvbb4bj7+9Xbpc4WTvSitlBvt7YEaEGM/8ZQ5g4Jr85H2KwkmDwjzmMN2r6VMQMMYq9JEcemq5wWpfUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@react-types/calendar": "^3.8.3",
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.24",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.24.tgz",
+      "integrity": "sha512-NFurEP/zV0dA/41422lV1t+0oh6f/13n+VmLHZG8R13m1J3ql/kAXZ49zBSqkqANBO1ojyugWebk99IiR4pYOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.18",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.18.tgz",
+      "integrity": "sha512-0sBJW0+I9nJcF4SmKrYFEWAlehiebSTy7xqriqAXtqfTEdvzAYLGaAK2/7gx+wlNZeDTdW43CDRJ4XAhyhBqnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.8.tgz",
+      "integrity": "sha512-zJvXH8gc1e1VH2H3LRnHH/W2HIkLkZMH3Cu5pLcj0vDuLBSWpcr3Ikh3jZ+VUOZF0G1Jt1lO8pKIaqFzDLNmLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.7.tgz",
+      "integrity": "sha512-1apXCFJgMC1uydc2KNENrps1qR642FqDpwlNWe254UTpRZn/hEZhA6ImVr8WhomfLJu672WyWA0rUOv4HT+/pQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.6.tgz",
+      "integrity": "sha512-335NYElKEByXMalAmeRPyulKIDd2cjOCQhLwvv2BtxO5zaJfZnBbhZs+XPd9zwU6YomyOxODKSHrwbNDx+Jf3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.7.tgz",
+      "integrity": "sha512-+p7ixZdvPDJZhisqdtWiiuJ9pteNfK5i19NB6wzAw5XkljbEzodNhwLv6rI96DY5XpbFso2kcjw7IWi+rAAGGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/meter": {
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.15.tgz",
+      "integrity": "sha512-9WjNphhLLM+TA4Ev1y2MkpugJ5JjTXseHh7ZWWx2veq5DrXMZYclkRpfUrUdLVKvaBIPQCgpQIj0TcQi+quR9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/progress": "^3.5.18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.18",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.18.tgz",
+      "integrity": "sha512-nLzk7YAG9yAUtSv+9R8LgCHsu8hJq8/A+m1KsKxvc8WmNJjIujSFgWvT21MWBiUgPBzJKGzAqpMDDa087mltJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.4.tgz",
+      "integrity": "sha512-7Z9HaebMFyYBqtv3XVNHEmVkm7AiYviV7gv0c98elEN2Co+eQcKFGvwBM9Gy/lV57zlTqFX1EX/SAqkMEbCLOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.18.tgz",
+      "integrity": "sha512-mKeQn+KrHr1y0/k7KtrbeDGDaERH6i4f6yBwj/ZtYDCTNKMO3tPHJY6nzF0w/KKZLplIO+BjUbHXc2RVm8ovwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.4.tgz",
+      "integrity": "sha512-TkMRY3sA1PcFZhhclu4IUzUTIir6MzNJj8h6WT8vO6Nug2kXJ72qigugVFBWJSE472mltduOErEAo0rtAYWbQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/searchfield": {
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.8.tgz",
+      "integrity": "sha512-M2p7OVdMTMDmlBcHd4N2uCBwg3uJSNM4lmEyf09YD44N5wDAI0yogk52QBwsnhpe+i2s65UwCYgunB+QltRX8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1",
+        "@react-types/textfield": "^3.12.8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.12.2.tgz",
+      "integrity": "sha512-AseOjfr3qM1W1qIWcbAe6NFpwZluVeQX/dmu9BYxjcnVvtoBLPMbE5zX/BPbv+N5eFYjoMyj7Ug9dqnI+LrlGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.33.1.tgz",
+      "integrity": "sha512-oJHtjvLG43VjwemQDadlR5g/8VepK56B/xKO2XORPHt9zlW6IZs3tZrYlvH29BMvoqC7RtE7E5UjgbnbFtDGag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.8.4.tgz",
+      "integrity": "sha512-C+xFVvfKREai9S/ekBDCVaGPOQYkNUAsQhjQnNsUAATaox4I6IYLmcIgLmljpMQWqAe+gZiWsIwacRYMez2Tew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.17.tgz",
+      "integrity": "sha512-2GTPJvBCYI8YZ3oerHtXg+qikabIXCMJ6C2wcIJ5Xn0k9XOovowghfJi10OPB2GGyOiLBU74CczP5nx8adG90Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.6.tgz",
+      "integrity": "sha512-eluL+iFfnVmFm7OSZrrFG9AUjw+tcv898zbv+NsZACa8oXG1v9AimhZfd+Mo8q/5+sX/9hguWNXFkSvmTjuVPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.22",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.22.tgz",
+      "integrity": "sha512-HGwLD9dA3k3AGfRKGFBhNgxU9/LyRmxN0kxVj1ghA4L9S/qTOzS6GhrGNkGzsGxyVLV4JN8MLxjWN2o9QHnLEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.8.tgz",
+      "integrity": "sha512-wt6FcuE5AyntxsnPika/h3nf/DPmeAVbI018L9o6h+B/IL4sMWWdx663wx2KOOeHH8ejKGZQNPLhUKs4s1mVQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.5.2.tgz",
+      "integrity": "sha512-FvSuZ2WP08NEWefrpCdBYpEEZh/5TvqvGjq0wqGzWg2OPwpc14HjD8aE7I3MOuylXkD4MSlMjl7J4DlvlcCs3Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.4",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
@@ -2499,11 +4381,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5006,14 +6898,12 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -5073,7 +6963,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/kdbush": {
@@ -5093,8 +6982,8 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -5131,6 +7020,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5141,6 +7031,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5242,6 +7133,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -5672,8 +7564,8 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5685,7 +7577,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5695,7 +7586,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5938,6 +7828,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6061,6 +7952,12 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6074,6 +7971,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -6348,6 +8254,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6391,7 +8298,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6750,6 +8656,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6897,14 +8804,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/delaunator": {
@@ -7218,7 +9123,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7231,8 +9135,8 @@
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7332,7 +9236,6 @@
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
       "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
@@ -7363,7 +9266,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
       "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -7381,7 +9283,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -7394,7 +9295,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -7407,7 +9307,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -7427,7 +9326,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7537,14 +9435,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
@@ -7599,7 +9495,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -7633,7 +9528,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -7650,7 +9544,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -7664,7 +9557,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
       "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/form-data": {
@@ -7886,7 +9778,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -8093,7 +9984,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -8138,7 +10028,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -8177,6 +10066,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/ioredis": {
@@ -8223,7 +10124,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8243,7 +10143,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8298,7 +10197,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8344,8 +10242,9 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -8447,7 +10346,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -8461,14 +10359,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -8512,7 +10408,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -8522,7 +10417,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -8804,7 +10698,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -9268,7 +11161,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -9286,7 +11178,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -9302,7 +11193,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -9372,7 +11262,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9382,7 +11271,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9410,6 +11298,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9690,7 +11579,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -9782,7 +11670,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9869,8 +11756,104 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.47.0.tgz",
+      "integrity": "sha512-nvahimIqdByl/PXk/xPkG30LPRzcin+/Uk0uFfwbbKRRFC9aa22a6BRULZLqVHwa9GaNyKe6CDUxO1Dde4v0kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/breadcrumbs": "^3.5.32",
+        "@react-aria/button": "^3.14.5",
+        "@react-aria/calendar": "^3.9.5",
+        "@react-aria/checkbox": "^3.16.5",
+        "@react-aria/color": "^3.1.5",
+        "@react-aria/combobox": "^3.15.0",
+        "@react-aria/datepicker": "^3.16.1",
+        "@react-aria/dialog": "^3.5.34",
+        "@react-aria/disclosure": "^3.1.3",
+        "@react-aria/dnd": "^3.11.6",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/gridlist": "^3.14.4",
+        "@react-aria/i18n": "^3.12.16",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/label": "^3.7.25",
+        "@react-aria/landmark": "^3.0.10",
+        "@react-aria/link": "^3.8.9",
+        "@react-aria/listbox": "^3.15.3",
+        "@react-aria/menu": "^3.21.0",
+        "@react-aria/meter": "^3.4.30",
+        "@react-aria/numberfield": "^3.12.5",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/progress": "^3.4.30",
+        "@react-aria/radio": "^3.12.5",
+        "@react-aria/searchfield": "^3.8.12",
+        "@react-aria/select": "^3.17.3",
+        "@react-aria/selection": "^3.27.2",
+        "@react-aria/separator": "^3.4.16",
+        "@react-aria/slider": "^3.8.5",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/switch": "^3.7.11",
+        "@react-aria/table": "^3.17.11",
+        "@react-aria/tabs": "^3.11.1",
+        "@react-aria/tag": "^3.8.1",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/toast": "^3.0.11",
+        "@react-aria/tooltip": "^3.9.2",
+        "@react-aria/tree": "^3.1.7",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/visually-hidden": "^3.8.31",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.16.0.tgz",
+      "integrity": "sha512-MjHbTLpMFzzD2Tv5KbeXoZwPczuUWZcRavVvQQlNHRtXHH38D+sToMEYpNeir7Wh3K/XWtzeX3EujfJW6QNkrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.0",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/autocomplete": "3.0.0-rc.6",
+        "@react-aria/collections": "^3.0.3",
+        "@react-aria/dnd": "^3.11.6",
+        "@react-aria/focus": "^3.21.5",
+        "@react-aria/interactions": "^3.27.1",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.31.2",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/textfield": "^3.18.5",
+        "@react-aria/toolbar": "3.0.0-beta.24",
+        "@react-aria/utils": "^3.33.1",
+        "@react-aria/virtualizer": "^4.1.13",
+        "@react-stately/autocomplete": "3.0.0-beta.4",
+        "@react-stately/layout": "^4.6.0",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/table": "^3.15.4",
+        "@react-stately/utils": "^3.11.0",
+        "@react-stately/virtualizer": "^4.4.6",
+        "@react-types/form": "^3.7.18",
+        "@react-types/grid": "^3.3.8",
+        "@react-types/shared": "^3.33.1",
+        "@react-types/table": "^3.13.6",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "^3.47.0",
+        "react-stately": "^3.45.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/react-dom": {
@@ -9878,6 +11861,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9890,6 +11874,43 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-stately": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.45.0.tgz",
+      "integrity": "sha512-G3bYr0BIiookpt4H05VeZUuVS/FslQAj2TeT8vDfCiL314Y+LtPXIPe/a3eamCA0wljy7z1EDYKV50Qbz7pcJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/calendar": "^3.9.3",
+        "@react-stately/checkbox": "^3.7.5",
+        "@react-stately/collections": "^3.12.10",
+        "@react-stately/color": "^3.9.5",
+        "@react-stately/combobox": "^3.13.0",
+        "@react-stately/data": "^3.15.2",
+        "@react-stately/datepicker": "^3.16.1",
+        "@react-stately/disclosure": "^3.0.11",
+        "@react-stately/dnd": "^3.7.4",
+        "@react-stately/form": "^3.2.4",
+        "@react-stately/list": "^3.13.4",
+        "@react-stately/menu": "^3.9.11",
+        "@react-stately/numberfield": "^3.11.0",
+        "@react-stately/overlays": "^3.6.23",
+        "@react-stately/radio": "^3.11.5",
+        "@react-stately/searchfield": "^3.5.19",
+        "@react-stately/select": "^3.9.2",
+        "@react-stately/selection": "^3.20.9",
+        "@react-stately/slider": "^3.7.5",
+        "@react-stately/table": "^3.15.4",
+        "@react-stately/tabs": "^3.8.9",
+        "@react-stately/toast": "^3.1.3",
+        "@react-stately/toggle": "^3.9.5",
+        "@react-stately/tooltip": "^3.5.11",
+        "@react-stately/tree": "^3.9.6",
+        "@react-types/shared": "^3.33.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -10616,7 +12637,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10629,7 +12649,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11269,7 +13288,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -11321,8 +13339,8 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11368,7 +13386,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -11415,10 +13432,18 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/varint": {
@@ -11443,6 +13468,7 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -11522,6 +13548,7 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -11650,7 +13677,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11683,7 +13709,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11826,7 +13851,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11840,6 +13864,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Replaces all custom interactive input components with [react-aria-components](https://react-spectrum.adobe.com/react-aria/react-aria-components.html) for correct ARIA roles, keyboard navigation, and focus management.

**Components migrated:**
- `Switch` — `input[type=checkbox]` → React Aria `Switch` (proper `role="switch"`, `aria-checked`, keyboard toggle)
- `Range` — `input[type=range]` → React Aria `Slider` (`aria-valuenow/min/max`, keyboard arrow navigation, drag)
- `Typeahead` — custom portal combobox → React Aria `ComboBox` (arrow key navigation, `aria-activedescendant`, `role="combobox"` + `role="listbox"`)
- `ContextMenu` — custom Tab-trap → enhanced implementation with arrow key navigation, outside-click close, CSS module

**Consumers updated:** `TogglesPanel`, `Incidents`, `ConfigForm`, `SpeedPanel`, `SearchBar`

**Breaking API changes:**
- `Switch`: `checked` → `isSelected`, `onChange(e)` → `onChange(boolean)`
- `Range`: `onChange(e)` → `onChange(number)` (direct value, not event)

## Test plan
- [ ] All 461 tests pass (`npm test -- --run` in `apps/ui/`)
- [ ] TypeScript clean (`turbo type-check`)
- [ ] Switch toggles work in TogglesPanel and Incidents panels
- [ ] Range slider responds to arrow keys in TogglesPanel / SpeedPanel
- [ ] Typeahead in SearchBar: type to filter, arrow keys navigate, Enter selects, Escape closes
- [ ] Right-click on map: context menu opens, arrow keys navigate items, Escape closes, click outside closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)