### PR TITLE
feat(network): prune disconnected components, fix city-agnostic spawning

### DIFF
--- a/apps/adapter/src/__tests__/integration/plugin-flows.test.ts
+++ b/apps/adapter/src/__tests__/integration/plugin-flows.test.ts
@@ -141,8 +141,8 @@ describe("Plugin flow integration tests", () => {
       // Convert to updates and publish
       const updates: VehicleUpdate[] = vehicles.map((v) => ({
         id: v.id,
-        latitude: v.position[0],
-        longitude: v.position[1],
+        latitude: v.position?.[0] ?? 0,
+        longitude: v.position?.[1] ?? 0,
         type: v.type,
       }));
 
@@ -169,8 +169,8 @@ describe("Plugin flow integration tests", () => {
       const vehicles = await manager.getVehicles();
       const updates: VehicleUpdate[] = vehicles.map((v) => ({
         id: v.id,
-        latitude: v.position[0],
-        longitude: v.position[1],
+        latitude: v.position?.[0] ?? 0,
+        longitude: v.position?.[1] ?? 0,
       }));
 
       const result = await manager.publishUpdates(updates);
@@ -405,8 +405,8 @@ describe("Plugin flow integration tests", () => {
 
       const updates: VehicleUpdate[] = vehicles.map((v) => ({
         id: v.id,
-        latitude: v.position[0],
-        longitude: v.position[1],
+        latitude: v.position?.[0] ?? 0,
+        longitude: v.position?.[1] ?? 0,
       }));
 
       const result = await manager.publishUpdates(updates);

--- a/apps/adapter/src/__tests__/integration/plugin-flows.test.ts
+++ b/apps/adapter/src/__tests__/integration/plugin-flows.test.ts
@@ -136,7 +136,7 @@ describe("Plugin flow integration tests", () => {
       const vehicles = await manager.getVehicles();
       expect(vehicles).toHaveLength(5);
       expect(vehicles[0]).toHaveProperty("id");
-      expect(vehicles[0]).toHaveProperty("position");
+      expect(vehicles[0]).toHaveProperty("name");
 
       // Convert to updates and publish
       const updates: VehicleUpdate[] = vehicles.map((v) => ({

--- a/apps/adapter/src/__tests__/static-source.test.ts
+++ b/apps/adapter/src/__tests__/static-source.test.ts
@@ -28,9 +28,8 @@ describe("StaticSource", () => {
     const [vehicle] = await source.getVehicles();
     expect(vehicle.id).toBe("static-0");
     expect(vehicle.name).toBe("Test Vehicle 1");
-    expect(vehicle.position).toHaveLength(2);
-    expect(typeof vehicle.position[0]).toBe("number");
-    expect(typeof vehicle.position[1]).toBe("number");
+    expect(vehicle.type).toBeDefined();
+    expect(vehicle.position).toBeUndefined();
   });
 
   it("clears vehicles on disconnect", async () => {

--- a/apps/adapter/src/plugins/sources/static.test.ts
+++ b/apps/adapter/src/plugins/sources/static.test.ts
@@ -28,22 +28,16 @@ describe("StaticSource", () => {
 
     expect(vehicle).toHaveProperty("id");
     expect(vehicle).toHaveProperty("name");
-    expect(vehicle.position).toHaveLength(2);
-    expect(typeof vehicle.position[0]).toBe("number");
-    expect(typeof vehicle.position[1]).toBe("number");
+    expect(vehicle).toHaveProperty("type");
   });
 
-  it("generates vehicles around Nairobi coordinates", async () => {
+  it("generates vehicles without hardcoded positions", async () => {
     const source = new StaticSource();
     await source.connect({ count: 10 });
     const vehicles = await source.getVehicles();
 
     for (const v of vehicles) {
-      const [lat, lng] = v.position;
-      expect(lat).toBeGreaterThanOrEqual(-1.28);
-      expect(lat).toBeLessThan(-1.18);
-      expect(lng).toBeGreaterThanOrEqual(36.8);
-      expect(lng).toBeLessThan(36.9);
+      expect(v.position).toBeUndefined();
     }
   });
 

--- a/apps/adapter/src/plugins/sources/static.ts
+++ b/apps/adapter/src/plugins/sources/static.ts
@@ -16,7 +16,6 @@ export class StaticSource implements DataSource {
     this.vehicles = Array.from({ length: count }, (_, i) => ({
       id: `static-${i}`,
       name: `Test Vehicle ${i + 1}`,
-      position: [-1.28 + Math.random() * 0.1, 36.8 + Math.random() * 0.1] as [number, number],
       type: vehicleTypes[i % vehicleTypes.length],
     }));
 

--- a/apps/network/README.md
+++ b/apps/network/README.md
@@ -37,18 +37,18 @@ This runs the full pipeline and writes the result to `apps/simulator/export.geoj
 
 ## Built-in regions
 
-| Region key    | City                  |
-|---------------|-----------------------|
-| `nairobi`     | Nairobi, Kenya        |
-| `cairo`       | Cairo, Egypt          |
-| `lagos`       | Lagos, Nigeria        |
-| `london`      | London, UK            |
-| `berlin`      | Berlin, Germany       |
-| `paris`       | Paris, France         |
-| `mumbai`      | Mumbai, India         |
-| `jakarta`     | Jakarta, Indonesia    |
-| `mexico-city` | Mexico City, Mexico   |
-| `new-york`    | New York, USA         |
+| Region key    | City                |
+| ------------- | ------------------- |
+| `nairobi`     | Nairobi, Kenya      |
+| `cairo`       | Cairo, Egypt        |
+| `lagos`       | Lagos, Nigeria      |
+| `london`      | London, UK          |
+| `berlin`      | Berlin, Germany     |
+| `paris`       | Paris, France       |
+| `mumbai`      | Mumbai, India       |
+| `jakarta`     | Jakarta, Indonesia  |
+| `mexico-city` | Mexico City, Mexico |
+| `new-york`    | New York, USA       |
 
 ```bash
 npx tsx src/cli.ts prepare nairobi
@@ -75,7 +75,7 @@ npx tsx src/cli.ts prepare cairo --output /tmp/cairo.geojson
 
 ## Pipeline steps
 
-The `prepare` command chains four steps. You can also run them individually:
+The `prepare` command chains six steps. You can also run them individually:
 
 ```bash
 # 1. Download country PBF (cached by ETag)
@@ -98,7 +98,10 @@ npx tsx src/cli.ts export \
   --output apps/simulator/export.geojson \
   --region cairo
 
-# 5. Validate topology
+# 5. Prune disconnected components (keeps largest)
+npx tsx src/cli.ts prune --input apps/simulator/export.geojson
+
+# 6. Validate topology
 npx tsx src/cli.ts validate --input apps/simulator/export.geojson
 ```
 
@@ -110,10 +113,18 @@ Downloaded PBF files are stored in `apps/network/.cache/` and reused on subseque
 
 `motorway`, `motorway_link`, `trunk`, `trunk_link`, `primary`, `primary_link`, `secondary`, `secondary_link`, `tertiary`, `tertiary_link`, `unclassified`, `residential`, `living_street`, plus `junction=roundabout`.
 
+## Pruning
+
+The `prune` step removes all features not connected to the largest component. Real-world city exports always include small disconnected fragments at bounding-box boundaries (e.g. Cairo had 1,130 components before pruning). Pruning runs automatically in the `prepare` pipeline before validation.
+
+```bash
+npx tsx src/cli.ts prune --input network.geojson
+npx tsx src/cli.ts prune --input network.geojson --output pruned.geojson
+```
+
 ## Validation thresholds
 
 The `validate` command passes when:
+
 - ≥ 95% of nodes are in the largest connected component
 - < 5% of nodes are isolated (degree 0)
-
-Real-world city exports always include small disconnected fragments at bounding-box boundaries; a strict component-count limit would reject valid networks.

--- a/apps/network/src/cli.ts
+++ b/apps/network/src/cli.ts
@@ -5,6 +5,7 @@ import { download } from "./commands/download.js";
 import { extract } from "./commands/extract.js";
 import { filter, DEFAULT_ROAD_CLASSES } from "./commands/filter.js";
 import { exportNetwork } from "./commands/export.js";
+import { prune } from "./commands/prune.js";
 import { validate } from "./commands/validate.js";
 import { diff } from "./commands/diff.js";
 import { prepare } from "./commands/prepare.js";
@@ -87,6 +88,15 @@ program
       bbox: [0, 0, 0, 0],
       classes: [],
     });
+  });
+
+program
+  .command("prune")
+  .description("Remove disconnected components, keeping only the largest")
+  .requiredOption("--input <path>", "GeoJSON file to prune")
+  .option("--output <path>", "Output path (defaults to overwriting input)")
+  .action((opts: { input: string; output?: string }) => {
+    prune(opts.input, opts.output);
   });
 
 program

--- a/apps/network/src/commands/prepare.ts
+++ b/apps/network/src/commands/prepare.ts
@@ -5,6 +5,7 @@ import { download, getCachePath } from "./download.js";
 import { extract } from "./extract.js";
 import { filter, DEFAULT_ROAD_CLASSES } from "./filter.js";
 import { exportNetwork } from "./export.js";
+import { prune } from "./prune.js";
 import { validate } from "./validate.js";
 
 const CACHE_DIR = path.resolve("apps/network/.cache");
@@ -80,7 +81,8 @@ export async function prepare(opts: PrepareOptions): Promise<void> {
     console.log(`  2. extract   bbox [${region.bbox.join(", ")}] → ${pbfExtracted}`);
     console.log(`  3. filter    classes: ${classes.join(",")} → ${pbfFiltered}`);
     console.log(`  4. export    → ${output}`);
-    console.log(`  5. validate  ${output}\n`);
+    console.log(`  5. prune     keep largest connected component`);
+    console.log(`  6. validate  ${output}\n`);
     return;
   }
 
@@ -96,6 +98,7 @@ export async function prepare(opts: PrepareOptions): Promise<void> {
     bbox: region.bbox,
     classes,
   });
+  prune(output);
   const report = validate(output);
 
   if (!report.passed) {

--- a/apps/network/src/commands/prune.test.ts
+++ b/apps/network/src/commands/prune.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { pruneNetwork } from "./prune.js";
+import type { FeatureCollection, Feature, LineString } from "geojson";
+
+function makeLine(coords: [number, number][]): Feature<LineString> {
+  return {
+    type: "Feature",
+    properties: {},
+    geometry: { type: "LineString", coordinates: coords },
+  };
+}
+
+describe("pruneNetwork", () => {
+  it("keeps all features when network is fully connected", () => {
+    const fc: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        makeLine([[0, 0], [1, 0]]),
+        makeLine([[1, 0], [2, 0]]),
+      ],
+    };
+    const { pruned, removedFeatures } = pruneNetwork(fc);
+    expect(pruned.features).toHaveLength(2);
+    expect(removedFeatures).toBe(0);
+  });
+
+  it("removes a small disconnected island", () => {
+    const fc: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        // Large component (3 features)
+        makeLine([[0, 0], [1, 0]]),
+        makeLine([[1, 0], [2, 0]]),
+        makeLine([[2, 0], [3, 0]]),
+        // Small disconnected island (1 feature)
+        makeLine([[10, 10], [11, 10]]),
+      ],
+    };
+    const { pruned, removedFeatures } = pruneNetwork(fc);
+    expect(pruned.features).toHaveLength(3);
+    expect(removedFeatures).toBe(1);
+  });
+
+  it("keeps the larger component when two exist", () => {
+    const fc: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        // Component A: 1 feature, 2 nodes
+        makeLine([[0, 0], [1, 0]]),
+        // Component B: 2 features, 3 nodes (larger)
+        makeLine([[10, 10], [11, 10]]),
+        makeLine([[11, 10], [12, 10]]),
+      ],
+    };
+    const { pruned, removedFeatures } = pruneNetwork(fc);
+    expect(pruned.features).toHaveLength(2);
+    expect(removedFeatures).toBe(1);
+    // Verify the kept features are from component B
+    const coords = (pruned.features[0] as Feature<LineString>).geometry.coordinates;
+    expect(coords[0][0]).toBe(10);
+  });
+
+  it("returns zero removals for an empty collection", () => {
+    const fc: FeatureCollection = { type: "FeatureCollection", features: [] };
+    const { pruned, removedFeatures } = pruneNetwork(fc);
+    expect(pruned.features).toHaveLength(0);
+    expect(removedFeatures).toBe(0);
+  });
+});

--- a/apps/network/src/commands/prune.ts
+++ b/apps/network/src/commands/prune.ts
@@ -1,0 +1,125 @@
+import fs from "fs";
+import type { FeatureCollection, Feature, LineString } from "geojson";
+
+const PRECISION = 6;
+
+function nodeKey(coord: [number, number]): string {
+  return `${coord[0].toFixed(PRECISION)},${coord[1].toFixed(PRECISION)}`;
+}
+
+/**
+ * Remove features that are not part of the largest connected component.
+ * Returns the pruned FeatureCollection and stats about what was removed.
+ */
+export function pruneNetwork(fc: FeatureCollection): {
+  pruned: FeatureCollection;
+  removedFeatures: number;
+  removedNodes: number;
+} {
+  const adjacency = new Map<string, Set<string>>();
+
+  const addNode = (key: string) => {
+    if (!adjacency.has(key)) adjacency.set(key, new Set());
+  };
+  const addEdge = (a: string, b: string) => {
+    adjacency.get(a)!.add(b);
+    adjacency.get(b)!.add(a);
+  };
+
+  // Build adjacency from LineString features only
+  for (const feature of fc.features) {
+    if (feature.geometry.type !== "LineString") continue;
+    const coords = (feature as Feature<LineString>).geometry
+      .coordinates as [number, number][];
+    for (const coord of coords) addNode(nodeKey(coord));
+    for (let i = 0; i < coords.length - 1; i++) {
+      addEdge(nodeKey(coords[i]), nodeKey(coords[i + 1]));
+    }
+  }
+
+  // BFS to find connected components
+  const visited = new Set<string>();
+  const componentOf = new Map<string, number>();
+  const componentSizes: number[] = [];
+  let componentId = 0;
+
+  for (const node of adjacency.keys()) {
+    if (visited.has(node)) continue;
+    let size = 0;
+    const queue: string[] = [node];
+    while (queue.length) {
+      const curr = queue.shift()!;
+      if (visited.has(curr)) continue;
+      visited.add(curr);
+      componentOf.set(curr, componentId);
+      size++;
+      for (const neighbor of adjacency.get(curr)!) {
+        if (!visited.has(neighbor)) queue.push(neighbor);
+      }
+    }
+    componentSizes.push(size);
+    componentId++;
+  }
+
+  // Find the largest component
+  let largestId = 0;
+  let largestSize = 0;
+  for (let i = 0; i < componentSizes.length; i++) {
+    if (componentSizes[i] > largestSize) {
+      largestSize = componentSizes[i];
+      largestId = i;
+    }
+  }
+
+  const totalNodesBefore = adjacency.size;
+
+  // Keep features where ALL coordinates belong to the largest component
+  const kept: typeof fc.features = [];
+  let removedFeatures = 0;
+
+  for (const feature of fc.features) {
+    if (feature.geometry.type !== "LineString") {
+      kept.push(feature); // keep non-LineString features as-is
+      continue;
+    }
+    const coords = (feature as Feature<LineString>).geometry
+      .coordinates as [number, number][];
+    const inLargest = coords.every(
+      (c) => componentOf.get(nodeKey(c)) === largestId
+    );
+    if (inLargest) {
+      kept.push(feature);
+    } else {
+      removedFeatures++;
+    }
+  }
+
+  // Count remaining nodes
+  const remainingNodes = new Set<string>();
+  for (const feature of kept) {
+    if (feature.geometry.type !== "LineString") continue;
+    const coords = (feature as Feature<LineString>).geometry
+      .coordinates as [number, number][];
+    for (const coord of coords) remainingNodes.add(nodeKey(coord));
+  }
+
+  return {
+    pruned: { type: "FeatureCollection", features: kept },
+    removedFeatures,
+    removedNodes: totalNodesBefore - remainingNodes.size,
+  };
+}
+
+export function prune(inputPath: string, outputPath?: string): void {
+  const raw = fs.readFileSync(inputPath, "utf8");
+  const fc = JSON.parse(raw) as FeatureCollection;
+  const originalCount = fc.features.length;
+
+  const { pruned, removedFeatures, removedNodes } = pruneNetwork(fc);
+
+  const dest = outputPath ?? inputPath;
+  fs.writeFileSync(dest, JSON.stringify(pruned));
+
+  console.log(`\nPrune: removed ${removedFeatures.toLocaleString()} features, ${removedNodes.toLocaleString()} nodes`);
+  console.log(`  ${originalCount.toLocaleString()} → ${pruned.features.length.toLocaleString()} features`);
+}

--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -34,4 +34,4 @@ SYNC_ADAPTER_TIMEOUT=5000
 
 # GeoJSON Data Path
 # Path to the road network GeoJSON file
-GEOJSON_PATH=./export.geojson
+GEOJSON_PATH=./data/network.geojson

--- a/apps/simulator/Dockerfile
+++ b/apps/simulator/Dockerfile
@@ -35,7 +35,7 @@ ENV NODE_ENV=production \
     ACCELERATION=5 \
     DECELERATION=7 \
     TURN_THRESHOLD=30 \
-    GEOJSON_PATH=/app/export.geojson
+    GEOJSON_PATH=/app/data/network.geojson
 
 USER nodejs
 

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -6,7 +6,7 @@ Vehicle location simulator for fleet management systems. Simulates multiple vehi
 
 - **Real Road Networks**: Uses OpenStreetMap GeoJSON data for realistic vehicle movement
 - **Heat Zones**: Dynamic areas that affect vehicle behavior and speed
-- **A* Pathfinding**: Intelligent routing between locations
+- **A\* Pathfinding**: Intelligent routing between locations
 - **WebSocket Support**: Real-time vehicle updates
 - **External Adapter**: Integration with external fleet management systems
 - **Rate Limiting**: Built-in protection against API abuse
@@ -37,34 +37,36 @@ cp .env.example .env
 Edit `.env` with your configuration. **Required variables:**
 
 ```bash
-GEOJSON_PATH=./export.geojson
+GEOJSON_PATH=./data/network.geojson
 ```
 
 ## Configuration Options
 
-| Variable                | Description                                    | Default           |
-| ----------------------- | ---------------------------------------------- | ----------------- |
-| `PORT`                  | HTTP server port                               | 5010              |
-| `GEOJSON_PATH`          | Path to OpenStreetMap GeoJSON file             | ./export.geojson  |
-| `UPDATE_INTERVAL`       | Vehicle position update frequency (ms)         | 500               |
-| `MIN_SPEED`             | Minimum vehicle speed (km/h)                   | 20                |
-| `MAX_SPEED`             | Maximum vehicle speed (km/h)                   | 60                |
-| `ACCELERATION`          | Speed increase rate (km/h/update)              | 5                 |
-| `DECELERATION`          | Speed decrease rate (km/h/update)              | 7                 |
-| `TURN_THRESHOLD`        | Angle to trigger turn behavior (degrees)       | 30                |
-| `SPEED_VARIATION`       | Speed randomization factor (0.0-1.0)           | 0.1               |
-| `HEATZONE_SPEED_FACTOR` | Speed reduction in heat zones (0.0-1.0)        | 0.5               |
-| `ADAPTER_URL`           | URL of external adapter service (enables adapter when set) | -    |
-| `SYNC_ADAPTER_TIMEOUT`  | Interval for syncing vehicle positions to adapter (ms) | 5000       |
+| Variable                | Description                                                | Default                |
+| ----------------------- | ---------------------------------------------------------- | ---------------------- |
+| `PORT`                  | HTTP server port                                           | 5010                   |
+| `GEOJSON_PATH`          | Path to OpenStreetMap GeoJSON file                         | ./data/network.geojson |
+| `UPDATE_INTERVAL`       | Vehicle position update frequency (ms)                     | 500                    |
+| `MIN_SPEED`             | Minimum vehicle speed (km/h)                               | 20                     |
+| `MAX_SPEED`             | Maximum vehicle speed (km/h)                               | 60                     |
+| `ACCELERATION`          | Speed increase rate (km/h/update)                          | 5                      |
+| `DECELERATION`          | Speed decrease rate (km/h/update)                          | 7                      |
+| `TURN_THRESHOLD`        | Angle to trigger turn behavior (degrees)                   | 30                     |
+| `SPEED_VARIATION`       | Speed randomization factor (0.0-1.0)                       | 0.1                    |
+| `HEATZONE_SPEED_FACTOR` | Speed reduction in heat zones (0.0-1.0)                    | 0.5                    |
+| `ADAPTER_URL`           | URL of external adapter service (enables adapter when set) | -                      |
+| `SYNC_ADAPTER_TIMEOUT`  | Interval for syncing vehicle positions to adapter (ms)     | 5000                   |
 
 ## API Endpoints
 
 ### Simulation Control
 
 #### `GET /status`
+
 Get current simulation status.
 
 **Response:**
+
 ```json
 {
   "isRunning": true,
@@ -74,9 +76,11 @@ Get current simulation status.
 ```
 
 #### `POST /start`
+
 Start the simulation with optional configuration.
 
 **Request Body:**
+
 ```json
 {
   "updateInterval": 500,
@@ -86,17 +90,21 @@ Start the simulation with optional configuration.
 ```
 
 #### `POST /stop`
+
 Stop the simulation.
 
 #### `POST /reset`
+
 Reset the simulation to initial state.
 
 ### Vehicle Management
 
 #### `GET /vehicles`
+
 Get all vehicles with their current state.
 
 **Response:**
+
 ```json
 [
   {
@@ -110,9 +118,11 @@ Get all vehicles with their current state.
 ```
 
 #### `POST /direction`
+
 Set destination for specific vehicles.
 
 **Request Body:**
+
 ```json
 [
   {
@@ -126,19 +136,23 @@ Set destination for specific vehicles.
 ### Network Queries
 
 #### `POST /find-node`
+
 Find the nearest road network node to coordinates. **Rate limited.**
 
 **Request Body:** `[longitude, latitude]`
 
 #### `POST /find-road`
+
 Find the nearest road to coordinates. **Rate limited.**
 
 **Request Body:** `[longitude, latitude]`
 
 #### `POST /search`
+
 Search for locations by name. **Rate limited.**
 
 **Request Body:**
+
 ```json
 {
   "query": "Main Street"
@@ -146,28 +160,35 @@ Search for locations by name. **Rate limited.**
 ```
 
 #### `GET /network`
+
 Get the entire road network (GeoJSON).
 
 #### `GET /roads`
+
 Get all roads in the network.
 
 #### `GET /pois`
+
 Get all points of interest.
 
 ### Heat Zones
 
 #### `POST /heatzones`
+
 Generate new heat zones.
 
 #### `GET /heatzones`
+
 Get current heat zones.
 
 ### Configuration
 
 #### `GET /options`
+
 Get current simulation options.
 
 #### `POST /options`
+
 Update simulation options.
 
 ## WebSocket API
@@ -175,6 +196,7 @@ Update simulation options.
 Connect to `ws://localhost:5010` for real-time updates.
 
 **Message Types:**
+
 - `vehicle`: Vehicle position update
 - `status`: Simulation status change
 - `heatzones`: Heat zone updates
@@ -199,21 +221,25 @@ docker compose up
 ## Development
 
 ### Start Development Server
+
 ```bash
 npm run dev
 ```
 
 ### Build
+
 ```bash
 npm run build
 ```
 
 ### Run Tests
+
 ```bash
 npm test
 ```
 
 ### Lint
+
 ```bash
 npm run lint
 ```
@@ -251,11 +277,13 @@ npm run lint
 ### Application won't start
 
 **Check GeoJSON file exists:**
+
 ```bash
 ls -la export.geojson
 ```
 
 **Verify environment variables:**
+
 ```bash
 cat .env
 ```

--- a/apps/simulator/src/__tests__/config.test.ts
+++ b/apps/simulator/src/__tests__/config.test.ts
@@ -27,7 +27,7 @@ function validEnv(overrides: Record<string, string> = {}): Record<string, string
     HEATZONE_SPEED_FACTOR: "0.5",
     SYNC_ADAPTER_TIMEOUT: "5000",
     VEHICLE_COUNT: "70",
-    GEOJSON_PATH: "./export.geojson",
+    GEOJSON_PATH: "./data/network.geojson",
     ADAPTER_URL: "",
     ...overrides,
   };
@@ -52,7 +52,7 @@ describe("envSchema / parseEnv", () => {
     expect(cfg.MIN_SPEED).toBe(20);
     expect(cfg.MAX_SPEED).toBe(60);
     expect(cfg.VEHICLE_COUNT).toBe(70);
-    expect(cfg.GEOJSON_PATH).toBe("./export.geojson");
+    expect(cfg.GEOJSON_PATH).toBe("./data/network.geojson");
     expect(cfg.ADAPTER_URL).toBe("");
   });
 

--- a/apps/simulator/src/modules/AdapterSyncManager.ts
+++ b/apps/simulator/src/modules/AdapterSyncManager.ts
@@ -16,7 +16,7 @@ export class AdapterSyncManager {
    * Must be called after construction when ADAPTER_URL is configured.
    */
   async initFromAdapter(
-    addVehicle: (id: string, name: string, position: [number, number]) => void,
+    addVehicle: (id: string, name: string, position?: [number, number]) => void,
     loadFallback: () => void
   ): Promise<void> {
     if (!config.adapterURL) return;

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -45,7 +45,7 @@ export const envSchema = z
     VEHICLE_COUNT: z.coerce.number().int().min(1).default(70),
 
     /** Path to the GeoJSON road network file */
-    GEOJSON_PATH: z.string().default("./export.geojson"),
+    GEOJSON_PATH: z.string().default("./data/network.geojson"),
 
     /** URL of the adapter service (empty = disabled) */
     ADAPTER_URL: z.string().default(""),

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -28,7 +28,7 @@ export interface VehicleDTO {
 export interface ExportVehicle {
   id: string;
   name: string;
-  position: Position;
+  position?: Position;
   type?: VehicleType;
 }
 


### PR DESCRIPTION
## Summary

- **Prune step** added to network pipeline (between export and validate) — removes all features not in the largest connected component. Cairo went from 1,130 disconnected fragments to 1 clean component.
- **City-agnostic vehicle spawning** — the adapter's static source no longer hardcodes Nairobi coordinates. `ExportVehicle.position` is now optional; when omitted the simulator places vehicles on random streets using its sector-based distribution.
- **GEOJSON_PATH default updated** from `./export.geojson` to `./data/network.geojson` across .env.example, Dockerfile, config.ts, README, and tests.

## Test plan

- [x] `npx tsx apps/network/src/cli.ts prepare cairo` completes with `PASSED` validation
- [x] All 1041 simulator tests pass
- [x] All adapter tests pass (updated for optional position)
- [x] All 4 packages pass type-check
- [ ] Start simulator + adapter + UI with Cairo network — vehicles should be spread across the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)