### PR TITLE
fix(ui): UI panel and controls polish (fleetsim-all-czzr)

### DIFF
--- a/apps/simulator/src/__tests__/routes/incidents.test.ts
+++ b/apps/simulator/src/__tests__/routes/incidents.test.ts
@@ -23,6 +23,10 @@ vi.mock("../../middleware/rateLimiter", () => ({
     middleware: () => (_req: unknown, _res: unknown, next: () => void) => next(),
     cleanup: vi.fn(),
   },
+  incidentRateLimiter: {
+    middleware: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+    cleanup: vi.fn(),
+  },
 }));
 
 const mockIncidentDTO = {

--- a/apps/simulator/src/middleware/rateLimiter.ts
+++ b/apps/simulator/src/middleware/rateLimiter.ts
@@ -77,3 +77,4 @@ export class RateLimiter {
 // Create rate limiter instances
 export const generalRateLimiter = new RateLimiter(60000, 100); // 100 requests per minute
 export const expensiveRateLimiter = new RateLimiter(60000, 20); // 20 requests per minute for expensive operations
+export const incidentRateLimiter = new RateLimiter(60000, 100); // 100 incident creations per minute

--- a/apps/simulator/src/routes/incidents.ts
+++ b/apps/simulator/src/routes/incidents.ts
@@ -4,7 +4,7 @@ import type { IncidentType } from "../types";
 import { asyncHandler } from "./helpers";
 import { validateBody } from "../middleware/validate";
 import { createIncidentSchema, incidentAtPositionSchema } from "../middleware/schemas";
-import { expensiveRateLimiter } from "../middleware/rateLimiter";
+import { incidentRateLimiter } from "../middleware/rateLimiter";
 import logger from "../utils/logger";
 
 const VALID_INCIDENT_TYPES: IncidentType[] = ["accident", "closure", "construction"];
@@ -28,7 +28,7 @@ export function createIncidentRoutes(ctx: RouteContext): Router {
 
   router.post(
     "/incidents",
-    expensiveRateLimiter.middleware(),
+    incidentRateLimiter.middleware(),
     validateBody(createIncidentSchema),
     asyncHandler(async (req, res) => {
       const { edgeIds, type, duration, severity } = req.body;
@@ -56,7 +56,7 @@ export function createIncidentRoutes(ctx: RouteContext): Router {
 
   router.post(
     "/incidents/random",
-    expensiveRateLimiter.middleware(),
+    incidentRateLimiter.middleware(),
     asyncHandler(async (_req, res) => {
       const edge = network.getRandomEdge();
       const type = VALID_INCIDENT_TYPES[Math.floor(Math.random() * VALID_INCIDENT_TYPES.length)];
@@ -80,7 +80,7 @@ export function createIncidentRoutes(ctx: RouteContext): Router {
 
   router.post(
     "/incidents/at-position",
-    expensiveRateLimiter.middleware(),
+    incidentRateLimiter.middleware(),
     validateBody(incidentAtPositionSchema),
     asyncHandler(async (req, res) => {
       const { lat, lng, type } = req.body;

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -68,6 +68,8 @@ export default function App() {
   const [fences, setFences] = useState<GeoFence[]>([]);
   const [alerts, setAlerts] = useState<GeoFenceEvent[]>([]);
   const [drawingActive, setDrawingActive] = useState(false);
+  const [drawingVertexCount, setDrawingVertexCount] = useState(0);
+  const [drawConfirmId, setDrawConfirmId] = useState(0);
   const [pendingPolygon, setPendingPolygon] = useState<[number, number][] | null>(null);
 
   const dispatch = useDispatchFlow();
@@ -263,12 +265,18 @@ export default function App() {
 
   const onDrawComplete = useCallback((polygon: [number, number][]) => {
     setDrawingActive(false);
+    setDrawingVertexCount(0);
     setPendingPolygon(polygon);
   }, []);
 
   const onDrawCancel = useCallback(() => {
     setDrawingActive(false);
+    setDrawingVertexCount(0);
     setPendingPolygon(null);
+  }, []);
+
+  const onConfirmDraw = useCallback(() => {
+    setDrawConfirmId((n) => n + 1);
   }, []);
 
   const onCreateZone = useCallback((req: CreateGeoFenceRequest) => {
@@ -390,7 +398,7 @@ export default function App() {
               )}
               {activePanel === "recordings" && (
                 <RecordReplay
-                  recording={recording}
+                  recordings={recording.recordings}
                   replayStatus={replay.replayStatus}
                   onStartReplay={replay.startReplay}
                 />
@@ -413,6 +421,11 @@ export default function App() {
                   onFenceToggle={onFenceToggle}
                   onFenceDelete={onFenceDelete}
                   alerts={alerts}
+                  drawingActive={drawingActive}
+                  vertexCount={drawingVertexCount}
+                  onStartDrawing={() => setDrawingActive(true)}
+                  onCancelDrawing={onDrawCancel}
+                  onConfirmDrawing={onConfirmDraw}
                 />
               )}
               {activePanel === "adapter" && (
@@ -452,6 +465,8 @@ export default function App() {
               drawingActive={drawingActive}
               onDrawComplete={onDrawComplete}
               onDrawCancel={onDrawCancel}
+              onDrawVertexCountChange={setDrawingVertexCount}
+              drawConfirmId={drawConfirmId}
             />
             <SearchBar
               selectedItem={selectedItem}
@@ -478,18 +493,6 @@ export default function App() {
               onStartRecording={recording.startRecording}
               onStopRecording={recording.stopRecording}
             />
-            {/* Draw Zone toolbar button */}
-            <button
-              type="button"
-              className={classNames(styles.drawZoneButton, {
-                [styles.drawZoneButtonActive]: drawingActive,
-              })}
-              onClick={() => setDrawingActive((v) => !v)}
-              title={drawingActive ? "Cancel drawing (Esc)" : "Draw geofence zone"}
-              aria-pressed={drawingActive}
-            >
-              {drawingActive ? "Cancel Zone" : "Draw Zone"}
-            </button>
             <CreateZoneDialog
               polygon={pendingPolygon}
               onSubmit={onCreateZone}

--- a/apps/ui/src/Controls/ClockPanel.module.css
+++ b/apps/ui/src/Controls/ClockPanel.module.css
@@ -1,16 +1,9 @@
-/* ── Clock header (custom, not using PanelHeader) ───── */
-.clockHeader {
-  padding: var(--space-4) var(--space-5) 0;
+/* ── Clock display (inside PanelBody) ───────────────── */
+.clockDisplay {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-}
-
-.subtitle {
-  margin: var(--space-2) 0 0;
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  line-height: 1.4;
+  padding-bottom: var(--space-2);
 }
 
 .body {
@@ -67,7 +60,6 @@
   gap: var(--space-2);
   border-top: var(--panel-border);
   padding-top: var(--space-4);
-  margin-top: var(--space-2);
 }
 
 .sectionLabel {

--- a/apps/ui/src/Controls/ClockPanel.tsx
+++ b/apps/ui/src/Controls/ClockPanel.tsx
@@ -1,6 +1,6 @@
 import type { TimeOfDay } from "@/types";
 import { useClock } from "@/hooks/useClock";
-import { PanelBody } from "./PanelPrimitives";
+import { PanelBody, PanelHeader } from "./PanelPrimitives";
 import styles from "./ClockPanel.module.css";
 import { Slider, SliderTrack, SliderThumb, Button } from "react-aria-components";
 
@@ -58,14 +58,15 @@ export default function ClockPanel() {
 
   return (
     <>
-      <div className={styles.clockHeader}>
-        <span className={styles[`eyebrow_${clock.timeOfDay}`]}>
-          {TIME_OF_DAY_LABELS[clock.timeOfDay]}
-        </span>
-        <div className={styles.timeValue}>{timeStr}</div>
-        <p className={styles.subtitle}>Nairobi Fleet Simulation</p>
-      </div>
+      <PanelHeader title="Simulation Clock" subtitle="Nairobi Fleet Simulation" />
       <PanelBody className={styles.body}>
+        <div className={styles.clockDisplay}>
+          <span className={styles[`eyebrow_${clock.timeOfDay}`]}>
+            {TIME_OF_DAY_LABELS[clock.timeOfDay]}
+          </span>
+          <div className={styles.timeValue}>{timeStr}</div>
+        </div>
+
         <div className={styles.speedSection}>
           <span className={styles.sectionLabel}>SIMULATION SPEED</span>
           <Slider

--- a/apps/ui/src/Controls/GeofencePanel.module.css
+++ b/apps/ui/src/Controls/GeofencePanel.module.css
@@ -2,6 +2,98 @@
   gap: var(--space-3);
 }
 
+/* ── Draw Zone controls ──────────────────────────────── */
+.drawZoneBtn {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  border: var(--surface-border);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.drawZoneBtn:hover {
+  background: var(--surface-bg-hover);
+  color: var(--color-text-primary);
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.drawingBanner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.drawingHint {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.drawingActions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.confirmBtn {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  color: #93c5fd;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.confirmBtn:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.25);
+  color: #fff;
+}
+
+.confirmBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.cancelBtn {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.cancelBtn:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
 .tabs {
   display: flex;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);

--- a/apps/ui/src/Controls/GeofencePanel.tsx
+++ b/apps/ui/src/Controls/GeofencePanel.tsx
@@ -9,6 +9,11 @@ interface GeofencePanelProps {
   onFenceToggle: (id: string) => void;
   onFenceDelete: (id: string) => void;
   alerts: GeoFenceEvent[];
+  drawingActive: boolean;
+  vertexCount: number;
+  onStartDrawing: () => void;
+  onCancelDrawing: () => void;
+  onConfirmDrawing: () => void;
 }
 
 type Tab = "zones" | "alerts";
@@ -42,8 +47,15 @@ export default function GeofencePanel({
   onFenceToggle,
   onFenceDelete,
   alerts,
+  drawingActive,
+  vertexCount,
+  onStartDrawing,
+  onCancelDrawing,
+  onConfirmDrawing,
 }: GeofencePanelProps) {
   const [tab, setTab] = useState<Tab>("zones");
+
+  const canConfirm = vertexCount >= 3;
 
   return (
     <>
@@ -94,9 +106,50 @@ export default function GeofencePanel({
 
       {tab === "zones" && (
         <PanelBody className={styles.body}>
+          {/* Drawing controls */}
+          {drawingActive ? (
+            <div className={styles.drawingBanner}>
+              <span className={styles.drawingHint}>
+                {vertexCount === 0
+                  ? "Click on the map to add points"
+                  : vertexCount < 3
+                    ? `${vertexCount} point${vertexCount === 1 ? "" : "s"} — need at least 3`
+                    : `${vertexCount} points — ready to confirm`}
+              </span>
+              <div className={styles.drawingActions}>
+                <button
+                  type="button"
+                  className={styles.confirmBtn}
+                  onClick={onConfirmDrawing}
+                  disabled={!canConfirm}
+                  title="Finish drawing and name the zone"
+                >
+                  Confirm
+                </button>
+                <button
+                  type="button"
+                  className={styles.cancelBtn}
+                  onClick={onCancelDrawing}
+                  title="Cancel drawing (Esc)"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className={styles.drawZoneBtn}
+              onClick={onStartDrawing}
+              title="Draw a geofence zone on the map"
+            >
+              + Draw Zone
+            </button>
+          )}
+
           {fences.length === 0 ? (
             <PanelEmptyState>
-              No zones yet. Use the &ldquo;Draw Zone&rdquo; button to create one.
+              No zones yet. Use the &ldquo;Draw Zone&rdquo; button above to create one.
             </PanelEmptyState>
           ) : (
             <div className={styles.list}>

--- a/apps/ui/src/Controls/Incidents.tsx
+++ b/apps/ui/src/Controls/Incidents.tsx
@@ -17,6 +17,7 @@ const INCIDENT_COLORS: Record<IncidentType, string> = {
 };
 
 function formatTimeRemaining(expiresAt: number): string {
+  if (!Number.isFinite(expiresAt)) return "—";
   const remaining = Math.max(0, expiresAt - Date.now());
   const totalSeconds = Math.floor(remaining / 1000);
   const minutes = Math.floor(totalSeconds / 60);
@@ -100,7 +101,7 @@ export default function Incidents({ incidents, createRandom, remove }: Incidents
                     <div
                       className={styles.severityFill}
                       style={{
-                        width: `${incident.severity * 100}%`,
+                        width: `${(incident.severity ?? 0) * 100}%`,
                         backgroundColor: INCIDENT_COLORS[incident.type],
                       }}
                     />

--- a/apps/ui/src/Controls/RecordReplay.tsx
+++ b/apps/ui/src/Controls/RecordReplay.tsx
@@ -1,7 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import classNames from "classnames";
 import type { RecordingFile, ReplayStatus } from "@/types";
-import { Stop, Record } from "@/components/Icons";
 import {
   PanelBadge,
   PanelBody,
@@ -11,29 +8,16 @@ import {
 } from "./PanelPrimitives";
 import styles from "./RecordReplay.module.css";
 import { Button } from "react-aria-components";
-
-interface RecordingHook {
-  isRecording: boolean;
-  recordings: RecordingFile[];
-  startRecording: () => Promise<void>;
-  stopRecording: () => Promise<unknown>;
-  refreshRecordings: () => Promise<void>;
-}
+import classNames from "classnames";
 
 interface RecordReplayProps {
-  recording: RecordingHook;
+  recordings: RecordingFile[];
   replayStatus: ReplayStatus;
   onStartReplay: (file: string, speed?: number) => Promise<void>;
 }
 
 /** Recordings smaller than this are header-only (no events). */
 const MIN_PLAYABLE_SIZE = 300;
-
-function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-}
 
 function formatFileSize(bytes: number): string {
   if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
@@ -64,54 +48,14 @@ function formatLabel(file: RecordingFile): string {
 }
 
 export default function RecordReplay({
-  recording,
+  recordings,
   replayStatus,
   onStartReplay,
 }: RecordReplayProps) {
-  const { isRecording, recordings, startRecording, stopRecording } = recording;
-
-  const [elapsed, setElapsed] = useState(0);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
   const isReplayMode = replayStatus.mode === "replay";
   const isPaused = replayStatus.paused ?? false;
   // Server returns path like "recordings/file.ndjson", recordings list has just "file.ndjson"
   const activeFile = replayStatus.file?.replace(/^recordings\//, "") ?? null;
-
-  // Elapsed timer for recording
-  useEffect(() => {
-    if (isRecording) {
-      setElapsed(0);
-      timerRef.current = setInterval(() => {
-        setElapsed((prev) => prev + 1);
-      }, 1000);
-    } else {
-      if (timerRef.current) {
-        clearInterval(timerRef.current);
-        timerRef.current = null;
-      }
-      setElapsed(0);
-    }
-    return () => {
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [isRecording]);
-
-  const handleRecordToggle = useCallback(async () => {
-    if (isRecording) {
-      await stopRecording();
-    } else {
-      await startRecording();
-    }
-  }, [isRecording, startRecording, stopRecording]);
-
-  const handleFileClick = useCallback(
-    async (file: RecordingFile) => {
-      if (file.fileSize < MIN_PLAYABLE_SIZE) return;
-      await onStartReplay(file.fileName, 1);
-    },
-    [onStartReplay]
-  );
 
   const playableRecordings = recordings.filter((f) => f.fileSize >= MIN_PLAYABLE_SIZE);
 
@@ -128,31 +72,6 @@ export default function RecordReplay({
       />
 
       <PanelBody className={styles.body}>
-        <div className={styles.recordRow}>
-          <Button
-            className={classNames(styles.recordButton, {
-              [styles.recordButtonActive]: isRecording,
-            })}
-            onPress={handleRecordToggle}
-            aria-label={isRecording ? "Stop recording" : "Start recording"}
-          >
-            {isRecording ? (
-              <>
-                <span className={classNames(styles.recordDot, styles.recordDotActive)} />
-                <Stop className={styles.recordIcon} />
-                Stop
-              </>
-            ) : (
-              <>
-                <span className={styles.recordDot} />
-                <Record className={styles.recordIcon} />
-                Record
-              </>
-            )}
-          </Button>
-          {isRecording && <span className={styles.elapsed}>{formatTime(elapsed)}</span>}
-        </div>
-
         <div className={styles.listHeader}>
           <PanelSectionLabel>Saved</PanelSectionLabel>
         </div>
@@ -170,7 +89,7 @@ export default function RecordReplay({
                   className={classNames(styles.recordingItem, {
                     [styles.recordingItemActive]: isActive,
                   })}
-                  onPress={() => !isActive && handleFileClick(file)}
+                  onPress={() => !isActive && onStartReplay(file.fileName, 1)}
                   isDisabled={isActive}
                   aria-label={`Play recording ${formatLabel(file)}`}
                 >

--- a/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
@@ -6,16 +6,29 @@ interface GeofenceDrawToolProps {
   active: boolean;
   onComplete: (polygon: [number, number][]) => void;
   onCancel: () => void;
+  /** Called whenever the vertex count changes (0 when idle/cancelled). */
+  onVertexCountChange?: (count: number) => void;
+  /**
+   * Increment this to programmatically trigger completion (like the confirm button).
+   * The tool fires onComplete with current vertices when this value changes.
+   */
+  confirmRequestId?: number;
 }
 
-export default function GeofenceDrawTool({ active, onComplete, onCancel }: GeofenceDrawToolProps) {
+export default function GeofenceDrawTool({
+  active,
+  onComplete,
+  onCancel,
+  onVertexCountChange,
+  confirmRequestId,
+}: GeofenceDrawToolProps) {
   const { map: svgRef, projection, transform } = useMapContext();
 
-  // Vertices in SVG display space
+  // Vertices in SVG viewport space (for rendering)
   const svgVertices = useRef<[number, number][]>([]);
   // Vertices in geo space [lng, lat]
   const geoVertices = useRef<[number, number][]>([]);
-  // Cursor position in SVG display space
+  // Cursor position in SVG viewport space
   const cursorSvg = useRef<[number, number] | null>(null);
 
   // The <g> element we render into
@@ -25,6 +38,9 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
   projectionRef.current = projection;
   const transformRef = useRef(transform);
   transformRef.current = transform;
+
+  const onVertexCountChangeRef = useRef(onVertexCountChange);
+  onVertexCountChangeRef.current = onVertexCountChange;
 
   const redraw = useCallback(() => {
     const g = gRef.current;
@@ -42,7 +58,7 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
       polygon.setAttribute("points", verts.map(([x, y]) => `${x},${y}`).join(" "));
       polygon.setAttribute("fill", "rgba(59,130,246,0.15)");
       polygon.setAttribute("stroke", "rgb(59,130,246)");
-      polygon.setAttribute("stroke-width", "1");
+      polygon.setAttribute("stroke-width", "1.5");
       polygon.setAttribute("stroke-dasharray", "4 3");
       g.appendChild(polygon);
     } else if (verts.length === 2) {
@@ -52,7 +68,7 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
       line.setAttribute("x2", String(verts[1][0]));
       line.setAttribute("y2", String(verts[1][1]));
       line.setAttribute("stroke", "rgb(59,130,246)");
-      line.setAttribute("stroke-width", "1");
+      line.setAttribute("stroke-width", "1.5");
       g.appendChild(line);
     }
 
@@ -79,7 +95,7 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
       circle.setAttribute("r", "4");
       circle.setAttribute("fill", "rgb(59,130,246)");
       circle.setAttribute("stroke", "#fff");
-      circle.setAttribute("stroke-width", "1");
+      circle.setAttribute("stroke-width", "1.5");
       g.appendChild(circle);
     }
   }, []);
@@ -87,18 +103,12 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
   useEffect(() => {
     if (!active || !svgRef) return;
 
-    // Create overlay <g>
+    // Create overlay <g> and attach to SVG root (not inside the zoom-transformed markers
+    // group) so that viewport-space coordinates render without double-transform.
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
     g.setAttribute("data-layer", "geofence-draw");
     g.style.pointerEvents = "none";
-
-    // Insert inside the markers group so it participates in zoom transforms
-    const markersGroup = svgRef.querySelector("g.markers");
-    if (markersGroup) {
-      markersGroup.appendChild(g);
-    } else {
-      svgRef.appendChild(g);
-    }
+    svgRef.appendChild(g);
     gRef.current = g;
     svgVertices.current = [];
     geoVertices.current = [];
@@ -112,43 +122,41 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
       const t = transformRef.current;
       if (!proj) return;
 
+      // rawX/rawY are in SVG viewport space
       const [rawX, rawY] = pointer(e, svgRef);
-      // Convert raw SVG pointer to map-space, then invert to geo coords
+      // Convert to map-space coordinates for geo inversion
       const [mx, my] = t ? t.invert([rawX, rawY]) : [rawX, rawY];
       const coords = proj.invert?.([mx, my]);
       if (!coords) return;
 
-      // Store SVG display position for rendering vertices
-      const svgPt: [number, number] = t ? [t.applyX(mx), t.applyY(my)] : [mx, my];
-      svgVertices.current = [...svgVertices.current, svgPt];
+      // Store viewport-space position for rendering (no additional transform needed
+      // since the <g> is a direct child of the SVG root)
+      svgVertices.current = [...svgVertices.current, [rawX, rawY]];
       geoVertices.current = [...geoVertices.current, coords as [number, number]];
+      onVertexCountChangeRef.current?.(svgVertices.current.length);
       redraw();
     };
 
-    const handleDblClick = (e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-
+    const completeDrawing = () => {
       if (geoVertices.current.length < 3) return;
-
       const polygon = [...geoVertices.current];
       svgVertices.current = [];
       geoVertices.current = [];
       cursorSvg.current = null;
       g.innerHTML = "";
-
+      onVertexCountChangeRef.current?.(0);
       onComplete(polygon);
     };
 
+    const handleDblClick = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      completeDrawing();
+    };
+
     const handleMouseMove = (e: MouseEvent) => {
-      const t = transformRef.current;
       const [rawX, rawY] = pointer(e, svgRef);
-      if (t) {
-        const [mx, my] = t.invert([rawX, rawY]);
-        cursorSvg.current = [t.applyX(mx), t.applyY(my)];
-      } else {
-        cursorSvg.current = [rawX, rawY];
-      }
+      cursorSvg.current = [rawX, rawY];
       redraw();
     };
 
@@ -158,9 +166,13 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
         geoVertices.current = [];
         cursorSvg.current = null;
         g.innerHTML = "";
+        onVertexCountChangeRef.current?.(0);
         onCancel();
       }
     };
+
+    // Expose completeDrawing on the g element so the confirm button can trigger it
+    (g as SVGGElement & { _complete?: () => void })._complete = completeDrawing;
 
     svgRef.addEventListener("click", handleClick);
     svgRef.addEventListener("dblclick", handleDblClick);
@@ -179,6 +191,16 @@ export default function GeofenceDrawTool({ active, onComplete, onCancel }: Geofe
       cursorSvg.current = null;
     };
   }, [active, svgRef, redraw, onComplete, onCancel]);
+
+  // Trigger completion when confirmRequestId changes
+  const prevConfirmIdRef = useRef(confirmRequestId);
+  useEffect(() => {
+    if (confirmRequestId === prevConfirmIdRef.current) return;
+    prevConfirmIdRef.current = confirmRequestId;
+    if (!active || geoVertices.current.length < 3) return;
+    const g = gRef.current as (SVGGElement & { _complete?: () => void }) | null;
+    g?._complete?.();
+  }, [confirmRequestId, active]);
 
   // Renders nothing into React's tree — SVG is managed via DOM
   return null;

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -50,6 +50,8 @@ interface MapProps {
   drawingActive?: boolean;
   onDrawComplete?: (polygon: [number, number][]) => void;
   onDrawCancel?: () => void;
+  onDrawVertexCountChange?: (count: number) => void;
+  drawConfirmId?: number;
 }
 
 export default function Map({
@@ -71,6 +73,8 @@ export default function Map({
   drawingActive = false,
   onDrawComplete,
   onDrawCancel,
+  onDrawVertexCountChange,
+  drawConfirmId,
 }: MapProps) {
   const network = useNetwork();
 
@@ -147,6 +151,8 @@ export default function Map({
           active={drawingActive}
           onComplete={onDrawComplete ?? (() => {})}
           onCancel={onDrawCancel ?? (() => {})}
+          onVertexCountChange={onDrawVertexCountChange}
+          confirmRequestId={drawConfirmId}
         />
       </RoadNetworkMap>
     </>


### PR DESCRIPTION
## Summary

- Resolve geofence draw offset (`fleetsim-all-9exq`)
- Add confirm button to geofence drawing (`fleetsim-all-t4ep`)
- Move draw zone button to panel (`fleetsim-all-x5lw`)
- Fix clock panel timer layout in header (`fleetsim-all-53ki`)
- Fix record button position in recordings panel (`fleetsim-all-ci8o`)
- Fix incidents NaN display (`fleetsim-all-xihj`)
- Add rate limiting to incidents endpoint (`fleetsim-all-x0aa`)

Closes epic `fleetsim-all-czzr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)