### PR TITLE
feat: add lint-staged pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npm run type-check
+npx --no lint-staged

--- a/README.md
+++ b/README.md
@@ -30,24 +30,24 @@ A real-time vehicle fleet simulator that runs vehicles on actual road networks w
 
 ## Features
 
-| | |
-|---|---|
-| 🗺 **Road-network agnostic** | Ingests any GeoJSON/OSM-derived road graph — swap the file to simulate a different city |
-| 🌐 **Network CLI** | `apps/network` pipeline: download OSM data from Geofabrik, extract a bbox, filter road classes, export GeoJSON, validate topology, and diff versions — one `prepare` command does it all |
-| 🔀 **A\* pathfinding** | Haversine heuristic over bidirectional road segments; respects turn restrictions, roundabouts, and road-class access rules; incident-aware route cache |
-| 🚗 **Vehicle types** | Five types (car, truck, motorcycle, ambulance, bus) with distinct speed profiles, acceleration curves, road restrictions, and special behaviours (e.g. ambulances ignore heat-zone penalties) |
-| 🚦 **Traffic realism** | BPR congestion model (flow/capacity), time-of-day rush-hour/night demand multipliers, traffic-signal intersection delays, surface-smoothness speed factors |
-| 🎨 **Custom map renderer** | D3 SVG scene with a Mercator projection (1×–15× zoom, pan); dedicated layers for roads, vehicles, POIs, heat-zone contours, incident markers, geofences, breadcrumb trails, and dispatch routes — no Leaflet or Mapbox |
-| 📡 **Real-time WebSocket** | 100 ms batched broadcast with backpressure handling; streams vehicle positions, routes, heat zones, incidents, geofence events, fleet events, and replay frames |
-| 🔥 **Heat zones** | Contour density map (green → red, 50 thresholds) derived from road-network intersection density |
-| 🔲 **Geofencing** | Draw custom polygons on the map; monitor vehicles crossing zone boundaries; enter/exit events broadcast in real time |
-| ⚠️ **Incidents & rerouting** | Operator-created road incidents trigger live A\* rerouting for all affected vehicles |
-| 🎬 **Recording & replay** | NDJSON session recording; replay with pause, seek, and 1×/2×/4× speed controls and interpolated progress bar |
-| 🚘 **Breadcrumb trails** | Per-vehicle position history rendered as fading path overlays on the map |
-| 🚦 **Fleet management** | Group vehicles into named, colour-coded fleets; assign/unassign at runtime |
-| 🔍 **POI + road search** | Typeahead combining road names and points of interest; dispatches selected vehicles to result |
-| 🖥 **Operator UI** | Icon-rail sidebar (Vehicles · Fleets · Incidents · Geofences · Recordings · Visibility · Speed · Adapter) + bottom dock with live and replay controls |
-| 🔌 **Adapter plugins** | Hot-swappable source and sink plugins; configure via env vars or REST API at runtime |
+|                              |                                                                                                                                                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🗺 **Road-network agnostic** | Ingests any GeoJSON/OSM-derived road graph — swap the file to simulate a different city                                                                                                                                |
+| 🌐 **Network CLI**           | `apps/network` pipeline: download OSM data from Geofabrik, extract a bbox, filter road classes, export GeoJSON, validate topology, and diff versions — one `prepare` command does it all                               |
+| 🔀 **A\* pathfinding**       | Haversine heuristic over bidirectional road segments; respects turn restrictions, roundabouts, and road-class access rules; incident-aware route cache                                                                 |
+| 🚗 **Vehicle types**         | Five types (car, truck, motorcycle, ambulance, bus) with distinct speed profiles, acceleration curves, road restrictions, and special behaviours (e.g. ambulances ignore heat-zone penalties)                          |
+| 🚦 **Traffic realism**       | BPR congestion model (flow/capacity), time-of-day rush-hour/night demand multipliers, traffic-signal intersection delays, surface-smoothness speed factors                                                             |
+| 🎨 **Custom map renderer**   | D3 SVG scene with a Mercator projection (1×–15× zoom, pan); dedicated layers for roads, vehicles, POIs, heat-zone contours, incident markers, geofences, breadcrumb trails, and dispatch routes — no Leaflet or Mapbox |
+| 📡 **Real-time WebSocket**   | 100 ms batched broadcast with backpressure handling; streams vehicle positions, routes, heat zones, incidents, geofence events, fleet events, and replay frames                                                        |
+| 🔥 **Heat zones**            | Contour density map (green → red, 50 thresholds) derived from road-network intersection density                                                                                                                        |
+| 🔲 **Geofencing**            | Draw custom polygons on the map; monitor vehicles crossing zone boundaries; enter/exit events broadcast in real time                                                                                                   |
+| ⚠️ **Incidents & rerouting** | Operator-created road incidents trigger live A\* rerouting for all affected vehicles                                                                                                                                   |
+| 🎬 **Recording & replay**    | NDJSON session recording; replay with pause, seek, and 1×/2×/4× speed controls and interpolated progress bar                                                                                                           |
+| 🚘 **Breadcrumb trails**     | Per-vehicle position history rendered as fading path overlays on the map                                                                                                                                               |
+| 🚦 **Fleet management**      | Group vehicles into named, colour-coded fleets; assign/unassign at runtime                                                                                                                                             |
+| 🔍 **POI + road search**     | Typeahead combining road names and points of interest; dispatches selected vehicles to result                                                                                                                          |
+| 🖥 **Operator UI**           | Icon-rail sidebar (Vehicles · Fleets · Incidents · Geofences · Recordings · Visibility · Speed · Adapter) + bottom dock with live and replay controls                                                                  |
+| 🔌 **Adapter plugins**       | Hot-swappable source and sink plugins; configure via env vars or REST API at runtime                                                                                                                                   |
 
 ---
 
