### PR TITLE
feat: geofencing system with zone drawing and alerts (fleetsim-all-8xl)

### DIFF
--- a/apps/simulator/openapi.yaml
+++ b/apps/simulator/openapi.yaml
@@ -1223,6 +1223,151 @@ paths:
                   ok:
                     type: boolean
 
+  # ─── Geofences ──────────────────────────────────────────────────
+  /geofences:
+    post:
+      operationId: createGeofence
+      summary: Create a new geofence zone
+      tags: [Geofences]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGeoFenceRequest"
+      responses:
+        "201":
+          description: Zone created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "400":
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    get:
+      operationId: listGeofences
+      summary: List all geofence zones
+      tags: [Geofences]
+      responses:
+        "200":
+          description: List of zones
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GeoFence"
+
+  /geofences/{id}:
+    get:
+      operationId: getGeofence
+      summary: Get a single geofence zone by ID
+      tags: [Geofences]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Zone found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      operationId: replaceGeofence
+      summary: Full replace of a geofence zone
+      tags: [Geofences]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGeoFenceRequest"
+      responses:
+        "200":
+          description: Zone updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteGeofence
+      summary: Delete a geofence zone
+      tags: [Geofences]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Zone removed
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /geofences/{id}/toggle:
+    patch:
+      operationId: toggleGeofence
+      summary: Flip the active flag of a geofence zone
+      tags: [Geofences]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Zone updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   schemas:
     # ─── Core types ──────────────────────────────────────────────────
@@ -1946,3 +2091,49 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/VehicleStats"
+
+    # ─── Geofencing ──────────────────────────────────────────────────
+    GeoFence:
+      type: object
+      required: [id, name, type, polygon, active]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum: [restricted, delivery, monitoring]
+        polygon:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+          description: Array of [longitude, latitude] coordinate pairs forming a closed polygon
+        color:
+          type: string
+        active:
+          type: boolean
+
+    CreateGeoFenceRequest:
+      type: object
+      required: [name, type, polygon]
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+          enum: [restricted, delivery, monitoring]
+        polygon:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+            minItems: 2
+            maxItems: 2
+        color:
+          type: string

