### PR TITLE
feat(ws): subscribe filter — UI sends subscribe on fleet toggle (fleetsim-all-hpo.4)

### DIFF
--- a/apps/simulator/src/__tests__/WebSocketBroadcaster.test.ts
+++ b/apps/simulator/src/__tests__/WebSocketBroadcaster.test.ts
@@ -1063,6 +1063,242 @@ describe("WebSocketBroadcaster", () => {
     });
   });
 
+  describe("subscribe filters", () => {
+    it("no filter → all vehicles sent (backwards compatibility)", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { fleetId: "fleet-a" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { fleetId: "fleet-b" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v3"));
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.type).toBe("vehicles");
+      expect(parsed.data).toHaveLength(3);
+      expect(parsed.data.map((v: VehicleDTO) => v.id)).toEqual(["v1", "v2", "v3"]);
+
+      broadcaster.stop();
+    });
+
+    it("filter by fleetId → only matching vehicles sent", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+      broadcaster.setClientFilter(client as unknown as WebSocket, { fleetIds: ["fleet-a"] });
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { fleetId: "fleet-a" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { fleetId: "fleet-b" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v3")); // no fleetId
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].id).toBe("v1");
+
+      broadcaster.stop();
+    });
+
+    it("filter by vehicleType → only matching types sent", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+      broadcaster.setClientFilter(client as unknown as WebSocket, { vehicleTypes: ["truck"] });
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { type: "car" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { type: "truck" }));
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].id).toBe("v2");
+
+      broadcaster.stop();
+    });
+
+    it("filter by bounding box → only in-bounds vehicles sent", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+      broadcaster.setClientFilter(client as unknown as WebSocket, {
+        bbox: { minLat: -2, maxLat: 0, minLng: 36, maxLng: 37 },
+      });
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { position: [-1.5, 36.5] })); // in bounds
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { position: [1.0, 36.5] })); // out of bounds (lat > maxLat)
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].id).toBe("v1");
+
+      broadcaster.stop();
+    });
+
+    it("combined filters use AND logic → vehicle must match all criteria", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+      broadcaster.setClientFilter(client as unknown as WebSocket, {
+        fleetIds: ["fleet-a"],
+        vehicleTypes: ["truck"],
+      });
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { type: "truck", fleetId: "fleet-a" })); // passes both
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { type: "car", fleetId: "fleet-a" })); // fails type
+      broadcaster.queueVehicleUpdate(makeVehicle("v3", { type: "truck", fleetId: "fleet-b" })); // fails fleet
+      broadcaster.queueVehicleUpdate(makeVehicle("v4", { type: "car", fleetId: "fleet-b" })); // fails both
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].id).toBe("v1");
+
+      broadcaster.stop();
+    });
+
+    it("setClientFilter with null removes filter → all vehicles sent", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+
+      // First set a restrictive filter
+      broadcaster.setClientFilter(client as unknown as WebSocket, { fleetIds: ["fleet-a"] });
+
+      // Then remove it
+      broadcaster.setClientFilter(client as unknown as WebSocket, null);
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { fleetId: "fleet-a" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { fleetId: "fleet-b" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v3"));
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(3);
+
+      broadcaster.stop();
+    });
+
+    it("empty fleetIds array → no fleet filtering (all vehicles pass)", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+
+      // Empty fleetIds means no restriction (filter.fleetIds?.length is falsy)
+      broadcaster.setClientFilter(client as unknown as WebSocket, { fleetIds: [] });
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { fleetId: "fleet-a" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { fleetId: "fleet-b" }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v3")); // no fleetId
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(3);
+
+      broadcaster.stop();
+    });
+
+    it("vehicle on bbox boundary → included (boundary is inclusive)", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+      broadcaster.setClientFilter(client as unknown as WebSocket, {
+        bbox: { minLat: -1.5, maxLat: -1.5, minLng: 36.5, maxLng: 36.5 },
+      });
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { position: [-1.5, 36.5] })); // exactly on boundary
+
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse(client.send.mock.calls[0][0] as string);
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].id).toBe("v1");
+
+      broadcaster.stop();
+    });
+
+    it("delta filter and subscribe filter both apply independently", () => {
+      const client = createMockClient();
+      const wss = createMockWSS([client]);
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer, {
+        flushIntervalMs: 100,
+      });
+      broadcaster.start();
+      broadcaster.setClientFilter(client as unknown as WebSocket, { fleetIds: ["fleet-a"] });
+
+      // First flush: send both vehicles to establish lastSent positions
+      broadcaster.queueVehicleUpdate(
+        makeVehicle("v1", { position: [-1.286, 36.817], fleetId: "fleet-a" })
+      );
+      broadcaster.queueVehicleUpdate(
+        makeVehicle("v2", { position: [-1.3, 36.83], fleetId: "fleet-a" })
+      );
+      vi.advanceTimersByTime(100);
+      expect(client.send).toHaveBeenCalledTimes(1);
+
+      // Second flush:
+      // - v1: same position → skipped by delta filter (never reaches subscribe filter)
+      // - v2: new vehicle matching filter → passes both filters
+      broadcaster.queueVehicleUpdate(
+        makeVehicle("v1", { position: [-1.286, 36.817], fleetId: "fleet-a" }) // unchanged position
+      );
+      broadcaster.queueVehicleUpdate(
+        makeVehicle("v2", {
+          position: [-1.3 + POSITION_DELTA_THRESHOLD * 3, 36.83],
+          fleetId: "fleet-a",
+        }) // moved significantly
+      );
+      vi.advanceTimersByTime(100);
+
+      expect(client.send).toHaveBeenCalledTimes(2);
+      const batch2 = JSON.parse(client.send.mock.calls[1][0] as string);
+      expect(batch2.data).toHaveLength(1);
+      expect(batch2.data[0].id).toBe("v2");
+
+      broadcaster.stop();
+    });
+  });
+
   describe("exported constants", () => {
     it("should export BACKPRESSURE_THRESHOLD as 64KB", () => {
       expect(BACKPRESSURE_THRESHOLD).toBe(64 * 1024);

--- a/apps/simulator/src/modules/WebSocketBroadcaster.ts
+++ b/apps/simulator/src/modules/WebSocketBroadcaster.ts
@@ -1,5 +1,5 @@
 import type { WebSocketServer, WebSocket } from "ws";
-import type { VehicleDTO } from "../types";
+import type { VehicleDTO, SubscribeFilter } from "../types";
 import { WS_BROADCASTER } from "../constants";
 
 /** @deprecated Import from constants.ts instead. Re-exported for backwards compatibility. */
@@ -38,6 +38,8 @@ interface ClientState {
   lastPong: number;
   /** Timestamp (ms) of the last ping sent to this client. 0 means no ping sent yet. */
   lastPingSent: number;
+  /** Optional subscribe filter. When set, only matching vehicles are sent. */
+  filter?: SubscribeFilter;
 }
 
 /**
@@ -120,6 +122,15 @@ export class WebSocketBroadcaster {
   }
 
   /**
+   * Sets or clears a subscribe filter for a specific client.
+   * Passing null removes the filter (client receives all vehicle updates).
+   */
+  setClientFilter(client: WebSocket, filter: SubscribeFilter | null): void {
+    const state = this.getClientState(client);
+    state.filter = filter ?? undefined;
+  }
+
+  /**
    * Sends a non-vehicle message immediately to all connected clients.
    */
   broadcast<T>(type: string, data: T): void {
@@ -147,7 +158,7 @@ export class WebSocketBroadcaster {
   private getClientState(client: WebSocket): ClientState {
     let state = this.clientStates.get(client);
     if (!state) {
-      state = { lastSent: new Map(), droppedFlushes: 0, lastPong: 0, lastPingSent: 0 };
+      state = { lastSent: new Map(), droppedFlushes: 0, lastPong: 0, lastPingSent: 0, filter: undefined };
       this.clientStates.set(client, state);
     }
     return state;
@@ -209,6 +220,26 @@ export class WebSocketBroadcaster {
   }
 
   /**
+   * Returns true if the vehicle passes the client's subscribe filter.
+   * A missing filter always passes.
+   */
+  private passesFilter(vehicle: VehicleDTO, filter: SubscribeFilter | undefined): boolean {
+    if (!filter) return true;
+    if (filter.fleetIds?.length) {
+      if (!vehicle.fleetId || !filter.fleetIds.includes(vehicle.fleetId)) return false;
+    }
+    if (filter.vehicleTypes?.length) {
+      if (!filter.vehicleTypes.includes(vehicle.type)) return false;
+    }
+    if (filter.bbox) {
+      const [lat, lng] = vehicle.position;
+      const { minLat, maxLat, minLng, maxLng } = filter.bbox;
+      if (lat < minLat || lat > maxLat || lng < minLng || lng > maxLng) return false;
+    }
+    return true;
+  }
+
+  /**
    * Flushes all queued vehicle updates to connected clients, applying
    * backpressure checks and delta filtering per client.
    */
@@ -237,13 +268,16 @@ export class WebSocketBroadcaster {
       // Delta filtering: only send vehicles whose position changed above threshold
       const changed = vehicles.filter((v) => this.hasPositionChanged(v, state.lastSent));
 
-      if (changed.length === 0) continue;
+      // Subscribe filter: only send vehicles matching this client's filter criteria
+      const toSend = changed.filter((v) => this.passesFilter(v, state.filter));
 
-      const message = JSON.stringify({ type: "vehicles", data: changed });
+      if (toSend.length === 0) continue;
+
+      const message = JSON.stringify({ type: "vehicles", data: toSend });
       client.send(message);
 
       // Update last-sent positions and reset dropped counter
-      for (const v of changed) {
+      for (const v of toSend) {
         state.lastSent.set(v.id, [v.position[0], v.position[1]]);
       }
       state.droppedFlushes = 0;

--- a/apps/simulator/src/modules/WebSocketBroadcaster.ts
+++ b/apps/simulator/src/modules/WebSocketBroadcaster.ts
@@ -158,7 +158,13 @@ export class WebSocketBroadcaster {
   private getClientState(client: WebSocket): ClientState {
     let state = this.clientStates.get(client);
     if (!state) {
-      state = { lastSent: new Map(), droppedFlushes: 0, lastPong: 0, lastPingSent: 0, filter: undefined };
+      state = {
+        lastSent: new Map(),
+        droppedFlushes: 0,
+        lastPong: 0,
+        lastPingSent: 0,
+        filter: undefined,
+      };
       this.clientStates.set(client, state);
     }
     return state;

--- a/apps/simulator/src/setup/websocket.ts
+++ b/apps/simulator/src/setup/websocket.ts
@@ -1,6 +1,7 @@
 import type { Server } from "http";
 import { WebSocketServer } from "ws";
 import { WebSocketBroadcaster } from "../modules/WebSocketBroadcaster";
+import type { SubscribeFilter } from "@moveet/shared-types";
 import logger from "../utils/logger";
 
 export interface WebSocketSetupResult {
@@ -19,6 +20,18 @@ export function setupWebSocket(server: Server): WebSocketSetupResult {
   wss.on("connection", (ws) => {
     broadcaster.trackClient(ws);
     logger.info(`Client connected (total: ${broadcaster.clientCount})`);
+
+    ws.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString()) as { type?: string; filter?: unknown };
+        if (msg.type === "subscribe") {
+          broadcaster.setClientFilter(ws, (msg.filter as SubscribeFilter | null) ?? null);
+          logger.debug({ filter: msg.filter }, "Client updated subscribe filter");
+        }
+      } catch {
+        // Ignore malformed messages
+      }
+    });
 
     ws.on("close", () => {
       logger.info(`Client disconnected (total: ${broadcaster.clientCount})`);

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -26,6 +26,7 @@ export type {
   AnalyticsSummary,
   FleetAnalytics,
   AnalyticsSnapshot,
+  SubscribeFilter,
 } from "@moveet/shared-types";
 
 // Re-export ExportVehicle under its old name for backwards compatibility

--- a/apps/ui/src/hooks/useFleets.test.ts
+++ b/apps/ui/src/hooks/useFleets.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/utils/client", () => ({
     onFleetCreated: vi.fn(),
     onFleetDeleted: vi.fn(),
     onFleetAssigned: vi.fn(),
+    subscribe: vi.fn(),
   },
 }));
 

--- a/apps/ui/src/hooks/useFleets.ts
+++ b/apps/ui/src/hooks/useFleets.ts
@@ -72,6 +72,17 @@ export function useFleets(): UseFleets {
     });
   }, []);
 
+  useEffect(() => {
+    if (hiddenFleetIds.size === 0) {
+      client.subscribe(null);
+    } else {
+      const visibleFleetIds = fleets
+        .map((f) => f.id)
+        .filter((id) => !hiddenFleetIds.has(id));
+      client.subscribe({ fleetIds: visibleFleetIds });
+    }
+  }, [hiddenFleetIds, fleets]);
+
   return {
     fleets,
     createFleet,

--- a/apps/ui/src/hooks/useFleets.ts
+++ b/apps/ui/src/hooks/useFleets.ts
@@ -76,9 +76,7 @@ export function useFleets(): UseFleets {
     if (hiddenFleetIds.size === 0) {
       client.subscribe(null);
     } else {
-      const visibleFleetIds = fleets
-        .map((f) => f.id)
-        .filter((id) => !hiddenFleetIds.has(id));
+      const visibleFleetIds = fleets.map((f) => f.id).filter((id) => !hiddenFleetIds.has(id));
       client.subscribe({ fleetIds: visibleFleetIds });
     }
   }, [hiddenFleetIds, fleets]);

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -35,6 +35,7 @@ import type {
   GeoFenceEvent,
   CreateGeoFenceRequest,
   UpdateGeoFenceRequest,
+  SubscribeFilter,
 } from "@moveet/shared-types";
 
 class SimulationService {
@@ -118,6 +119,7 @@ class SimulationService {
     this.toggleGeofence = this.toggleGeofence.bind(this);
     this.onGeofenceEvent = this.onGeofenceEvent.bind(this);
     this.offGeofenceEvent = this.offGeofenceEvent.bind(this);
+    this.subscribe = this.subscribe.bind(this);
   }
 
   connectWebSocket(): void {
@@ -445,6 +447,10 @@ class SimulationService {
 
   offGeofenceEvent(): void {
     this.ws.off("geofence-event");
+  }
+
+  subscribe(filter: SubscribeFilter | null): void {
+    this.ws.send({ type: "subscribe", filter });
   }
 }
 

--- a/apps/ui/src/utils/wsClient.ts
+++ b/apps/ui/src/utils/wsClient.ts
@@ -153,6 +153,12 @@ export class WebSocketClient {
     };
   }
 
+  send(message: object): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(message));
+    }
+  }
+
   on<T = unknown>(type: string, handler: HandlerFn<T>) {
     this.handlers.set(type, handler);
   }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -248,6 +248,29 @@ export interface UpdateGeoFenceRequest {
   active?: boolean;
 }
 
+// ─── WebSocket Subscribe Filters ─────────────────────────────────────
+
+/** Geographic bounding box for spatial filtering. */
+export interface BoundingBox {
+  minLat: number;
+  maxLat: number;
+  minLng: number;
+  maxLng: number;
+}
+
+/**
+ * Filter criteria for a WebSocket client's vehicle update subscription.
+ * All specified criteria must match (AND logic). Omitted fields are not filtered.
+ */
+export interface SubscribeFilter {
+  /** Only send vehicles assigned to these fleet IDs. Vehicles with no fleetId are excluded. */
+  fleetIds?: string[];
+  /** Only send vehicles of these types. */
+  vehicleTypes?: VehicleType[];
+  /** Only send vehicles whose position is within this bounding box. */
+  bbox?: BoundingBox;
+}
+
 // ─── Recording & Replay ────────────────────────────────────────────
 
 export interface RecordingMetadata {


### PR DESCRIPTION
## Summary

Implements the UI side of the WebSocket subscribe filter feature (fleetsim-all-hpo.4).

- **`wsClient.ts`**: Added `send(message: object): void` method to `WebSocketClient` that serialises and sends a JSON message when the socket is open.
- **`client.ts`**: Added `subscribe(filter: SubscribeFilter | null): void` to `SimulationService`, importing `SubscribeFilter` from `@moveet/shared-types`. Sends `{ type: "subscribe", filter }` over the WebSocket. Also bound the method in the constructor.
- **`useFleets.ts`**: Added a `useEffect` watching `[hiddenFleetIds, fleets]`. When no fleets are hidden it calls `client.subscribe(null)` (full stream); when some are hidden it computes `visibleFleetIds` and calls `client.subscribe({ fleetIds: visibleFleetIds })`.

The simulator already handles the `subscribe` message on its end (done in this branch). This completes the round-trip so toggling fleet visibility in the UI panel actually filters the vehicle stream at the source.

## Test plan

- [ ] Toggle a fleet's visibility in the Fleet panel and verify the simulator logs show a `subscribe` message with the correct `fleetIds`.
- [ ] Hide all non-default fleets and confirm only vehicles from visible fleets appear on the map.
- [ ] Re-show all fleets and confirm `subscribe(null)` is sent, resuming the full stream.
- [ ] Confirm no type errors: `npm run type-check --prefix apps/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)