@@ -68,11 +68,11 @@ npm install
 npm run dev          # starts all three services via Turborepo
 ```
 
-| Service | URL |
-|---|---|
-| Dashboard | http://localhost:5012 |
+| Service       | URL                   |
+| ------------- | --------------------- |
+| Dashboard     | http://localhost:5012 |
 | Simulator API | http://localhost:5010 |
-| Adapter API | http://localhost:5011 |
+| Adapter API   | http://localhost:5011 |
 
 Or start services individually:
 
@@ -149,15 +149,15 @@ The `prepare` command runs the full pipeline: **download → extract → filter 
 
 ### Individual commands
 
-| Command | Description |
-|---|---|
-| `network download` | Download country PBF from Geofabrik (cached after first run) |
-| `network extract` | Clip a bounding box from the country PBF using osmium (Docker) |
-| `network filter` | Keep only drivable road classes from the extracted PBF |
-| `network export` | Convert filtered PBF to GeoJSON via osmium |
-| `network validate` | Run topology checks: orphan nodes, duplicate edges, disconnected components |
-| `network diff <old> <new>` | Compare two network GeoJSON files and report changes |
-| `network prepare [region]` | Full pipeline in one step |
+| Command                    | Description                                                                 |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `network download`         | Download country PBF from Geofabrik (cached after first run)                |
+| `network extract`          | Clip a bounding box from the country PBF using osmium (Docker)              |
+| `network filter`           | Keep only drivable road classes from the extracted PBF                      |
+| `network export`           | Convert filtered PBF to GeoJSON via osmium                                  |
+| `network validate`         | Run topology checks: orphan nodes, duplicate edges, disconnected components |
+| `network diff <old> <new>` | Compare two network GeoJSON files and report changes                        |
+| `network prepare [region]` | Full pipeline in one step                                                   |
 
 Regions are defined in `regions.json` (covers major cities globally). Pass `--bbox w,s,e,n` for a custom area or `--geofabrik <path>` for a Geofabrik sub-path.
 
@@ -169,86 +169,86 @@ Regions are defined in `regions.json` (covers major cities globally). Pass `--bb
 
 ### Simulation control
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/status` | Simulation state (`running`, `ready`, `interval`) |
-| `POST` | `/start` | Start simulation (accepts options body) |
-| `POST` | `/stop` | Stop simulation |
-| `POST` | `/reset` | Reset to initial state |
-| `GET` | `/options` | Get current simulation options |
-| `POST` | `/options` | Update simulation options |
+| Method | Path       | Description                                       |
+| ------ | ---------- | ------------------------------------------------- |
+| `GET`  | `/status`  | Simulation state (`running`, `ready`, `interval`) |
+| `POST` | `/start`   | Start simulation (accepts options body)           |
+| `POST` | `/stop`    | Stop simulation                                   |
+| `POST` | `/reset`   | Reset to initial state                            |
+| `GET`  | `/options` | Get current simulation options                    |
+| `POST` | `/options` | Update simulation options                         |
 
 ### Vehicles & routing
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/vehicles` | List all vehicle DTOs |
-| `POST` | `/direction` | Dispatch one or more vehicles to a destination |
-| `GET` | `/directions` | Get active direction assignments |
-| `POST` | `/find-node` | Snap a lat/lng to the nearest graph node |
-| `POST` | `/find-road` | Snap a lat/lng to the nearest road edge |
-| `POST` | `/search` | Full-text POI search |
+| Method | Path          | Description                                    |
+| ------ | ------------- | ---------------------------------------------- |
+| `GET`  | `/vehicles`   | List all vehicle DTOs                          |
+| `POST` | `/direction`  | Dispatch one or more vehicles to a destination |
+| `GET`  | `/directions` | Get active direction assignments               |
+| `POST` | `/find-node`  | Snap a lat/lng to the nearest graph node       |
+| `POST` | `/find-road`  | Snap a lat/lng to the nearest road edge        |
+| `POST` | `/search`     | Full-text POI search                           |
 
 ### Map data
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/network` | Full road-network GeoJSON |
-| `GET` | `/roads` | Road segments GeoJSON |
-| `GET` | `/pois` | Points of interest |
-| `GET` | `/heatzones` | Current heat zone features |
-| `POST` | `/heatzones` | Regenerate heat zones |
+| Method | Path         | Description                |
+| ------ | ------------ | -------------------------- |
+| `GET`  | `/network`   | Full road-network GeoJSON  |
+| `GET`  | `/roads`     | Road segments GeoJSON      |
+| `GET`  | `/pois`      | Points of interest         |
+| `GET`  | `/heatzones` | Current heat zone features |
+| `POST` | `/heatzones` | Regenerate heat zones      |
 
 ### Fleets
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/fleets` | List all fleets |
-| `POST` | `/fleets` | Create a fleet |
-| `DELETE` | `/fleets/:id` | Delete a fleet |
-| `POST` | `/fleets/:id/assign` | Assign vehicles to a fleet |
-| `POST` | `/fleets/:id/unassign` | Unassign vehicles from a fleet |
+| Method   | Path                   | Description                    |
+| -------- | ---------------------- | ------------------------------ |
+| `GET`    | `/fleets`              | List all fleets                |
+| `POST`   | `/fleets`              | Create a fleet                 |
+| `DELETE` | `/fleets/:id`          | Delete a fleet                 |
+| `POST`   | `/fleets/:id/assign`   | Assign vehicles to a fleet     |
+| `POST`   | `/fleets/:id/unassign` | Unassign vehicles from a fleet |
 
 ### Incidents
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/incidents` | List active incidents |
-| `POST` | `/incidents` | Create an incident (triggers rerouting) |
-| `DELETE` | `/incidents/:id` | Clear an incident |
-| `POST` | `/incidents/random` | Create a random incident |
+| Method   | Path                | Description                             |
+| -------- | ------------------- | --------------------------------------- |
+| `GET`    | `/incidents`        | List active incidents                   |
+| `POST`   | `/incidents`        | Create an incident (triggers rerouting) |
+| `DELETE` | `/incidents/:id`    | Clear an incident                       |
+| `POST`   | `/incidents/random` | Create a random incident                |
 
 ### Geofences
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/geofences` | List all geofence zones |
-| `POST` | `/geofences` | Create a geofence (GeoJSON polygon + metadata) |
-| `GET` | `/geofences/:id` | Get a geofence |
-| `PUT` | `/geofences/:id` | Update a geofence |
-| `DELETE` | `/geofences/:id` | Delete a geofence |
-| `PATCH` | `/geofences/:id/toggle` | Enable / disable a geofence |
+| Method   | Path                    | Description                                    |
+| -------- | ----------------------- | ---------------------------------------------- |
+| `GET`    | `/geofences`            | List all geofence zones                        |
+| `POST`   | `/geofences`            | Create a geofence (GeoJSON polygon + metadata) |
+| `GET`    | `/geofences/:id`        | Get a geofence                                 |
+| `PUT`    | `/geofences/:id`        | Update a geofence                              |
+| `DELETE` | `/geofences/:id`        | Delete a geofence                              |
+| `PATCH`  | `/geofences/:id/toggle` | Enable / disable a geofence                    |
 
 ### Health
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/health` | Uptime and subsystem status |
+| Method | Path      | Description                 |
+| ------ | --------- | --------------------------- |
+| `GET`  | `/health` | Uptime and subsystem status |
 
 ### Recording & replay
 
-| Method | Path | Description |
-|---|---|---|
-| `POST` | `/recording/start` | Start recording the session |
-| `POST` | `/recording/stop` | Stop recording and save NDJSON file |
-| `GET` | `/recordings` | List saved recordings |
-| `POST` | `/replay/start` | Load and start a recording replay |
-| `POST` | `/replay/pause` | Pause replay |
-| `POST` | `/replay/resume` | Resume replay |
-| `POST` | `/replay/stop` | Stop replay, return to live mode |
-| `POST` | `/replay/seek` | Seek to a timestamp (ms) |
-| `POST` | `/replay/speed` | Set playback speed multiplier |
-| `GET` | `/replay/status` | Current replay state |
+| Method | Path               | Description                         |
+| ------ | ------------------ | ----------------------------------- |
+| `POST` | `/recording/start` | Start recording the session         |
+| `POST` | `/recording/stop`  | Stop recording and save NDJSON file |
+| `GET`  | `/recordings`      | List saved recordings               |
+| `POST` | `/replay/start`    | Load and start a recording replay   |
+| `POST` | `/replay/pause`    | Pause replay                        |
+| `POST` | `/replay/resume`   | Resume replay                       |
+| `POST` | `/replay/stop`     | Stop replay, return to live mode    |
+| `POST` | `/replay/seek`     | Seek to a timestamp (ms)            |
+| `POST` | `/replay/speed`    | Set playback speed multiplier       |
+| `GET`  | `/replay/status`   | Current replay state                |
 
 ---
 
@@ -256,23 +256,23 @@ Regions are defined in `regions.json` (covers major cities globally). Pass `--bb
 
 Connect to `ws://localhost:5010`. On connect the server sends a `status` and `options` snapshot.
 