--- a/apps/simulator/src/__tests__/GeoFenceManager.test.ts
+++ b/apps/simulator/src/__tests__/GeoFenceManager.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GeoFenceManager } from "../modules/GeoFenceManager";
+import type { GeoFence, GeoFenceEvent } from "@moveet/shared-types";
+import type { VehicleDTO } from "../types";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** A simple square polygon in [lng, lat] order centered near 0,0. */
+const SQUARE_POLYGON: [number, number][] = [
+  [0, 0],
+  [1, 0],
+  [1, 1],
+  [0, 1],
+  [0, 0], // closed
+];
+
+function makeFence(overrides: Partial<GeoFence> = {}): GeoFence {
+  return {
+    id: "fence-1",
+    name: "Test Zone",
+    type: "monitoring",
+    polygon: SQUARE_POLYGON,
+    active: true,
+    ...overrides,
+  };
+}
+
+function makeVehicle(
+  id: string,
+  latLng: [number, number],
+  overrides: Partial<VehicleDTO> = {}
+): VehicleDTO {
+  return {
+    id,
+    name: `Vehicle ${id}`,
+    type: "car",
+    position: latLng, // [lat, lng]
+    speed: 30,
+    heading: 0,
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe("GeoFenceManager", () => {
+  let manager: GeoFenceManager;
+
+  beforeEach(() => {
+    manager = new GeoFenceManager();
+  });
+
+  // ── CRUD ──────────────────────────────────────────────────────────
+
+  describe("addZone / getZone", () => {
+    it("stores and retrieves a zone by id", () => {
+      const fence = makeFence();
+      manager.addZone(fence);
+      expect(manager.getZone("fence-1")).toEqual(fence);
+    });
+
+    it("returns undefined for unknown id", () => {
+      expect(manager.getZone("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("getAllZones", () => {
+    it("returns empty array when no zones exist", () => {
+      expect(manager.getAllZones()).toEqual([]);
+    });
+
+    it("returns all added zones", () => {
+      manager.addZone(makeFence({ id: "z1" }));
+      manager.addZone(makeFence({ id: "z2" }));
+      expect(manager.getAllZones()).toHaveLength(2);
+    });
+  });
+
+  describe("removeZone", () => {
+    it("removes an existing zone and returns true", () => {
+      manager.addZone(makeFence());
+      expect(manager.removeZone("fence-1")).toBe(true);
+      expect(manager.getZone("fence-1")).toBeUndefined();
+    });
+
+    it("returns false for unknown id", () => {
+      expect(manager.removeZone("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("updateZone", () => {
+    it("applies a partial patch and returns updated zone", () => {
+      manager.addZone(makeFence());
+      const updated = manager.updateZone("fence-1", { name: "Updated Zone", active: false });
+      expect(updated).not.toBeNull();
+      expect(updated!.name).toBe("Updated Zone");
+      expect(updated!.active).toBe(false);
+      expect(updated!.id).toBe("fence-1"); // id must not change
+    });
+
+    it("returns null for unknown id", () => {
+      expect(manager.updateZone("nonexistent", { name: "X" })).toBeNull();
+    });
+  });
+
+  describe("toggleZone", () => {
+    it("flips active from true to false", () => {
+      manager.addZone(makeFence({ active: true }));
+      const result = manager.toggleZone("fence-1");
+      expect(result).not.toBeNull();
+      expect(result!.active).toBe(false);
+    });
+
+    it("flips active from false to true", () => {
+      manager.addZone(makeFence({ active: false }));
+      const result = manager.toggleZone("fence-1");
+      expect(result!.active).toBe(true);
+    });
+
+    it("returns null for unknown id", () => {
+      expect(manager.toggleZone("nonexistent")).toBeNull();
+    });
+  });
+
+  // ── Ray-casting ───────────────────────────────────────────────────
+
+  describe("checkVehicles — ray-casting", () => {
+    /*
+     * SQUARE_POLYGON spans lng 0..1, lat 0..1.
+     * VehicleDTO.position is [lat, lng].
+     * A vehicle at lat=0.5, lng=0.5 → point [lng=0.5, lat=0.5] is inside.
+     * A vehicle at lat=2,   lng=2   → point [lng=2, lat=2] is outside.
+     */
+
+    it("detects a vehicle inside the polygon and emits 'enter'", () => {
+      manager.addZone(makeFence());
+      const listener = vi.fn();
+      manager.on("geofence-event", listener);
+
+      const inside = makeVehicle("v1", [0.5, 0.5]); // lat=0.5, lng=0.5 → inside
+      manager.checkVehicles([inside]);
+
+      expect(listener).toHaveBeenCalledOnce();
+      const event: GeoFenceEvent = listener.mock.calls[0][0];
+      expect(event.event).toBe("enter");
+      expect(event.vehicleId).toBe("v1");
+      expect(event.fenceId).toBe("fence-1");
+      expect(event.type).toBe("geofence-event");
+    });
+
+    it("does not emit for a vehicle outside the polygon", () => {
+      manager.addZone(makeFence());
+      const listener = vi.fn();
+      manager.on("geofence-event", listener);
+
+      const outside = makeVehicle("v2", [2.0, 2.0]); // lat=2, lng=2 → outside
+      manager.checkVehicles([outside]);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("emits 'exit' when a vehicle leaves the polygon", () => {
+      manager.addZone(makeFence());
+      const events: GeoFenceEvent[] = [];
+      manager.on("geofence-event", (e) => events.push(e));
+
+      const vehicle = makeVehicle("v3", [0.5, 0.5]); // inside
+      manager.checkVehicles([vehicle]);
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe("enter");
+
+      // Move vehicle outside
+      const vehicleOutside = makeVehicle("v3", [2.0, 2.0]);
+      manager.checkVehicles([vehicleOutside]);
+      expect(events).toHaveLength(2);
+      expect(events[1].event).toBe("exit");
+    });
+
+    it("does not emit when a vehicle stays inside across ticks", () => {
+      manager.addZone(makeFence());
+      const listener = vi.fn();
+      manager.on("geofence-event", listener);
+
+      const vehicle = makeVehicle("v4", [0.5, 0.5]);
+      manager.checkVehicles([vehicle]);
+      manager.checkVehicles([vehicle]); // second tick, still inside
+      expect(listener).toHaveBeenCalledOnce(); // only the initial enter
+    });
+
+    it("does not emit when a vehicle stays outside across ticks", () => {
+      manager.addZone(makeFence());
+      const listener = vi.fn();
+      manager.on("geofence-event", listener);
+
+      const vehicle = makeVehicle("v5", [2.0, 2.0]);
+      manager.checkVehicles([vehicle]);
+      manager.checkVehicles([vehicle]);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("ignores inactive zones", () => {
+      manager.addZone(makeFence({ active: false }));
+      const listener = vi.fn();
+      manager.on("geofence-event", listener);
+
+      const inside = makeVehicle("v6", [0.5, 0.5]);
+      manager.checkVehicles([inside]);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("emits multiple enter events for multiple zones", () => {
+      const polygon2: [number, number][] = [
+        [10, 10],
+        [11, 10],
+        [11, 11],
+        [10, 11],
+        [10, 10],
+      ];
+      manager.addZone(makeFence({ id: "z1" }));
+      manager.addZone(makeFence({ id: "z2", polygon: polygon2 }));
+
+      const events: GeoFenceEvent[] = [];
+      manager.on("geofence-event", (e) => events.push(e));
+
+      // Vehicle inside zone z1 only
+      manager.checkVehicles([makeVehicle("v7", [0.5, 0.5])]);
+      const enterZ1 = events.filter((e) => e.fenceId === "z1" && e.event === "enter");
+      const enterZ2 = events.filter((e) => e.fenceId === "z2" && e.event === "enter");
+      expect(enterZ1).toHaveLength(1);
+      expect(enterZ2).toHaveLength(0);
+    });
+
+    it("cleans up zone membership when a zone is removed", () => {
+      manager.addZone(makeFence());
+      const events: GeoFenceEvent[] = [];
+      manager.on("geofence-event", (e) => events.push(e));
+
+      manager.checkVehicles([makeVehicle("v8", [0.5, 0.5])]); // enter
+      expect(events).toHaveLength(1);
+
+      manager.removeZone("fence-1");
+
+      // Re-add the same zone; vehicle should enter again (membership was wiped)
+      manager.addZone(makeFence());
+      manager.checkVehicles([makeVehicle("v8", [0.5, 0.5])]); // should enter again
+      expect(events).toHaveLength(2);
+      expect(events[1].event).toBe("enter");
+    });
+  });
+});

--- a/apps/simulator/src/__tests__/setup/eventWiring.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiring.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 import { wireEvents } from "../../setup/eventWiring";
 import type { EventWiringContext } from "../../setup/eventWiring";
+import { GeoFenceManager } from "../../modules/GeoFenceManager";
 
 function createMockEmitter() {
   return new EventEmitter();
@@ -30,7 +31,8 @@ describe("wireEvents", () => {
   let simulationController: EventEmitter;
   let broadcaster: ReturnType<typeof createMockBroadcaster>;
   let recordingManager: ReturnType<typeof createMockRecordingManager>;
-  let result: { trafficBroadcastInterval: NodeJS.Timeout };
+  let geoFenceManager: GeoFenceManager;
+  let result: { trafficBroadcastInterval: NodeJS.Timeout; analyticsBroadcastInterval: NodeJS.Timeout };
 
   beforeEach(() => {
     network = createMockEmitter();
@@ -40,6 +42,7 @@ describe("wireEvents", () => {
     simulationController = createMockEmitter();
     broadcaster = createMockBroadcaster();
     recordingManager = createMockRecordingManager();
+    geoFenceManager = new GeoFenceManager();
 
     const ctx: EventWiringContext = {
       network: network as unknown as EventWiringContext["network"],
@@ -52,6 +55,7 @@ describe("wireEvents", () => {
       simulationController:
         simulationController as unknown as EventWiringContext["simulationController"],
       broadcaster,
+      geoFenceManager,
     };
 
     result = wireEvents(ctx);
@@ -59,6 +63,7 @@ describe("wireEvents", () => {
 
   afterEach(() => {
     clearInterval(result.trafficBroadcastInterval);
+    clearInterval(result.analyticsBroadcastInterval);
   });
 
   it("should return a traffic broadcast interval", () => {

--- a/apps/simulator/src/__tests__/setup/eventWiring.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiring.test.ts
@@ -32,7 +32,10 @@ describe("wireEvents", () => {
   let broadcaster: ReturnType<typeof createMockBroadcaster>;
   let recordingManager: ReturnType<typeof createMockRecordingManager>;
   let geoFenceManager: GeoFenceManager;
-  let result: { trafficBroadcastInterval: NodeJS.Timeout; analyticsBroadcastInterval: NodeJS.Timeout };
+  let result: {
+    trafficBroadcastInterval: NodeJS.Timeout;
+    analyticsBroadcastInterval: NodeJS.Timeout;
+  };
 
   beforeEach(() => {
     network = createMockEmitter();

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -10,6 +10,7 @@ import { FleetManager } from "./modules/FleetManager";
 import { IncidentManager } from "./modules/IncidentManager";
 import { RecordingManager } from "./modules/RecordingManager";
 import { SimulationController } from "./modules/SimulationController";
+import { GeoFenceManager } from "./modules/GeoFenceManager";
 import { config, verifyConfig, logConfig } from "./utils/config";
 import { generalRateLimiter } from "./middleware/rateLimiter";
 import { correlationIdMiddleware } from "./middleware/correlationId";
@@ -24,6 +25,7 @@ import {
   createFleetRoutes,
   createAnalyticsRoutes,
 } from "./routes";
+import { createGeofenceRoutes } from "./routes/geofences";
 import type { RouteContext } from "./routes";
 import { setupWebSocket, wireEvents, registerGracefulShutdown } from "./setup";
 
@@ -51,6 +53,7 @@ const incidentManager = new IncidentManager();
 const vehicleManager = new VehicleManager(network, fleetManager);
 const simulationController = new SimulationController(vehicleManager, incidentManager);
 const recordingManager = new RecordingManager();
+const geoFenceManager = new GeoFenceManager();
 
 // ─── Route context shared by all route modules ──────────────────────
 
@@ -86,6 +89,7 @@ app.use(createRecordingRoutes(ctx));
 app.use(createReplayRoutes(ctx));
 app.use(createFleetRoutes(ctx));
 app.use(createAnalyticsRoutes(ctx));
+app.use(createGeofenceRoutes(geoFenceManager));
 
 // ─── API documentation ──────────────────────────────────────────────
 
@@ -118,6 +122,7 @@ async function main() {
   const { trafficBroadcastInterval, analyticsBroadcastInterval } = wireEvents({
     ...ctx,
     broadcaster,
+    geoFenceManager,
   });
 
   registerGracefulShutdown({

--- a/apps/simulator/src/modules/GeoFenceManager.ts
+++ b/apps/simulator/src/modules/GeoFenceManager.ts
@@ -17,8 +17,7 @@ function pointInPolygon(point: [number, number], polygon: [number, number][]): b
     const [xi, yi] = polygon[i];
     const [xj, yj] = polygon[j];
 
-    const intersects =
-      yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi;
+    const intersects = yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi;
 
     if (intersects) {
       inside = !inside;

--- a/apps/simulator/src/modules/GeoFenceManager.ts
+++ b/apps/simulator/src/modules/GeoFenceManager.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from "events";
+import type { GeoFence, GeoFenceEvent } from "@moveet/shared-types";
+import type { VehicleDTO } from "../types";
+
+/**
+ * Determines whether a point [lng, lat] is inside a polygon using the
+ * standard ray-casting algorithm.
+ *
+ * @param point  [longitude, latitude]
+ * @param polygon  Array of [longitude, latitude] coordinate pairs
+ */
+function pointInPolygon(point: [number, number], polygon: [number, number][]): boolean {
+  const [px, py] = point;
+  let inside = false;
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const [xi, yi] = polygon[i];
+    const [xj, yj] = polygon[j];
+
+    const intersects =
+      yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi) + xi;
+
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}
+
+/**
+ * Manages geofence zones and emits enter/exit events as vehicles cross zone
+ * boundaries. Uses ray-casting for point-in-polygon checks.
+ *
+ * Emits: 'geofence-event' (GeoFenceEvent) on each enter/exit transition.
+ */
+export class GeoFenceManager extends EventEmitter {
+  /** Active and inactive zones keyed by fence id. */
+  private readonly zones: Map<string, GeoFence> = new Map();
+
+  /**
+   * Per-vehicle zone membership: vehicleId → Set of fenceIds the vehicle is
+   * currently inside.
+   */
+  private readonly membership: Map<string, Set<string>> = new Map();
+
+  // ─── Zone CRUD ────────────────────────────────────────────────────
+
+  addZone(fence: GeoFence): void {
+    this.zones.set(fence.id, fence);
+  }
+
+  updateZone(id: string, patch: Partial<GeoFence>): GeoFence | null {
+    const existing = this.zones.get(id);
+    if (!existing) return null;
+    const updated: GeoFence = { ...existing, ...patch, id };
+    this.zones.set(id, updated);
+    return updated;
+  }
+
+  removeZone(id: string): boolean {
+    const existed = this.zones.has(id);
+    if (existed) {
+      this.zones.delete(id);
+      // Clean up membership tracking for this zone
+      for (const [, fences] of this.membership) {
+        fences.delete(id);
+      }
+    }
+    return existed;
+  }
+
+  getZone(id: string): GeoFence | undefined {
+    return this.zones.get(id);
+  }
+
+  getAllZones(): GeoFence[] {
+    return Array.from(this.zones.values());
+  }
+
+  /**
+   * Flips the `active` flag of a zone.
+   * Returns the updated zone, or null if not found.
+   */
+  toggleZone(id: string): GeoFence | null {
+    const existing = this.zones.get(id);
+    if (!existing) return null;
+    const updated: GeoFence = { ...existing, active: !existing.active };
+    this.zones.set(id, updated);
+    return updated;
+  }
+
+  // ─── Vehicle checking ─────────────────────────────────────────────
+
+  /**
+   * Checks all active zones for each vehicle and detects enter/exit
+   * transitions. Emits `"geofence-event"` for each transition detected.
+   *
+   * Vehicle position is [lat, lng]; polygon coordinates are [lng, lat].
+   * We reorder to [lng, lat] before passing to pointInPolygon.
+   */
+  checkVehicles(vehicles: VehicleDTO[]): void {
+    for (const [, zone] of this.zones) {
+      if (!zone.active) continue;
+
+      for (const vehicle of vehicles) {
+        // VehicleDTO.position is [lat, lng]; convert to [lng, lat] for the polygon
+        const point: [number, number] = [vehicle.position[1], vehicle.position[0]];
+        const isInside = pointInPolygon(point, zone.polygon);
+
+        // Ensure we have a membership set for this vehicle
+        if (!this.membership.has(vehicle.id)) {
+          this.membership.set(vehicle.id, new Set());
+        }
+        const vehicleFences = this.membership.get(vehicle.id)!;
+
+        const wasInside = vehicleFences.has(zone.id);
+
+        if (isInside && !wasInside) {
+          // Enter transition
+          vehicleFences.add(zone.id);
+          const event: GeoFenceEvent = {
+            type: "geofence-event",
+            fenceId: zone.id,
+            fenceName: zone.name,
+            vehicleId: vehicle.id,
+            vehicleName: vehicle.name,
+            event: "enter",
+            timestamp: new Date().toISOString(),
+          };
+          this.emit("geofence-event", event);
+        } else if (!isInside && wasInside) {
+          // Exit transition
+          vehicleFences.delete(zone.id);
+          const event: GeoFenceEvent = {
+            type: "geofence-event",
+            fenceId: zone.id,
+            fenceName: zone.name,
+            vehicleId: vehicle.id,
+            vehicleName: vehicle.name,
+            event: "exit",
+            timestamp: new Date().toISOString(),
+          };
+          this.emit("geofence-event", event);
+        }
+      }
+    }
+  }
+}

--- a/apps/simulator/src/routes/geofences.ts
+++ b/apps/simulator/src/routes/geofences.ts
@@ -1,0 +1,88 @@
+import { Router } from "express";
+import type { GeoFenceManager } from "../modules/GeoFenceManager";
+import type { CreateGeoFenceRequest } from "@moveet/shared-types";
+
+/**
+ * Creates Express routes for geofence zone CRUD operations.
+ *
+ * @param geoFenceManager  Shared GeoFenceManager instance
+ */
+export function createGeofenceRoutes(geoFenceManager: GeoFenceManager): Router {
+  const router = Router();
+
+  // POST /geofences — create a new zone
+  router.post("/geofences", (req, res) => {
+    const body = req.body as CreateGeoFenceRequest;
+
+    if (!body.name || !body.type || !Array.isArray(body.polygon)) {
+      res.status(400).json({ error: "name, type, and polygon are required" });
+      return;
+    }
+
+    const fence = {
+      id: crypto.randomUUID(),
+      name: body.name,
+      type: body.type,
+      polygon: body.polygon,
+      color: body.color,
+      active: true,
+    };
+
+    geoFenceManager.addZone(fence);
+    res.status(201).json(fence);
+  });
+
+  // GET /geofences — list all zones
+  router.get("/geofences", (_req, res) => {
+    res.json(geoFenceManager.getAllZones());
+  });
+
+  // GET /geofences/:id — get single zone
+  router.get("/geofences/:id", (req, res) => {
+    const zone = geoFenceManager.getZone(req.params.id);
+    if (!zone) {
+      res.status(404).json({ error: "Zone not found" });
+      return;
+    }
+    res.json(zone);
+  });
+
+  // PUT /geofences/:id — full replace
+  router.put("/geofences/:id", (req, res) => {
+    const existing = geoFenceManager.getZone(req.params.id);
+    if (!existing) {
+      res.status(404).json({ error: "Zone not found" });
+      return;
+    }
+
+    const body = req.body as Partial<CreateGeoFenceRequest> & { active?: boolean };
+    const updated = geoFenceManager.updateZone(req.params.id, body);
+    if (!updated) {
+      res.status(404).json({ error: "Zone not found" });
+      return;
+    }
+    res.json(updated);
+  });
+
+  // DELETE /geofences/:id — delete zone
+  router.delete("/geofences/:id", (req, res) => {
+    const removed = geoFenceManager.removeZone(req.params.id);
+    if (!removed) {
+      res.status(404).json({ error: "Zone not found" });
+      return;
+    }
+    res.json({ status: "removed" });
+  });
+
+  // PATCH /geofences/:id/toggle — flip active flag
+  router.patch("/geofences/:id/toggle", (req, res) => {
+    const updated = geoFenceManager.toggleZone(req.params.id);
+    if (!updated) {
+      res.status(404).json({ error: "Zone not found" });
+      return;
+    }
+    res.json(updated);
+  });
+
+  return router;
+}

--- a/apps/simulator/src/setup/eventWiring.ts
+++ b/apps/simulator/src/setup/eventWiring.ts
@@ -5,6 +5,8 @@ import type { IncidentManager } from "../modules/IncidentManager";
 import type { RecordingManager } from "../modules/RecordingManager";
 import type { SimulationController } from "../modules/SimulationController";
 import type { WebSocketBroadcaster } from "../modules/WebSocketBroadcaster";
+import type { GeoFenceManager } from "../modules/GeoFenceManager";
+import type { VehicleDTO } from "../types";
 
 export interface EventWiringContext {
   network: RoadNetwork;
@@ -14,6 +16,7 @@ export interface EventWiringContext {
   recordingManager: RecordingManager;
   simulationController: SimulationController;
   broadcaster: WebSocketBroadcaster;
+  geoFenceManager: GeoFenceManager;
 }
 
 /** Default analytics broadcast interval in ms (5 seconds). */
@@ -36,12 +39,22 @@ export function wireEvents(ctx: EventWiringContext): {
     recordingManager,
     simulationController,
     broadcaster,
+    geoFenceManager,
   } = ctx;
 
   // ─── Vehicle updates (batched by the broadcaster) ───────────────────
+  // Accumulate per-tick vehicle updates and run geofence checks once per flush
+  const vehicleBatch: Map<string, VehicleDTO> = new Map();
+
   vehicleManager.on("update", (data) => {
     broadcaster.queueVehicleUpdate(data);
     recordingManager.captureVehicleSnapshot([data]);
+    vehicleBatch.set(data.id, data);
+  });
+
+  // ─── Geofence event → WS broadcaster ───────────────────────────────
+  geoFenceManager.on("geofence-event", (event) => {
+    broadcaster.broadcast("geofence-event", event);
   });
 
   // ─── Non-vehicle events (broadcast immediately) ─────────────────────
@@ -62,10 +75,16 @@ export function wireEvents(ctx: EventWiringContext): {
   incidentManager.on("incident:cleared", (data) => broadcaster.broadcast("incident:cleared", data));
   vehicleManager.on("vehicle:rerouted", (data) => broadcaster.broadcast("vehicle:rerouted", data));
 
-  // ─── Traffic congestion snapshot every 2 seconds ────────────────────
+  // ─── Traffic congestion snapshot + geofence checks every 2 seconds ──
   const trafficBroadcastInterval = setInterval(() => {
     const traffic = vehicleManager.getTrafficSnapshot();
     broadcaster.broadcast("traffic", traffic);
+
+    // Run geofence checks against the vehicles accumulated since last tick
+    if (vehicleBatch.size > 0) {
+      geoFenceManager.checkVehicles(Array.from(vehicleBatch.values()));
+      vehicleBatch.clear();
+    }
   }, 2000);
 
   // ─── Recording events ──────────────────────────────────────────────

--- a/apps/ui/src/App.module.css
+++ b/apps/ui/src/App.module.css
@@ -139,3 +139,44 @@
   flex-direction: column;
   align-items: stretch;
 }
+
+.drawZoneButton {
+  position: absolute;
+  bottom: 60px;
+  right: var(--space-4, 12px);
+  z-index: 20;
+  padding: 0 var(--space-4, 12px);
+  height: var(--control, 36px);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--text-sm, 13px);
+  font-weight: 500;
+  color: var(--color-gray-lightest, #e0e0e0);
+  background: rgba(12, 14, 18, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition:
+    background var(--transition-fast, 150ms ease),
+    border-color var(--transition-fast, 150ms ease),
+    color var(--transition-fast, 150ms ease);
+  font-family: inherit;
+}
+
+.drawZoneButton:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.4);
+  color: #fff;
+}
+
+.drawZoneButtonActive {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fca5a5;
+}
+
+.drawZoneButtonActive:hover {
+  background: rgba(239, 68, 68, 0.3);
+  border-color: rgba(239, 68, 68, 0.6);
+  color: #fff;
+}

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -18,6 +18,8 @@ import MapView from "./Map/Map";
 import FleetLegend from "./Map/FleetLegend";
 import SearchBar from "./SearchBar";
 import Zoom from "./Zoom/";
+import GeofencePanel from "./Controls/GeofencePanel";
+import CreateZoneDialog from "./Map/Geofence/CreateZoneDialog";
 import type {
   Fleet,
   IncidentType,
@@ -27,6 +29,7 @@ import type {
   Road,
   SimulationStatus,
 } from "./types";
+import type { GeoFence, GeoFenceEvent, CreateGeoFenceRequest } from "@moveet/shared-types";
 import styles from "./App.module.css";
 import { useVehicles } from "./hooks/useVehicles";
 import { useFleets } from "./hooks/useFleets";
@@ -60,6 +63,12 @@ export default function App() {
 
   const [connected, setConnected] = useState(false);
   const connectionInfo = useConnectionState();
+
+  // ─── Geofencing state ───────────────────────────────────────────
+  const [fences, setFences] = useState<GeoFence[]>([]);
+  const [alerts, setAlerts] = useState<GeoFenceEvent[]>([]);
+  const [drawingActive, setDrawingActive] = useState(false);
+  const [pendingPolygon, setPendingPolygon] = useState<[number, number][] | null>(null);
 
   const dispatch = useDispatchFlow();
   const { activePanel, setActivePanel, closePanel } = usePanelNavigation(dispatch.dispatchMode);
@@ -227,6 +236,56 @@ export default function App() {
     });
   }, [setVehicles]);
 
+  // ─── Geofence data loading ────────────────────────────────────────
+  const fetchFences = useCallback(() => {
+    client.getGeofences().then((response) => {
+      if (response.data) setFences(response.data);
+    });
+  }, []);
+
+  useEffect(() => {
+    fetchFences();
+  }, [fetchFences]);
+
+  const onFenceToggle = useCallback(
+    (id: string) => {
+      client.toggleGeofence(id).then((response) => {
+        if (response.data) {
+          setFences((prev) => prev.map((f) => (f.id === id ? response.data! : f)));
+        }
+      });
+    },
+    []
+  );
+
+  const onFenceDelete = useCallback((id: string) => {
+    client.deleteGeofence(id).then(() => {
+      setFences((prev) => prev.filter((f) => f.id !== id));
+    });
+  }, []);
+
+  const onDrawComplete = useCallback((polygon: [number, number][]) => {
+    setDrawingActive(false);
+    setPendingPolygon(polygon);
+  }, []);
+
+  const onDrawCancel = useCallback(() => {
+    setDrawingActive(false);
+    setPendingPolygon(null);
+  }, []);
+
+  const onCreateZone = useCallback(
+    (req: CreateGeoFenceRequest) => {
+      client.createGeofence(req).then((response) => {
+        if (response.data) {
+          setFences((prev) => [...prev, response.data!]);
+        }
+        setPendingPolygon(null);
+      });
+    },
+    []
+  );
+
   useEffect(() => {
     client.onConnect(() => {
       setConnected(true);
@@ -253,8 +312,18 @@ export default function App() {
       }
     });
 
+    client.onGeofenceEvent((event) => {
+      setAlerts((prev) => {
+        const next = [event, ...prev];
+        return next.length > 200 ? next.slice(0, 200) : next;
+      });
+    });
+
     client.connectWebSocket();
-    return () => client.disconnect();
+    return () => {
+      client.offGeofenceEvent();
+      client.disconnect();
+    };
   }, [setVehicles, onUnselectVehicle]);
 
   const maxSpeedRef = useRef(60);
@@ -344,6 +413,14 @@ export default function App() {
                   summaryHistory={analytics.summaryHistory}
                 />
               )}
+              {activePanel === "geofences" && (
+                <GeofencePanel
+                  fences={fences}
+                  onFenceToggle={onFenceToggle}
+                  onFenceDelete={onFenceDelete}
+                  alerts={alerts}
+                />
+              )}
               {activePanel === "adapter" && (
                 <AdapterDrawer
                   isOpen={true}
@@ -377,6 +454,10 @@ export default function App() {
               dispatchState={dispatch.dispatchState}
               assignments={dispatch.assignments}
               incidents={incidents.incidents}
+              fences={fences}
+              drawingActive={drawingActive}
+              onDrawComplete={onDrawComplete}
+              onDrawCancel={onDrawCancel}
             />
             <SearchBar
               selectedItem={selectedItem}
@@ -402,6 +483,23 @@ export default function App() {
               isRecording={recording.isRecording}
               onStartRecording={recording.startRecording}
               onStopRecording={recording.stopRecording}
+            />
+            {/* Draw Zone toolbar button */}
+            <button
+              type="button"
+              className={classNames(styles.drawZoneButton, {
+                [styles.drawZoneButtonActive]: drawingActive,
+              })}
+              onClick={() => setDrawingActive((v) => !v)}
+              title={drawingActive ? "Cancel drawing (Esc)" : "Draw geofence zone"}
+              aria-pressed={drawingActive}
+            >
+              {drawingActive ? "Cancel Zone" : "Draw Zone"}
+            </button>
+            <CreateZoneDialog
+              polygon={pendingPolygon}
+              onSubmit={onCreateZone}
+              onClose={() => setPendingPolygon(null)}
             />
           </div>
         </ErrorBoundary>

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -247,16 +247,13 @@ export default function App() {
     fetchFences();
   }, [fetchFences]);
 
-  const onFenceToggle = useCallback(
-    (id: string) => {
-      client.toggleGeofence(id).then((response) => {
-        if (response.data) {
-          setFences((prev) => prev.map((f) => (f.id === id ? response.data! : f)));
-        }
-      });
-    },
-    []
-  );
+  const onFenceToggle = useCallback((id: string) => {
+    client.toggleGeofence(id).then((response) => {
+      if (response.data) {
+        setFences((prev) => prev.map((f) => (f.id === id ? response.data! : f)));
+      }
+    });
+  }, []);
 
   const onFenceDelete = useCallback((id: string) => {
     client.deleteGeofence(id).then(() => {
@@ -274,17 +271,14 @@ export default function App() {
     setPendingPolygon(null);
   }, []);
 
-  const onCreateZone = useCallback(
-    (req: CreateGeoFenceRequest) => {
-      client.createGeofence(req).then((response) => {
-        if (response.data) {
-          setFences((prev) => [...prev, response.data!]);
-        }
-        setPendingPolygon(null);
-      });
-    },
-    []
-  );
+  const onCreateZone = useCallback((req: CreateGeoFenceRequest) => {
+    client.createGeofence(req).then((response) => {
+      if (response.data) {
+        setFences((prev) => [...prev, response.data!]);
+      }
+      setPendingPolygon(null);
+    });
+  }, []);
 
   useEffect(() => {
     client.onConnect(() => {

--- a/apps/ui/src/Controls/GeofencePanel.module.css
+++ b/apps/ui/src/Controls/GeofencePanel.module.css
@@ -1,0 +1,175 @@
+.body {
+  gap: var(--space-3);
+}
+
+.tabs {
+  display: flex;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+}
+
+.tab {
+  flex: 1;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-gray);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  margin-bottom: -1px;
+}
+
+.tab:hover {
+  color: var(--color-gray-lightest);
+}
+
+.tab[data-active] {
+  color: var(--color-white);
+  border-bottom-color: rgba(59, 130, 246, 0.8);
+}
+
+.alertCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 var(--space-1);
+  border-radius: 999px;
+  background: rgba(255, 179, 71, 0.15);
+  border: 1px solid rgba(255, 179, 71, 0.22);
+  color: #ffb347;
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* Zones tab */
+.fenceRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  border: var(--surface-border);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.fenceRow:hover {
+  background: var(--surface-bg-hover);
+}
+
+.typeDot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  flex-shrink: 0;
+}
+
+.typeBadge {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: capitalize;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+  min-width: 72px;
+}
+
+.fenceName {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-base);
+  color: var(--color-gray-lightest);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fenceActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+/* Alerts tab */
+.alertRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  border: var(--surface-border);
+}
+
+.eventBadge {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-xs);
+  flex-shrink: 0;
+}
+
+.eventBadge[data-event="enter"] {
+  background: rgba(34, 197, 94, 0.15);
+  color: #4ade80;
+  border: 1px solid rgba(34, 197, 94, 0.2);
+}
+
+.eventBadge[data-event="exit"] {
+  background: rgba(239, 68, 68, 0.15);
+  color: #f87171;
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.alertInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.alertVehicle {
+  font-size: var(--text-base);
+  color: var(--color-gray-lightest);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.alertZone {
+  font-size: var(--text-xs);
+  color: var(--color-gray);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.alertTime {
+  font-size: var(--text-xs);
+  color: var(--color-gray);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  flex-shrink: 0;
+}

--- a/apps/ui/src/Controls/GeofencePanel.tsx
+++ b/apps/ui/src/Controls/GeofencePanel.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import type { GeoFence, GeoFenceEvent } from "@moveet/shared-types";
+import { Switch, SquaredButton } from "@/components/Inputs";
+import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
+import styles from "./GeofencePanel.module.css";
+
+interface GeofencePanelProps {
+  fences: GeoFence[];
+  onFenceToggle: (id: string) => void;
+  onFenceDelete: (id: string) => void;
+  alerts: GeoFenceEvent[];
+}
+
+type Tab = "zones" | "alerts";
+
+function typeBadgeColor(type: GeoFence["type"]): string {
+  switch (type) {
+    case "restricted":
+      return "#ef4444";
+    case "delivery":
+      return "#22c55e";
+    case "monitoring":
+      return "#3b82f6";
+  }
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+export default function GeofencePanel({
+  fences,
+  onFenceToggle,
+  onFenceDelete,
+  alerts,
+}: GeofencePanelProps) {
+  const [tab, setTab] = useState<Tab>("zones");
+
+  return (
+    <>
+      <PanelHeader
+        title="Geofences"
+        subtitle={
+          tab === "zones"
+            ? fences.length === 0
+              ? "No zones defined. Draw a zone on the map."
+              : `${fences.length} zone${fences.length === 1 ? "" : "s"} defined`
+            : alerts.length === 0
+              ? "No geofence events yet."
+              : `${alerts.length} event${alerts.length === 1 ? "" : "s"}`
+        }
+        badge={
+          <PanelBadge tone={tab === "alerts" && alerts.length > 0 ? "warning" : "active"}>
+            {tab === "zones" ? fences.length : alerts.length}
+          </PanelBadge>
+        }
+      />
+
+      {/* Tabs */}
+      <div className={styles.tabs} role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "zones"}
+          className={styles.tab}
+          data-active={tab === "zones" ? "true" : undefined}
+          onClick={() => setTab("zones")}
+        >
+          Zones
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === "alerts"}
+          className={styles.tab}
+          data-active={tab === "alerts" ? "true" : undefined}
+          onClick={() => setTab("alerts")}
+        >
+          Alerts
+          {alerts.length > 0 && (
+            <span className={styles.alertCount}>{alerts.length > 99 ? "99+" : alerts.length}</span>
+          )}
+        </button>
+      </div>
+
+      {tab === "zones" && (
+        <PanelBody className={styles.body}>
+          {fences.length === 0 ? (
+            <PanelEmptyState>
+              No zones yet. Use the &ldquo;Draw Zone&rdquo; button to create one.
+            </PanelEmptyState>
+          ) : (
+            <div className={styles.list}>
+              {fences.map((fence) => (
+                <div key={fence.id} className={styles.fenceRow}>
+                  <span
+                    className={styles.typeDot}
+                    style={{
+                      backgroundColor: fence.color ?? typeBadgeColor(fence.type),
+                    }}
+                  />
+                  <span className={styles.typeBadge} style={{ color: fence.color ?? typeBadgeColor(fence.type) }}>
+                    {fence.type}
+                  </span>
+                  <span className={styles.fenceName}>{fence.name}</span>
+                  <div className={styles.fenceActions}>
+                    <Switch
+                      isSelected={fence.active}
+                      onChange={() => onFenceToggle(fence.id)}
+                      aria-label={fence.active ? `Deactivate ${fence.name}` : `Activate ${fence.name}`}
+                    />
+                    <SquaredButton
+                      icon={<span aria-hidden="true">×</span>}
+                      variant="ghost"
+                      tone="danger"
+                      aria-label={`Delete ${fence.name}`}
+                      title={`Delete ${fence.name}`}
+                      onClick={() => onFenceDelete(fence.id)}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </PanelBody>
+      )}
+
+      {tab === "alerts" && (
+        <PanelBody className={styles.body}>
+          {alerts.length === 0 ? (
+            <PanelEmptyState>No events yet. Events appear when vehicles cross zone boundaries.</PanelEmptyState>
+          ) : (
+            <div className={styles.list}>
+              {alerts.map((alert, i) => (
+                <div key={`${alert.fenceId}-${alert.vehicleId}-${alert.timestamp}-${i}`} className={styles.alertRow}>
+                  <span
+                    className={styles.eventBadge}
+                    data-event={alert.event}
+                  >
+                    {alert.event}
+                  </span>
+                  <div className={styles.alertInfo}>
+                    <span className={styles.alertVehicle}>{alert.vehicleName}</span>
+                    <span className={styles.alertZone}>{alert.fenceName}</span>
+                  </div>
+                  <span className={styles.alertTime}>{formatTimestamp(alert.timestamp)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </PanelBody>
+      )}
+    </>
+  );
+}

--- a/apps/ui/src/Controls/GeofencePanel.tsx
+++ b/apps/ui/src/Controls/GeofencePanel.tsx
@@ -27,7 +27,11 @@ function typeBadgeColor(type: GeoFence["type"]): string {
 function formatTimestamp(iso: string): string {
   try {
     const d = new Date(iso);
-    return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    return d.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
   } catch {
     return iso;
   }
@@ -104,7 +108,10 @@ export default function GeofencePanel({
                       backgroundColor: fence.color ?? typeBadgeColor(fence.type),
                     }}
                   />
-                  <span className={styles.typeBadge} style={{ color: fence.color ?? typeBadgeColor(fence.type) }}>
+                  <span
+                    className={styles.typeBadge}
+                    style={{ color: fence.color ?? typeBadgeColor(fence.type) }}
+                  >
                     {fence.type}
                   </span>
                   <span className={styles.fenceName}>{fence.name}</span>
@@ -112,7 +119,9 @@ export default function GeofencePanel({
                     <Switch
                       isSelected={fence.active}
                       onChange={() => onFenceToggle(fence.id)}
-                      aria-label={fence.active ? `Deactivate ${fence.name}` : `Activate ${fence.name}`}
+                      aria-label={
+                        fence.active ? `Deactivate ${fence.name}` : `Activate ${fence.name}`
+                      }
                     />
                     <SquaredButton
                       icon={<span aria-hidden="true">×</span>}
@@ -133,15 +142,17 @@ export default function GeofencePanel({
       {tab === "alerts" && (
         <PanelBody className={styles.body}>
           {alerts.length === 0 ? (
-            <PanelEmptyState>No events yet. Events appear when vehicles cross zone boundaries.</PanelEmptyState>
+            <PanelEmptyState>
+              No events yet. Events appear when vehicles cross zone boundaries.
+            </PanelEmptyState>
           ) : (
             <div className={styles.list}>
               {alerts.map((alert, i) => (
-                <div key={`${alert.fenceId}-${alert.vehicleId}-${alert.timestamp}-${i}`} className={styles.alertRow}>
-                  <span
-                    className={styles.eventBadge}
-                    data-event={alert.event}
-                  >
+                <div
+                  key={`${alert.fenceId}-${alert.vehicleId}-${alert.timestamp}-${i}`}
+                  className={styles.alertRow}
+                >
+                  <span className={styles.eventBadge} data-event={alert.event}>
                     {alert.event}
                   </span>
                   <div className={styles.alertInfo}>

--- a/apps/ui/src/Controls/IconRail.test.tsx
+++ b/apps/ui/src/Controls/IconRail.test.tsx
@@ -7,7 +7,7 @@ describe("IconRail", () => {
     render(<IconRail activePanel={null} onPanelChange={() => {}} />);
 
     const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(9);
+    expect(buttons).toHaveLength(10);
 
     expect(screen.getByLabelText("Vehicles")).toBeInTheDocument();
     expect(screen.getByLabelText("Fleets")).toBeInTheDocument();
@@ -17,6 +17,7 @@ describe("IconRail", () => {
     expect(screen.getByLabelText("Speed")).toBeInTheDocument();
     expect(screen.getByLabelText("Analytics")).toBeInTheDocument();
     expect(screen.getByLabelText("Adapter")).toBeInTheDocument();
+    expect(screen.getByLabelText("Geofences")).toBeInTheDocument();
   });
 
   it("calls onPanelChange with panel id when clicking inactive button", async () => {

--- a/apps/ui/src/Controls/IconRail.tsx
+++ b/apps/ui/src/Controls/IconRail.tsx
@@ -9,6 +9,7 @@ import {
   Gear,
   ClockIcon,
   ChartIcon,
+  GeofenceIcon,
 } from "@/components/Icons";
 import styles from "./IconRail.module.css";
 
@@ -21,7 +22,8 @@ export type PanelId =
   | "speed"
   | "clock"
   | "analytics"
-  | "adapter";
+  | "adapter"
+  | "geofences";
 
 interface IconRailProps {
   activePanel: PanelId | null;
@@ -33,6 +35,7 @@ const topItems: { id: PanelId; Icon: React.FC<React.SVGProps<SVGSVGElement>>; la
   { id: "vehicles", Icon: CarIcon, label: "Vehicles" },
   { id: "fleets", Icon: LayersIcon, label: "Fleets" },
   { id: "incidents", Icon: AlertIcon, label: "Incidents" },
+  { id: "geofences", Icon: GeofenceIcon, label: "Geofences" },
   { id: "recordings", Icon: RecordCircleIcon, label: "Recordings" },
   { id: "toggles", Icon: EyeIcon, label: "Visibility" },
   { id: "speed", Icon: GaugeIcon, label: "Speed" },

--- a/apps/ui/src/Map/Geofence/CreateZoneDialog.module.css
+++ b/apps/ui/src/Map/Geofence/CreateZoneDialog.module.css
@@ -1,0 +1,205 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.dialog {
+  width: clamp(280px, 90vw, 360px);
+  background: var(--panel-surface, #1a1d23);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-lg, 8px);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.5),
+    0 1px 0 rgba(255, 255, 255, 0.06) inset;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4, 12px) var(--space-5, 16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--panel-header-bg, rgba(255, 255, 255, 0.03));
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-lg, 15px);
+  font-weight: 600;
+  color: var(--color-white, #fff);
+}
+
+.closeButton {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--color-gray, #888);
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm, 4px);
+  transition: color var(--transition-fast, 150ms ease);
+}
+
+.closeButton:hover {
+  color: var(--color-white, #fff);
+}
+
+.form {
+  padding: var(--space-4, 12px) var(--space-5, 16px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 12px);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 4px);
+}
+
+.label {
+  font-size: var(--text-sm, 13px);
+  color: var(--color-text-secondary, #aaa);
+}
+
+.required {
+  color: rgb(239, 68, 68);
+}
+
+.optional {
+  color: var(--color-gray, #888);
+  font-size: var(--text-xs, 11px);
+}
+
+.input,
+.select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 var(--space-4, 12px);
+  height: var(--control-sm, 32px);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--text-base, 13px);
+  color: var(--color-gray-lightest, #e0e0e0);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: inherit;
+  transition:
+    background var(--transition-fast, 150ms ease),
+    border-color var(--transition-fast, 150ms ease);
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: var(--focus-border, rgba(59, 130, 246, 0.6));
+  background: var(--focus-bg, rgba(59, 130, 246, 0.08));
+  box-shadow: var(--focus-ring, 0 0 0 2px rgba(59, 130, 246, 0.2));
+}
+
+.select option {
+  background: #1a1d23;
+  color: #e0e0e0;
+}
+
+.colorRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3, 8px);
+}
+
+.colorPicker {
+  width: 36px;
+  height: 32px;
+  padding: 2px;
+  border-radius: var(--radius-sm, 4px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+}
+
+.clearColor {
+  font-size: var(--text-xs, 11px);
+  color: var(--color-gray, #888);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.clearColor:hover {
+  color: var(--color-gray-light, #aaa);
+}
+
+.meta {
+  font-size: var(--text-xs, 11px);
+  color: var(--color-gray, #888);
+}
+
+.vertexCount::before {
+  content: "Polygon: ";
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-3, 8px);
+  justify-content: flex-end;
+  padding-top: var(--space-2, 8px);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.cancelButton {
+  padding: 0 var(--space-4, 12px);
+  height: var(--control, 36px);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--text-base, 13px);
+  color: var(--color-gray-light, #aaa);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast, 150ms ease),
+    color var(--transition-fast, 150ms ease);
+  font-family: inherit;
+}
+
+.cancelButton:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-white, #fff);
+}
+
+.submitButton {
+  padding: 0 var(--space-4, 12px);
+  height: var(--control, 36px);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--text-base, 13px);
+  font-weight: 500;
+  color: #fff;
+  background: rgba(59, 130, 246, 0.8);
+  border: 1px solid rgba(59, 130, 246, 0.5);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast, 150ms ease),
+    opacity var(--transition-fast, 150ms ease);
+  font-family: inherit;
+}
+
+.submitButton:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 1);
+}
+
+.submitButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/apps/ui/src/Map/Geofence/CreateZoneDialog.tsx
+++ b/apps/ui/src/Map/Geofence/CreateZoneDialog.tsx
@@ -34,7 +34,12 @@ export default function CreateZoneDialog({ polygon, onSubmit, onClose }: CreateZ
   };
 
   return (
-    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Create geofence zone">
+    <div
+      className={styles.overlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create geofence zone"
+    >
       <div className={styles.dialog}>
         <div className={styles.header}>
           <h2 className={styles.title}>Create Zone</h2>
@@ -88,11 +93,7 @@ export default function CreateZoneDialog({ polygon, onSubmit, onClose }: CreateZ
                 onChange={(e) => setColor(e.target.value)}
               />
               {color && (
-                <button
-                  type="button"
-                  className={styles.clearColor}
-                  onClick={() => setColor("")}
-                >
+                <button type="button" className={styles.clearColor} onClick={() => setColor("")}>
                   Use default
                 </button>
               )}

--- a/apps/ui/src/Map/Geofence/CreateZoneDialog.tsx
+++ b/apps/ui/src/Map/Geofence/CreateZoneDialog.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import type { CreateGeoFenceRequest, GeoFenceType } from "@moveet/shared-types";
+import styles from "./CreateZoneDialog.module.css";
+
+interface CreateZoneDialogProps {
+  polygon: [number, number][] | null;
+  onSubmit: (req: CreateGeoFenceRequest) => void;
+  onClose: () => void;
+}
+
+const FENCE_TYPES: GeoFenceType[] = ["restricted", "delivery", "monitoring"];
+
+export default function CreateZoneDialog({ polygon, onSubmit, onClose }: CreateZoneDialogProps) {
+  const [name, setName] = useState("");
+  const [type, setType] = useState<GeoFenceType>("monitoring");
+  const [color, setColor] = useState("");
+
+  if (polygon === null) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    const req: CreateGeoFenceRequest = {
+      name: name.trim(),
+      type,
+      polygon,
+      ...(color ? { color } : {}),
+    };
+    onSubmit(req);
+    setName("");
+    setType("monitoring");
+    setColor("");
+  };
+
+  return (
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-label="Create geofence zone">
+      <div className={styles.dialog}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>Create Zone</h2>
+          <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="zone-name">
+              Name <span className={styles.required}>*</span>
+            </label>
+            <input
+              id="zone-name"
+              type="text"
+              className={styles.input}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Zone name"
+              required
+              autoFocus
+            />
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="zone-type">
+              Type
+            </label>
+            <select
+              id="zone-type"
+              className={styles.select}
+              value={type}
+              onChange={(e) => setType(e.target.value as GeoFenceType)}
+            >
+              {FENCE_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="zone-color">
+              Color <span className={styles.optional}>(optional)</span>
+            </label>
+            <div className={styles.colorRow}>
+              <input
+                id="zone-color"
+                type="color"
+                className={styles.colorPicker}
+                value={color || "#3b82f6"}
+                onChange={(e) => setColor(e.target.value)}
+              />
+              {color && (
+                <button
+                  type="button"
+                  className={styles.clearColor}
+                  onClick={() => setColor("")}
+                >
+                  Use default
+                </button>
+              )}
+            </div>
+          </div>
+          <div className={styles.meta}>
+            <span className={styles.vertexCount}>{polygon.length} vertices</span>
+          </div>
+          <div className={styles.actions}>
+            <button type="button" className={styles.cancelButton} onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className={styles.submitButton} disabled={!name.trim()}>
+              Create Zone
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
@@ -8,11 +8,7 @@ interface GeofenceDrawToolProps {
   onCancel: () => void;
 }
 
-export default function GeofenceDrawTool({
-  active,
-  onComplete,
-  onCancel,
-}: GeofenceDrawToolProps) {
+export default function GeofenceDrawTool({ active, onComplete, onCancel }: GeofenceDrawToolProps) {
   const { map: svgRef, projection, transform } = useMapContext();
 
   // Vertices in SVG display space
@@ -43,10 +39,7 @@ export default function GeofenceDrawTool({
     // Draw polygon preview (filled) if >= 3 points
     if (verts.length >= 3) {
       const polygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-      polygon.setAttribute(
-        "points",
-        verts.map(([x, y]) => `${x},${y}`).join(" ")
-      );
+      polygon.setAttribute("points", verts.map(([x, y]) => `${x},${y}`).join(" "));
       polygon.setAttribute("fill", "rgba(59,130,246,0.15)");
       polygon.setAttribute("stroke", "rgb(59,130,246)");
       polygon.setAttribute("stroke-width", "1");

--- a/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useRef, useCallback } from "react";
+import { pointer } from "d3";
+import { useMapContext } from "@/components/Map/hooks";
+
+interface GeofenceDrawToolProps {
+  active: boolean;
+  onComplete: (polygon: [number, number][]) => void;
+  onCancel: () => void;
+}
+
+export default function GeofenceDrawTool({
+  active,
+  onComplete,
+  onCancel,
+}: GeofenceDrawToolProps) {
+  const { map: svgRef, projection, transform } = useMapContext();
+
+  // Vertices in SVG display space
+  const svgVertices = useRef<[number, number][]>([]);
+  // Vertices in geo space [lng, lat]
+  const geoVertices = useRef<[number, number][]>([]);
+  // Cursor position in SVG display space
+  const cursorSvg = useRef<[number, number] | null>(null);
+
+  // The <g> element we render into
+  const gRef = useRef<SVGGElement | null>(null);
+
+  const projectionRef = useRef(projection);
+  projectionRef.current = projection;
+  const transformRef = useRef(transform);
+  transformRef.current = transform;
+
+  const redraw = useCallback(() => {
+    const g = gRef.current;
+    if (!g) return;
+    g.innerHTML = "";
+
+    const verts = svgVertices.current;
+    const cursor = cursorSvg.current;
+
+    if (verts.length === 0) return;
+
+    // Draw polygon preview (filled) if >= 3 points
+    if (verts.length >= 3) {
+      const polygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+      polygon.setAttribute(
+        "points",
+        verts.map(([x, y]) => `${x},${y}`).join(" ")
+      );
+      polygon.setAttribute("fill", "rgba(59,130,246,0.15)");
+      polygon.setAttribute("stroke", "rgb(59,130,246)");
+      polygon.setAttribute("stroke-width", "1");
+      polygon.setAttribute("stroke-dasharray", "4 3");
+      g.appendChild(polygon);
+    } else if (verts.length === 2) {
+      const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      line.setAttribute("x1", String(verts[0][0]));
+      line.setAttribute("y1", String(verts[0][1]));
+      line.setAttribute("x2", String(verts[1][0]));
+      line.setAttribute("y2", String(verts[1][1]));
+      line.setAttribute("stroke", "rgb(59,130,246)");
+      line.setAttribute("stroke-width", "1");
+      g.appendChild(line);
+    }
+
+    // Preview dashed line from last vertex to cursor
+    if (cursor && verts.length >= 1) {
+      const last = verts[verts.length - 1];
+      const preview = document.createElementNS("http://www.w3.org/2000/svg", "line");
+      preview.setAttribute("x1", String(last[0]));
+      preview.setAttribute("y1", String(last[1]));
+      preview.setAttribute("x2", String(cursor[0]));
+      preview.setAttribute("y2", String(cursor[1]));
+      preview.setAttribute("stroke", "rgb(59,130,246)");
+      preview.setAttribute("stroke-width", "1");
+      preview.setAttribute("stroke-dasharray", "4 3");
+      preview.setAttribute("opacity", "0.7");
+      g.appendChild(preview);
+    }
+
+    // Draw vertex dots
+    for (const [x, y] of verts) {
+      const circle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      circle.setAttribute("cx", String(x));
+      circle.setAttribute("cy", String(y));
+      circle.setAttribute("r", "4");
+      circle.setAttribute("fill", "rgb(59,130,246)");
+      circle.setAttribute("stroke", "#fff");
+      circle.setAttribute("stroke-width", "1");
+      g.appendChild(circle);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!active || !svgRef) return;
+
+    // Create overlay <g>
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    g.setAttribute("data-layer", "geofence-draw");
+    g.style.pointerEvents = "none";
+
+    // Insert inside the markers group so it participates in zoom transforms
+    const markersGroup = svgRef.querySelector("g.markers");
+    if (markersGroup) {
+      markersGroup.appendChild(g);
+    } else {
+      svgRef.appendChild(g);
+    }
+    gRef.current = g;
+    svgVertices.current = [];
+    geoVertices.current = [];
+    cursorSvg.current = null;
+
+    const handleClick = (e: MouseEvent) => {
+      if (e.button !== 0) return;
+      e.stopPropagation();
+
+      const proj = projectionRef.current;
+      const t = transformRef.current;
+      if (!proj) return;
+
+      const [rawX, rawY] = pointer(e, svgRef);
+      // Convert raw SVG pointer to map-space, then invert to geo coords
+      const [mx, my] = t ? t.invert([rawX, rawY]) : [rawX, rawY];
+      const coords = proj.invert?.([mx, my]);
+      if (!coords) return;
+
+      // Store SVG display position for rendering vertices
+      const svgPt: [number, number] = t ? [t.applyX(mx), t.applyY(my)] : [mx, my];
+      svgVertices.current = [...svgVertices.current, svgPt];
+      geoVertices.current = [...geoVertices.current, coords as [number, number]];
+      redraw();
+    };
+
+    const handleDblClick = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (geoVertices.current.length < 3) return;
+
+      const polygon = [...geoVertices.current];
+      svgVertices.current = [];
+      geoVertices.current = [];
+      cursorSvg.current = null;
+      g.innerHTML = "";
+
+      onComplete(polygon);
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const t = transformRef.current;
+      const [rawX, rawY] = pointer(e, svgRef);
+      if (t) {
+        const [mx, my] = t.invert([rawX, rawY]);
+        cursorSvg.current = [t.applyX(mx), t.applyY(my)];
+      } else {
+        cursorSvg.current = [rawX, rawY];
+      }
+      redraw();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        svgVertices.current = [];
+        geoVertices.current = [];
+        cursorSvg.current = null;
+        g.innerHTML = "";
+        onCancel();
+      }
+    };
+
+    svgRef.addEventListener("click", handleClick);
+    svgRef.addEventListener("dblclick", handleDblClick);
+    svgRef.addEventListener("mousemove", handleMouseMove);
+    svgRef.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      svgRef.removeEventListener("click", handleClick);
+      svgRef.removeEventListener("dblclick", handleDblClick);
+      svgRef.removeEventListener("mousemove", handleMouseMove);
+      svgRef.removeEventListener("keydown", handleKeyDown);
+      g.remove();
+      gRef.current = null;
+      svgVertices.current = [];
+      geoVertices.current = [];
+      cursorSvg.current = null;
+    };
+  }, [active, svgRef, redraw, onComplete, onCancel]);
+
+  // Renders nothing into React's tree — SVG is managed via DOM
+  return null;
+}

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+import type { GeoFence, GeoFenceType } from "@moveet/shared-types";
+import { useMapContext } from "@/components/Map/hooks";
+
+// Default colors per type
+const TYPE_FILL: Record<GeoFenceType, string> = {
+  restricted: "rgba(239,68,68,0.25)",
+  delivery: "rgba(34,197,94,0.25)",
+  monitoring: "rgba(59,130,246,0.25)",
+};
+
+const TYPE_STROKE: Record<GeoFenceType, string> = {
+  restricted: "rgb(239,68,68)",
+  delivery: "rgb(34,197,94)",
+  monitoring: "rgb(59,130,246)",
+};
+
+function hexToRgba(hex: string, alpha: number): string {
+  const clean = hex.replace("#", "");
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+function getFill(fence: GeoFence): string {
+  if (fence.color) return hexToRgba(fence.color, 0.25);
+  return TYPE_FILL[fence.type];
+}
+
+function getStroke(fence: GeoFence): string {
+  if (fence.color) return fence.color;
+  return TYPE_STROKE[fence.type];
+}
+
+function polygonToPath(points: [number, number][]): string {
+  if (points.length === 0) return "";
+  return (
+    points.map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x} ${y}`).join(" ") + " Z"
+  );
+}
+
+function centroid(points: [number, number][]): [number, number] {
+  const x = points.reduce((sum, p) => sum + p[0], 0) / points.length;
+  const y = points.reduce((sum, p) => sum + p[1], 0) / points.length;
+  return [x, y];
+}
+
+interface GeofenceLayerProps {
+  fences: GeoFence[];
+  selectedFenceId?: string;
+}
+
+export default function GeofenceLayer({ fences, selectedFenceId }: GeofenceLayerProps) {
+  const { projection } = useMapContext();
+
+  const projected = useMemo(() => {
+    if (!projection) return [];
+    return fences.map((fence) => {
+      const pts = fence.polygon
+        .map((coord) => projection(coord))
+        .filter((p): p is [number, number] => p !== null && isFinite(p[0]) && isFinite(p[1]));
+      return { fence, pts };
+    });
+  }, [fences, projection]);
+
+  if (!projection) return null;
+
+  return (
+    <>
+      {projected.map(({ fence, pts }) => {
+        if (pts.length < 3) return null;
+        const isSelected = fence.id === selectedFenceId;
+        const fill = getFill(fence);
+        const stroke = getStroke(fence);
+        const strokeWidth = isSelected ? 2 : 1;
+        const d = polygonToPath(pts);
+        const [cx, cy] = centroid(pts);
+
+        return (
+          <g key={fence.id} data-fence-id={fence.id} opacity={fence.active ? 1 : 0.4}>
+            <path
+              d={d}
+              fill={fill}
+              stroke={stroke}
+              strokeWidth={strokeWidth}
+              strokeLinejoin="round"
+            />
+            <text
+              x={cx}
+              y={cy}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={11}
+              fill={stroke}
+              stroke="rgba(0,0,0,0.6)"
+              strokeWidth={3}
+              paintOrder="stroke"
+              pointerEvents="none"
+            >
+              {fence.name}
+            </text>
+          </g>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
@@ -35,9 +35,7 @@ function getStroke(fence: GeoFence): string {
 
 function polygonToPath(points: [number, number][]): string {
   if (points.length === 0) return "";
-  return (
-    points.map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x} ${y}`).join(" ") + " Z"
-  );
+  return points.map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x} ${y}`).join(" ") + " Z";
 }
 
 function centroid(points: [number, number][]): [number, number] {

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -101,9 +101,7 @@ export default function Map({
       >
         {/* <Selection /> */}
         {/* Geofence zones — rendered between roads and vehicles */}
-        {fences.length > 0 && (
-          <GeofenceLayer fences={fences} selectedFenceId={selectedFenceId} />
-        )}
+        {fences.length > 0 && <GeofenceLayer fences={fences} selectedFenceId={selectedFenceId} />}
         <Direction selected={filters.selected} hovered={filters.hovered} />
         {modifiers.showBreadcrumbs && (
           <Suspense fallback={null}>

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -9,6 +9,7 @@ import type {
   Road,
   Vehicle,
 } from "@/types";
+import type { GeoFence } from "@moveet/shared-types";
 import type { Filters } from "@/hooks/useVehicles";
 import { type DispatchState, cursorForDispatchState } from "@/hooks/useDispatchState";
 
@@ -21,6 +22,8 @@ import PendingDispatch from "./PendingDispatch";
 import IncidentMarkers from "./IncidentMarkers";
 import { isPOI, isRoad } from "@/utils/typeGuards";
 import POIMarker from "./POI/POI";
+import GeofenceLayer from "./Geofence/GeofenceLayer";
+import GeofenceDrawTool from "./Geofence/GeofenceDrawTool";
 
 const Heatmap = lazy(() => import("./Heatmap"));
 const POIs = lazy(() => import("./POIs"));
@@ -42,6 +45,11 @@ interface MapProps {
   dispatchState?: DispatchState;
   assignments?: DispatchAssignment[];
   incidents?: IncidentDTO[];
+  fences?: GeoFence[];
+  selectedFenceId?: string;
+  drawingActive?: boolean;
+  onDrawComplete?: (polygon: [number, number][]) => void;
+  onDrawCancel?: () => void;
 }
 
 export default function Map({
@@ -58,6 +66,11 @@ export default function Map({
   dispatchState,
   assignments = [],
   incidents,
+  fences = [],
+  selectedFenceId,
+  drawingActive = false,
+  onDrawComplete,
+  onDrawCancel,
 }: MapProps) {
   const network = useNetwork();
 
@@ -87,6 +100,10 @@ export default function Map({
         }
       >
         {/* <Selection /> */}
+        {/* Geofence zones — rendered between roads and vehicles */}
+        {fences.length > 0 && (
+          <GeofenceLayer fences={fences} selectedFenceId={selectedFenceId} />
+        )}
         <Direction selected={filters.selected} hovered={filters.hovered} />
         {modifiers.showBreadcrumbs && (
           <Suspense fallback={null}>
@@ -128,6 +145,11 @@ export default function Map({
         {assignments.length > 0 && (
           <PendingDispatch assignments={assignments} vehicles={vehicles} />
         )}
+        <GeofenceDrawTool
+          active={drawingActive}
+          onComplete={onDrawComplete ?? (() => {})}
+          onCancel={onDrawCancel ?? (() => {})}
+        />
       </RoadNetworkMap>
     </>
   );

--- a/apps/ui/src/components/Icons.tsx
+++ b/apps/ui/src/components/Icons.tsx
@@ -307,7 +307,15 @@ export function ChartIcon(props: SVGProps) {
 
 export function GeofenceIcon(props: SVGProps) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
       <path d="M12 2L2 7l10 5 10-5-10-5z" />
       <path d="M2 17l10 5 10-5" />
       <path d="M2 12l10 5 10-5" />

--- a/apps/ui/src/components/Icons.tsx
+++ b/apps/ui/src/components/Icons.tsx
@@ -305,6 +305,16 @@ export function ChartIcon(props: SVGProps) {
   );
 }
 
+export function GeofenceIcon(props: SVGProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M12 2L2 7l10 5 10-5-10-5z" />
+      <path d="M2 17l10 5 10-5" />
+      <path d="M2 12l10 5 10-5" />
+    </svg>
+  );
+}
+
 export function ClockIcon(props: SVGProps) {
   return (
     <svg

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -30,6 +30,12 @@ import type {
   IncidentClearedPayload,
   VehicleReroutedPayload,
 } from "./wsTypes";
+import type {
+  GeoFence,
+  GeoFenceEvent,
+  CreateGeoFenceRequest,
+  UpdateGeoFenceRequest,
+} from "@moveet/shared-types";
 
 class SimulationService {
   constructor(
@@ -104,6 +110,14 @@ class SimulationService {
     this.resetAnalytics = this.resetAnalytics.bind(this);
     // connection state
     this.onConnectionStateChange = this.onConnectionStateChange.bind(this);
+    // geofences
+    this.getGeofences = this.getGeofences.bind(this);
+    this.createGeofence = this.createGeofence.bind(this);
+    this.updateGeofence = this.updateGeofence.bind(this);
+    this.deleteGeofence = this.deleteGeofence.bind(this);
+    this.toggleGeofence = this.toggleGeofence.bind(this);
+    this.onGeofenceEvent = this.onGeofenceEvent.bind(this);
+    this.offGeofenceEvent = this.offGeofenceEvent.bind(this);
   }
 
   connectWebSocket(): void {
@@ -401,6 +415,36 @@ class SimulationService {
 
   async resetAnalytics(): Promise<ApiResponse<{ ok: true }>> {
     return this.http.post<undefined, { ok: true }>("/analytics/reset");
+  }
+
+  // ─── Geofences ────────────────────────────────────────────────────
+
+  async getGeofences(): Promise<ApiResponse<GeoFence[]>> {
+    return this.http.get<GeoFence[]>("/geofences");
+  }
+
+  async createGeofence(req: CreateGeoFenceRequest): Promise<ApiResponse<GeoFence>> {
+    return this.http.post<CreateGeoFenceRequest, GeoFence>("/geofences", req);
+  }
+
+  async updateGeofence(id: string, req: UpdateGeoFenceRequest): Promise<ApiResponse<GeoFence>> {
+    return this.http.patch<UpdateGeoFenceRequest, GeoFence>(`/geofences/${id}`, req);
+  }
+
+  async deleteGeofence(id: string): Promise<ApiResponse<void>> {
+    return this.http.delete(`/geofences/${id}`);
+  }
+
+  async toggleGeofence(id: string): Promise<ApiResponse<GeoFence>> {
+    return this.http.post<undefined, GeoFence>(`/geofences/${id}/toggle`);
+  }
+
+  onGeofenceEvent(handler: (event: GeoFenceEvent) => void): void {
+    this.ws.on("geofence-event", handler);
+  }
+
+  offGeofenceEvent(): void {
+    this.ws.off("geofence-event");
   }
 }
 

--- a/apps/ui/src/utils/httpClient.ts
+++ b/apps/ui/src/utils/httpClient.ts
@@ -42,4 +42,20 @@ export class HttpClient {
       return { data: undefined, error: errorMessage };
     }
   }
+
+  async patch<TBody, TReturn = void>(path: string, body?: TBody): Promise<ApiResponse<TReturn>> {
+    try {
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) throw new Error(`PATCH ${path} failed with status ${res.status}`);
+      const data = await res.json();
+      return { data };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return { data: undefined, error: errorMessage };
+    }
+  }
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -202,6 +202,46 @@ export interface AnalyticsSnapshot {
   timestamp: number;
 }
 
+// ─── Geofencing ─────────────────────────────────────────────────────
+
+export type GeoFenceType = "restricted" | "delivery" | "monitoring";
+
+export interface GeoFence {
+  id: string;
+  name: string;
+  type: GeoFenceType;
+  /** Array of [longitude, latitude] coordinate pairs forming a closed polygon. */
+  polygon: [number, number][];
+  color?: string;
+  active: boolean;
+}
+
+export interface GeoFenceEvent {
+  type: "geofence-event";
+  fenceId: string;
+  fenceName: string;
+  vehicleId: string;
+  vehicleName: string;
+  event: "enter" | "exit";
+  timestamp: string; // ISO date string
+}
+
+// REST CRUD types
+export interface CreateGeoFenceRequest {
+  name: string;
+  type: GeoFenceType;
+  polygon: [number, number][];
+  color?: string;
+}
+
+export interface UpdateGeoFenceRequest {
+  name?: string;
+  type?: GeoFenceType;
+  polygon?: [number, number][];
+  color?: string;
+  active?: boolean;
+}
+
 // ─── Recording & Replay ────────────────────────────────────────────
 
 export interface RecordingMetadata {


### PR DESCRIPTION
## Summary

- **Shared types**: `GeoFence`, `GeoFenceEvent`, `CreateGeoFenceRequest`, `UpdateGeoFenceRequest` added to `@moveet/shared-types`
- **Simulator — `GeoFenceManager`**: in-memory zone store with ray-casting point-in-polygon, per-vehicle membership tracking, enter/exit event emission via `EventEmitter`
- **Simulator — REST API**: full CRUD at `/geofences` (`POST`, `GET`, `PUT`, `DELETE`, `PATCH /:id/toggle`), zones wired into simulation tick, events broadcast over WebSocket
- **UI — `GeofenceLayer`**: D3 SVG polygon layer between roads and vehicles; color-coded by type (red/green/blue), semi-transparent fill, name labels at centroid, selected-zone highlight
- **UI — `GeofenceDrawTool`**: DOM-imperative drawing mode; click to place vertices, double-click to close, Escape to cancel; live preview polygon follows cursor
- **UI — `CreateZoneDialog`**: modal to name and type a drawn zone before POSTing to simulator
- **UI — `GeofencePanel`**: sidebar panel with Zones tab (toggle/delete) and Alerts tab (chronological WebSocket enter/exit log, capped at 200)

## Test plan

- [ ] Simulator: `npm test` in `apps/simulator/` — 989 tests, 48 files, all green
- [ ] UI: TypeScript compiles without errors (`npx tsc --noEmit` in `apps/ui/`)
- [ ] Manual: start simulator + UI, draw a polygon zone on the map, drive vehicles through it, observe enter/exit alerts in GeofencePanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)