-| Event | Direction | Payload |
-|---|---|---|
-| `vehicles` | server → client | Array of `VehicleDTO` (position, speed, heading, fleetId) |
-| `status` | server → client | `SimulationStatus` (running, ready, interval) |
-| `options` | server → client | Current `StartOptions` |
-| `heatzones` | server → client | `HeatZoneFeature[]` |
-| `direction` | server → client | Active dispatch assignment |
-| `waypoint:reached` | server → client | Vehicle reached a waypoint |
-| `route:completed` | server → client | Vehicle completed its full route |
-| `reset` | server → client | Simulation was reset |
-| `fleet:created` | server → client | New fleet |
-| `fleet:deleted` | server → client | Fleet removed |
-| `fleet:assigned` | server → client | Vehicles assigned to fleet |
-| `incident:created` | server → client | New incident + affected vehicles |
-| `incident:cleared` | server → client | Incident resolved |
-| `vehicle:rerouted` | server → client | Vehicle rerouted around incident |
-| `geofence:event` | server → client | Vehicle entered or exited a geofence zone |
+| Event              | Direction       | Payload                                                   |
+| ------------------ | --------------- | --------------------------------------------------------- |
+| `vehicles`         | server → client | Array of `VehicleDTO` (position, speed, heading, fleetId) |
+| `status`           | server → client | `SimulationStatus` (running, ready, interval)             |
+| `options`          | server → client | Current `StartOptions`                                    |
+| `heatzones`        | server → client | `HeatZoneFeature[]`                                       |
+| `direction`        | server → client | Active dispatch assignment                                |
+| `waypoint:reached` | server → client | Vehicle reached a waypoint                                |
+| `route:completed`  | server → client | Vehicle completed its full route                          |
+| `reset`            | server → client | Simulation was reset                                      |
+| `fleet:created`    | server → client | New fleet                                                 |
+| `fleet:deleted`    | server → client | Fleet removed                                             |
+| `fleet:assigned`   | server → client | Vehicles assigned to fleet                                |
+| `incident:created` | server → client | New incident + affected vehicles                          |
+| `incident:cleared` | server → client | Incident resolved                                         |
+| `vehicle:rerouted` | server → client | Vehicle rerouted around incident                          |
+| `geofence:event`   | server → client | Vehicle entered or exited a geofence zone                 |
 
 ---
 
@@ -282,16 +282,16 @@ Connect to `ws://localhost:5010`. On connect the server sends a `status` and `op
 
 ### Runtime configuration API
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/config` | Current source + sinks config |
-| `POST` | `/config/source` | Swap the active source plugin |
-| `POST` | `/config/sinks` | Replace the active sink list |
-| `DELETE` | `/config/sinks/:type` | Remove one sink |
-| `GET` | `/vehicles` | Vehicles from the current source |
-| `GET` | `/fleets` | Fleets from the current source |
-| `POST` | `/sync` | Push a position update through all sinks |
-| `GET` | `/health` | Health check |
+| Method   | Path                  | Description                              |
+| -------- | --------------------- | ---------------------------------------- |
+| `GET`    | `/config`             | Current source + sinks config            |
+| `POST`   | `/config/source`      | Swap the active source plugin            |
+| `POST`   | `/config/sinks`       | Replace the active sink list             |
+| `DELETE` | `/config/sinks/:type` | Remove one sink                          |
+| `GET`    | `/vehicles`           | Vehicles from the current source         |
+| `GET`    | `/fleets`             | Fleets from the current source           |
+| `POST`   | `/sync`               | Push a position update through all sinks |
+| `GET`    | `/health`             | Health check                             |
 
 ### Source plugins
 
@@ -308,13 +308,13 @@ flowchart LR
     Sources --> SRC
 ```
 
-| Plugin | Key config fields |
-|---|---|
-| `static` | `count` (default 20) |
-| `graphql` | `url`, `query`, `token`, `headers`, `vehiclePath`, `maxVehicles` |
-| `rest` | `url`, `token`, `headers`, `vehiclePath`, `maxVehicles` |
-| `mysql` | `host`, `port`, `user`, `password`, `database`, `query` |
-| `postgres` | `host`, `port`, `user`, `password`, `database`, `query` |
+| Plugin     | Key config fields                                                |
+| ---------- | ---------------------------------------------------------------- |
+| `static`   | `count` (default 20)                                             |
+| `graphql`  | `url`, `query`, `token`, `headers`, `vehiclePath`, `maxVehicles` |
+| `rest`     | `url`, `token`, `headers`, `vehiclePath`, `maxVehicles`          |
+| `mysql`    | `host`, `port`, `user`, `password`, `database`, `query`          |
+| `postgres` | `host`, `port`, `user`, `password`, `database`, `query`          |
 
 ### Sink plugins
 
@@ -350,31 +350,31 @@ SINK_WEBHOOK_CONFIG='{"url":"https://hooks.example.com/fleet"}'
 
 ### Simulator (`apps/simulator/.env`)
 
-| Variable | Default | Description |
-|---|---|---|
-| `PORT` | `5010` | HTTP / WebSocket port |
-| `GEOJSON_PATH` | `./export.geojson` | Path to the road-network GeoJSON file |
-| `VEHICLE_COUNT` | `70` | Number of vehicles to spawn |
-| `UPDATE_INTERVAL` | `500` | Position broadcast interval (ms) |
-| `MIN_SPEED` | `20` | Minimum vehicle speed (km/h) |
-| `MAX_SPEED` | `60` | Maximum vehicle speed (km/h) |
-| `ACCELERATION` | `5` | Acceleration rate (km/h per tick) |
-| `DECELERATION` | `7` | Deceleration rate (km/h per tick) |
-| `TURN_THRESHOLD` | `30` | Bearing change (°) that triggers slowdown |
-| `SPEED_VARIATION` | `0.1` | Random speed jitter factor `[0, 1]` |
-| `HEATZONE_SPEED_FACTOR` | `0.5` | Speed multiplier inside heat zones |
-| `ADAPTER_URL` | _(empty)_ | Enable adapter sync (e.g. `http://localhost:5011`) |
-| `SYNC_ADAPTER_TIMEOUT` | `5000` | Adapter sync timeout (ms) |
+| Variable                | Default            | Description                                        |
+| ----------------------- | ------------------ | -------------------------------------------------- |
+| `PORT`                  | `5010`             | HTTP / WebSocket port                              |
+| `GEOJSON_PATH`          | `./export.geojson` | Path to the road-network GeoJSON file              |
+| `VEHICLE_COUNT`         | `70`               | Number of vehicles to spawn                        |
+| `UPDATE_INTERVAL`       | `500`              | Position broadcast interval (ms)                   |
+| `MIN_SPEED`             | `20`               | Minimum vehicle speed (km/h)                       |
+| `MAX_SPEED`             | `60`               | Maximum vehicle speed (km/h)                       |
+| `ACCELERATION`          | `5`                | Acceleration rate (km/h per tick)                  |
+| `DECELERATION`          | `7`                | Deceleration rate (km/h per tick)                  |
+| `TURN_THRESHOLD`        | `30`               | Bearing change (°) that triggers slowdown          |
+| `SPEED_VARIATION`       | `0.1`              | Random speed jitter factor `[0, 1]`                |
+| `HEATZONE_SPEED_FACTOR` | `0.5`              | Speed multiplier inside heat zones                 |
+| `ADAPTER_URL`           | _(empty)_          | Enable adapter sync (e.g. `http://localhost:5011`) |
+| `SYNC_ADAPTER_TIMEOUT`  | `5000`             | Adapter sync timeout (ms)                          |
 
 ### Adapter (`apps/adapter/.env`)
 
-| Variable | Default | Description |
-|---|---|---|
-| `PORT` | `5011` | HTTP port |
-| `SOURCE_TYPE` | `static` | Active source plugin |
-| `SOURCE_CONFIG` | `{}` | JSON config for the source plugin |
-| `SINK_TYPES` | _(empty)_ | Comma-separated sink plugin names |
-| `SINK_<TYPE>_CONFIG` | `{}` | JSON config per sink, e.g. `SINK_REDPANDA_CONFIG` |
+| Variable             | Default   | Description                                       |
+| -------------------- | --------- | ------------------------------------------------- |
+| `PORT`               | `5011`    | HTTP port                                         |
+| `SOURCE_TYPE`        | `static`  | Active source plugin                              |
+| `SOURCE_CONFIG`      | `{}`      | JSON config for the source plugin                 |
+| `SINK_TYPES`         | _(empty)_ | Comma-separated sink plugin names                 |
+| `SINK_<TYPE>_CONFIG` | `{}`      | JSON config per sink, e.g. `SINK_REDPANDA_CONFIG` |
 
 ---
 
@@ -423,12 +423,12 @@ cd apps/simulator && docker compose up
 
 ## Project Structure
 
-| Package | Path | Tech | Port |
-|---|---|---|---|
-| **network** | [`apps/network/`](apps/network/) | Node.js 24 · Commander · osmium (Docker) | CLI |
-| **simulator** | [`apps/simulator/`](apps/simulator/) | Node.js 24 · Express 4 · ws 8 · Turf.js 7 | 5010 |
-| **adapter** | [`apps/adapter/`](apps/adapter/) | Node.js 24 · Express 4 | 5011 |
-| **ui** | [`apps/ui/`](apps/ui/) | React 19 · D3 7 · Vite · TypeScript 5.8 · CSS Modules | 5012 |
+| Package       | Path                                 | Tech                                                  | Port |
+| ------------- | ------------------------------------ | ----------------------------------------------------- | ---- |
+| **network**   | [`apps/network/`](apps/network/)     | Node.js 24 · Commander · osmium (Docker)              | CLI  |
+| **simulator** | [`apps/simulator/`](apps/simulator/) | Node.js 24 · Express 4 · ws 8 · Turf.js 7             | 5010 |
+| **adapter**   | [`apps/adapter/`](apps/adapter/)     | Node.js 24 · Express 4                                | 5011 |
+| **ui**        | [`apps/ui/`](apps/ui/)               | React 19 · D3 7 · Vite · TypeScript 5.8 · CSS Modules | 5012 |
 
 Each package has its own README with deeper architecture notes.
 
@@ -445,4 +445,3 @@ See [SECURITY.md](SECURITY.md) for the vulnerability disclosure policy.
 ## License
 
 [MIT](LICENSE) © Ivan Novazzi
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@commitlint/config-conventional": "^20.5.0",
         "@vitest/coverage-v8": "^4.1.0",
         "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
         "turbo": "^2.8.17"
       },
       "engines": {
@@ -8270,6 +8271,85 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -9319,6 +9399,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -9660,6 +9753,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -10050,6 +10150,19 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -11065,6 +11178,143 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -11133,6 +11383,160 @@
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -11305,6 +11709,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -11534,6 +11951,22 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -12396,6 +12829,30 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/robust-predicates": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
@@ -13158,6 +13615,52 @@
       "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
       "license": "MIT"
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -13235,6 +13738,16 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -13402,9 +13915,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,21 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@vitest/coverage-v8": "^4.1.0",
     "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "turbo": "^2.8.17"
+  },
+  "lint-staged": {
+    "apps/ui/**/*.{ts,tsx,js,jsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "apps/{simulator,adapter}/**/*.{ts,js}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{json,md,css,scss}": [
+      "prettier --write"
+    ]
   },
   "packageManager": "npm@11.11.1"
 }


### PR DESCRIPTION
## Summary
- Adds `lint-staged` to run `prettier --write` + `eslint --fix` on staged files during pre-commit
- Configures patterns for UI (ts/tsx/js/jsx), simulator/adapter (ts/js), and shared files (json/md/css/scss)
- Pre-commit hook now runs type-check + lint-staged (previously type-check only)

## Test plan
- [x] Verified lint-staged runs correctly against staged files
- [x] Pre-commit hook executes both type-check and lint-staged successfully
- [ ] Test committing a file with formatting issues — should auto-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)