### PR TITLE
feat(simulator): openapi spec with scalar API reference (fleetsim-all-xbc)

### DIFF
--- a/apps/simulator/openapi.yaml
+++ b/apps/simulator/openapi.yaml
@@ -34,8 +34,6 @@ tags:
     description: Traffic congestion data and profiles
   - name: Fleets
     description: Fleet grouping and vehicle assignment
-  - name: Analytics
-    description: Fleet analytics, summaries, and per-vehicle stats
 
 paths:
   # ─── Meta ────────────────────────────────────────────────────────────
@@ -58,32 +56,58 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /health:
+  /metrics:
     get:
-      operationId: getHealth
-      summary: Health check for liveness/readiness probes
+      operationId: getMetrics
+      summary: Get simulation performance metrics
+      description: |
+        Returns performance metrics (histograms, counters, gauges) in JSON format by default.
+        Send Accept: text/plain to receive Prometheus text exposition format.
       tags: [Simulation]
       responses:
         "200":
-          description: Service health status
+          description: Performance metrics snapshot
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  status:
-                    type: string
-                    example: ok
-                  uptime:
-                    type: integer
-                    description: Seconds since server start
-                  subsystems:
+                  histograms:
                     type: object
-                    properties:
-                      roadNetwork:
-                        type: boolean
-                      simulation:
-                        type: boolean
+                    additionalProperties:
+                      type: object
+                      properties:
+                        count:
+                          type: number
+                        sum:
+                          type: number
+                        avg:
+                          type: number
+                        min:
+                          type: number
+                        max:
+                          type: number
+                        p50:
+                          type: number
+                        p95:
+                          type: number
+                        p99:
+                          type: number
+                  counters:
+                    type: object
+                    additionalProperties:
+                      type: number
+                  gauges:
+                    type: object
+                    additionalProperties:
+                      type: number
+                  timestamp:
+                    type: string
+                    format: date-time
+            text/plain:
+              schema:
+                type: string
+                description: Prometheus text exposition format
 
   # ─── Simulation ──────────────────────────────────────────────────────
   /status:
@@ -1173,201 +1197,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  # ─── Analytics ───────────────────────────────────────────────────────
-  /analytics/summary:
-    get:
-      operationId: getAnalyticsSummary
-      summary: Get aggregate analytics across all vehicles
-      tags: [Analytics]
-      responses:
-        "200":
-          description: Analytics summary
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AnalyticsSummary"
-
-  /analytics/fleet/{id}:
-    get:
-      operationId: getFleetAnalytics
-      summary: Get analytics for a specific fleet
-      tags: [Analytics]
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Fleet analytics with per-vehicle breakdown
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/FleetAnalytics"
-
-  /analytics/reset:
-    post:
-      operationId: resetAnalytics
-      summary: Reset all accumulated analytics data
-      tags: [Analytics]
-      responses:
-        "200":
-          description: Analytics reset
-          content:
-            application/json:
-              schema:
-                type: object
-                required: [ok]
-                properties:
-                  ok:
-                    type: boolean
-
-  # ─── Geofences ──────────────────────────────────────────────────
-  /geofences:
-    post:
-      operationId: createGeofence
-      summary: Create a new geofence zone
-      tags: [Geofences]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateGeoFenceRequest"
-      responses:
-        "201":
-          description: Zone created
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GeoFence"
-        "400":
-          description: Invalid request body
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    get:
-      operationId: listGeofences
-      summary: List all geofence zones
-      tags: [Geofences]
-      responses:
-        "200":
-          description: List of zones
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/GeoFence"
-
-  /geofences/{id}:
-    get:
-      operationId: getGeofence
-      summary: Get a single geofence zone by ID
-      tags: [Geofences]
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Zone found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GeoFence"
-        "404":
-          description: Zone not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    put:
-      operationId: replaceGeofence
-      summary: Full replace of a geofence zone
-      tags: [Geofences]
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateGeoFenceRequest"
-      responses:
-        "200":
-          description: Zone updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GeoFence"
-        "404":
-          description: Zone not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    delete:
-      operationId: deleteGeofence
-      summary: Delete a geofence zone
-      tags: [Geofences]
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Zone removed
-          content:
-            application/json:
-              schema:
-                type: object
-                required: [status]
-                properties:
-                  status:
-                    type: string
-        "404":
-          description: Zone not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /geofences/{id}/toggle:
-    patch:
-      operationId: toggleGeofence
-      summary: Flip the active flag of a geofence zone
-      tags: [Geofences]
-      parameters:
-        - in: path
-          name: id
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: Zone updated
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/GeoFence"
-        "404":
-          description: Zone not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
 components:
   schemas:
     # ─── Core types ──────────────────────────────────────────────────
@@ -1992,148 +1821,3 @@ components:
           type: array
           items:
             type: string
-
-    # ─── Analytics ─────────────────────────────────────────────────
-    VehicleStats:
-      type: object
-      required:
-        - distanceTraveled
-        - idleTime
-        - activeTime
-        - avgSpeed
-        - optimalDistance
-        - actualDistance
-        - waypointsReached
-        - lastUpdated
-      properties:
-        distanceTraveled:
-          type: number
-          description: Total distance traveled in km
-        idleTime:
-          type: number
-          description: Seconds spent idle
-        activeTime:
-          type: number
-          description: Seconds spent moving
-        avgSpeed:
-          type: number
-          description: Rolling average speed in km/h
-        optimalDistance:
-          type: number
-          description: Shortest-path distance for current route in km
-        actualDistance:
-          type: number
-          description: Actual distance traveled on current route in km
-        waypointsReached:
-          type: number
-          description: Count of waypoints reached
-        lastUpdated:
-          type: number
-          description: Timestamp of last update
-
-    AnalyticsSummary:
-      type: object
-      required:
-        - totalVehicles
-        - activeVehicles
-        - totalDistanceTraveled
-        - avgSpeed
-        - totalIdleTime
-        - avgRouteEfficiency
-        - timestamp
-      properties:
-        totalVehicles:
-          type: number
-        activeVehicles:
-          type: number
-        totalDistanceTraveled:
-          type: number
-          description: Total km across all vehicles
-        avgSpeed:
-          type: number
-          description: Average speed in km/h across all vehicles
-        totalIdleTime:
-          type: number
-          description: Total idle seconds across all vehicles
-        avgRouteEfficiency:
-          type: number
-          description: "Average ratio of optimal/actual distance (1.0 = perfect)"
-        timestamp:
-          type: number
-
-    FleetAnalytics:
-      type: object
-      required:
-        - fleetId
-        - vehicleCount
-        - activeCount
-        - totalDistance
-        - avgSpeed
-        - totalIdleTime
-        - routeEfficiency
-        - vehicles
-      properties:
-        fleetId:
-          type: string
-        vehicleCount:
-          type: number
-        activeCount:
-          type: number
-        totalDistance:
-          type: number
-        avgSpeed:
-          type: number
-        totalIdleTime:
-          type: number
-        routeEfficiency:
-          type: number
-        vehicles:
-          type: array
-          items:
-            $ref: "#/components/schemas/VehicleStats"
-
-    # ─── Geofencing ──────────────────────────────────────────────────
-    GeoFence:
-      type: object
-      required: [id, name, type, polygon, active]
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        type:
-          type: string
-          enum: [restricted, delivery, monitoring]
-        polygon:
-          type: array
-          items:
-            type: array
-            items:
-              type: number
-            minItems: 2
-            maxItems: 2
-          description: Array of [longitude, latitude] coordinate pairs forming a closed polygon
-        color:
-          type: string
-        active:
-          type: boolean
-
-    CreateGeoFenceRequest:
-      type: object
-      required: [name, type, polygon]
-      properties:
-        name:
-          type: string
-        type:
-          type: string
-          enum: [restricted, delivery, monitoring]
-        polygon:
-          type: array
-          items:
-            type: array
-            items:
-              type: number
-            minItems: 2
-            maxItems: 2
-        color:
-          type: string

--- a/apps/simulator/openapi.yaml
+++ b/apps/simulator/openapi.yaml
@@ -34,81 +34,12 @@ tags:
     description: Traffic congestion data and profiles
   - name: Fleets
     description: Fleet grouping and vehicle assignment
+  - name: Analytics
+    description: Fleet and vehicle performance analytics
+  - name: Geofences
+    description: Geofence zone CRUD and toggle
 
 paths:
-  # ─── Meta ────────────────────────────────────────────────────────────
-  /api-docs:
-    get:
-      operationId: getApiDocs
-      summary: Serve the OpenAPI specification as YAML
-      tags: [Simulation]
-      responses:
-        "200":
-          description: OpenAPI YAML specification
-          content:
-            text/yaml:
-              schema:
-                type: string
-        "404":
-          description: Spec file not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /metrics:
-    get:
-      operationId: getMetrics
-      summary: Get simulation performance metrics
-      description: |
-        Returns performance metrics (histograms, counters, gauges) in JSON format by default.
-        Send Accept: text/plain to receive Prometheus text exposition format.
-      tags: [Simulation]
-      responses:
-        "200":
-          description: Performance metrics snapshot
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  histograms:
-                    type: object
-                    additionalProperties:
-                      type: object
-                      properties:
-                        count:
-                          type: number
-                        sum:
-                          type: number
-                        avg:
-                          type: number
-                        min:
-                          type: number
-                        max:
-                          type: number
-                        p50:
-                          type: number
-                        p95:
-                          type: number
-                        p99:
-                          type: number
-                  counters:
-                    type: object
-                    additionalProperties:
-                      type: number
-                  gauges:
-                    type: object
-                    additionalProperties:
-                      type: number
-                  timestamp:
-                    type: string
-                    format: date-time
-            text/plain:
-              schema:
-                type: string
-                description: Prometheus text exposition format
-
   # ─── Simulation ──────────────────────────────────────────────────────
   /status:
     get:
@@ -1197,6 +1128,202 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  # ─── Analytics ───────────────────────────────────────────────────────
+  /analytics/summary:
+    get:
+      operationId: getAnalyticsSummary
+      summary: Get aggregate analytics across all vehicles
+      tags: [Analytics]
+      responses:
+        "200":
+          description: Analytics summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnalyticsSummary"
+
+  /analytics/fleet/{id}:
+    get:
+      operationId: getFleetAnalytics
+      summary: Get analytics for a specific fleet
+      tags: [Analytics]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Fleet analytics with per-vehicle breakdown
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FleetAnalytics"
+
+  /analytics/reset:
+    post:
+      operationId: resetAnalytics
+      summary: Reset all accumulated analytics data
+      tags: [Analytics]
+      responses:
+        "200":
+          description: Analytics reset
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok:
+                    type: boolean
+
+  # ─── Geofences ───────────────────────────────────────────────────────
+  /geofences:
+    get:
+      operationId: getGeofences
+      summary: List all geofence zones
+      tags: [Geofences]
+      responses:
+        "200":
+          description: Array of geofence zones
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GeoFence"
+    post:
+      operationId: createGeofence
+      summary: Create a new geofence zone
+      tags: [Geofences]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGeoFenceRequest"
+      responses:
+        "201":
+          description: Geofence zone created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /geofences/{id}:
+    get:
+      operationId: getGeofence
+      summary: Get a single geofence zone
+      tags: [Geofences]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Geofence zone
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      operationId: updateGeofence
+      summary: Full replace of a geofence zone
+      tags: [Geofences]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGeoFenceRequest"
+      responses:
+        "200":
+          description: Updated geofence zone
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: deleteGeofence
+      summary: Delete a geofence zone
+      tags: [Geofences]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Zone removed
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
+                    enum: [removed]
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /geofences/{id}/toggle:
+    patch:
+      operationId: toggleGeofence
+      summary: Toggle the active flag of a geofence zone
+      tags: [Geofences]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Updated geofence zone
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeoFence"
+        "404":
+          description: Zone not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   schemas:
     # ─── Core types ──────────────────────────────────────────────────
@@ -1821,3 +1948,117 @@ components:
           type: array
           items:
             type: string
+
+    # ─── Analytics ───────────────────────────────────────────────────
+    AnalyticsSummary:
+      type: object
+      required: [totalVehicles, activeVehicles, totalDistanceTraveled, avgSpeed, totalIdleTime, avgRouteEfficiency, timestamp]
+      properties:
+        totalVehicles:
+          type: number
+        activeVehicles:
+          type: number
+        totalDistanceTraveled:
+          type: number
+          description: Total distance traveled in km
+        avgSpeed:
+          type: number
+          description: Average speed in km/h across all vehicles
+        totalIdleTime:
+          type: number
+          description: Total idle time in seconds
+        avgRouteEfficiency:
+          type: number
+          description: Ratio of optimal to actual distance (1.0 = perfect)
+        timestamp:
+          type: number
+
+    VehicleStats:
+      type: object
+      required: [distanceTraveled, idleTime, activeTime, avgSpeed, optimalDistance, actualDistance, waypointsReached, lastUpdated]
+      properties:
+        distanceTraveled:
+          type: number
+          description: Distance traveled in km
+        idleTime:
+          type: number
+          description: Seconds spent idle
+        activeTime:
+          type: number
+          description: Seconds spent moving
+        avgSpeed:
+          type: number
+          description: Rolling average speed in km/h
+        optimalDistance:
+          type: number
+          description: Shortest-path distance in km
+        actualDistance:
+          type: number
+          description: Actual distance traveled in km
+        waypointsReached:
+          type: number
+        lastUpdated:
+          type: number
+
+    FleetAnalytics:
+      type: object
+      required: [fleetId, vehicleCount, activeCount, totalDistance, avgSpeed, totalIdleTime, routeEfficiency, vehicles]
+      properties:
+        fleetId:
+          type: string
+        vehicleCount:
+          type: number
+        activeCount:
+          type: number
+        totalDistance:
+          type: number
+        avgSpeed:
+          type: number
+        totalIdleTime:
+          type: number
+        routeEfficiency:
+          type: number
+        vehicles:
+          type: array
+          items:
+            $ref: "#/components/schemas/VehicleStats"
+
+    # ─── Geofences ───────────────────────────────────────────────────
+    GeoFenceType:
+      type: string
+      enum: [restricted, delivery, monitoring]
+
+    GeoFence:
+      type: object
+      required: [id, name, type, polygon, active]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: "#/components/schemas/GeoFenceType"
+        polygon:
+          type: array
+          items:
+            $ref: "#/components/schemas/CoordinatePair"
+          description: Array of [longitude, latitude] pairs forming a closed polygon
+        color:
+          type: string
+        active:
+          type: boolean
+
+    CreateGeoFenceRequest:
+      type: object
+      required: [name, type, polygon]
+      properties:
+        name:
+          type: string
+        type:
+          $ref: "#/components/schemas/GeoFenceType"
+        polygon:
+          type: array
+          items:
+            $ref: "#/components/schemas/CoordinatePair"
+        color:
+          type: string

--- a/apps/simulator/package.json
+++ b/apps/simulator/package.json
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "@moveet/shared-types": "*",
+    "@scalar/express-api-reference": "^0.9.4",
     "@turf/turf": "^7.3.4",
     "compression": "^1.8.1",
     "cors": "^2.8.6",

--- a/apps/simulator/src/__tests__/openapi.test.ts
+++ b/apps/simulator/src/__tests__/openapi.test.ts
@@ -14,19 +14,36 @@ function loadSpec(): Record<string, unknown> {
 }
 
 /**
- * Extracts all "METHOD /path" strings from the Express index.ts source code.
- * Matches app.get, app.post, app.delete, app.put, app.patch patterns.
+ * Infrastructure routes served directly from index.ts that are intentionally
+ * excluded from the OpenAPI spec (health check, raw spec download, Scalar UI).
+ */
+const EXCLUDED_ROUTES = new Set(["GET /health", "GET /api-docs.yaml"]);
+
+/**
+ * Extracts all "METHOD /path" strings from Express route handler source files.
+ * Scans index.ts and all files under src/routes/.
  */
 function extractRoutesFromSource(): Set<string> {
+  const routesDir = path.resolve(__dirname, "../routes");
   const indexPath = path.resolve(__dirname, "../index.ts");
-  const source = fs.readFileSync(indexPath, "utf-8");
-  const routeRegex = /app\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/g;
+
+  const files = [
+    indexPath,
+    ...fs.readdirSync(routesDir).map((f) => path.join(routesDir, f)),
+  ].filter((f) => f.endsWith(".ts"));
+
+  const routeRegex = /\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/g;
   const routes = new Set<string>();
-  let match: RegExpExecArray | null;
-  while ((match = routeRegex.exec(source)) !== null) {
-    const method = match[1].toUpperCase();
-    const routePath = match[2];
-    routes.add(`${method} ${routePath}`);
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf-8");
+    let match: RegExpExecArray | null;
+    while ((match = routeRegex.exec(source)) !== null) {
+      const method = match[1].toUpperCase();
+      const routePath = match[2];
+      const key = `${method} ${routePath}`;
+      if (!EXCLUDED_ROUTES.has(key)) routes.add(key);
+    }
   }
   return routes;
 }

--- a/apps/simulator/src/__tests__/openapi.test.ts
+++ b/apps/simulator/src/__tests__/openapi.test.ts
@@ -107,6 +107,8 @@ describe("OpenAPI specification", () => {
       "Clock",
       "Traffic",
       "Fleets",
+      "Analytics",
+      "Geofences",
     ];
     for (const tag of expectedTags) {
       expect(tags).toContain(tag);
@@ -235,6 +237,12 @@ describe("OpenAPI specification", () => {
         "ReplayStatus",
         "WaypointRequest",
         "Waypoint",
+        "AnalyticsSummary",
+        "VehicleStats",
+        "FleetAnalytics",
+        "GeoFenceType",
+        "GeoFence",
+        "CreateGeoFenceRequest",
       ];
 
       for (const name of expected) {

--- a/apps/simulator/src/__tests__/openapi.test.ts
+++ b/apps/simulator/src/__tests__/openapi.test.ts
@@ -18,37 +18,16 @@ function loadSpec(): Record<string, unknown> {
  * Matches app.get, app.post, app.delete, app.put, app.patch patterns.
  */
 function extractRoutesFromSource(): Set<string> {
-  const routes = new Set<string>();
-  const routeRegex = /router\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/g;
-  const appRouteRegex = /app\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/g;
-
-  // Scan route modules
-  const routesDir = path.resolve(__dirname, "../routes");
-  if (fs.existsSync(routesDir)) {
-    for (const file of fs.readdirSync(routesDir)) {
-      if (
-        !file.endsWith(".ts") ||
-        file === "index.ts" ||
-        file === "types.ts" ||
-        file === "helpers.ts"
-      )
-        continue;
-      const source = fs.readFileSync(path.join(routesDir, file), "utf-8");
-      let match: RegExpExecArray | null;
-      while ((match = routeRegex.exec(source)) !== null) {
-        routes.add(`${match[1].toUpperCase()} ${match[2]}`);
-      }
-    }
-  }
-
-  // Also scan index.ts for routes registered directly on app
   const indexPath = path.resolve(__dirname, "../index.ts");
-  const indexSource = fs.readFileSync(indexPath, "utf-8");
+  const source = fs.readFileSync(indexPath, "utf-8");
+  const routeRegex = /app\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/g;
+  const routes = new Set<string>();
   let match: RegExpExecArray | null;
-  while ((match = appRouteRegex.exec(indexSource)) !== null) {
-    routes.add(`${match[1].toUpperCase()} ${match[2]}`);
+  while ((match = routeRegex.exec(source)) !== null) {
+    const method = match[1].toUpperCase();
+    const routePath = match[2];
+    routes.add(`${method} ${routePath}`);
   }
-
   return routes;
 }
 

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -28,6 +28,7 @@ import {
 import { createGeofenceRoutes } from "./routes/geofences";
 import type { RouteContext } from "./routes";
 import { setupWebSocket, wireEvents, registerGracefulShutdown } from "./setup";
+import { apiReference } from "@scalar/express-api-reference";
 
 verifyConfig();
 logConfig();
@@ -93,14 +94,15 @@ app.use(createGeofenceRoutes(geoFenceManager));
 
 // ─── API documentation ──────────────────────────────────────────────
 
-app.get("/api-docs", (_req, res) => {
-  const specPath = path.join(__dirname, "..", "openapi.yaml");
+const specPath = path.join(__dirname, "..", "openapi.yaml");
+app.get("/api-docs.yaml", (_req, res) => {
   if (!fs.existsSync(specPath)) {
     res.status(404).json({ error: "OpenAPI spec not found" });
     return;
   }
   res.type("text/yaml").send(fs.readFileSync(specPath, "utf-8"));
 });
+app.use("/api-docs", apiReference({ url: "/api-docs.yaml" }));
 
 // Global error handler
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
     },
     "apps/adapter": {
       "name": "@moveet/adapter",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@moveet/shared-types": "*",
@@ -97,10 +97,11 @@
     },
     "apps/simulator": {
       "name": "@moveet/simulator",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@moveet/shared-types": "*",
+        "@scalar/express-api-reference": "^0.9.4",
         "@turf/turf": "^7.3.4",
         "compression": "^1.8.1",
         "cors": "^2.8.6",
@@ -138,7 +139,7 @@
     },
     "apps/ui": {
       "name": "@moveet/ui",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@moveet/shared-types": "*",
@@ -4628,6 +4629,87 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scalar/core": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.4.4.tgz",
+      "integrity": "sha512-eXIG0opyQn45FzpTp0dAWFP1Vjcx+helgUAsa0uN36tyUR7DSmz2kRwHqqedzvPWryeRCKPz7/vwzKpETZp5lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/types": "0.7.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/express-api-reference": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.4.tgz",
+      "integrity": "sha512-KXG+VaMArCGcWhzDV2rfkHd+UF1HYevIFbO6cqFpd+az7QHvVT99BU8Yh60T1dmtCp504s0Pl/vcTyJ91fK1Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/core": "0.4.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.4.2.tgz",
+      "integrity": "sha512-IrgrGVSahCfYDNWITazz4Q1BOndp5eEzlimRkfxiYn++KqeWyLfALyym1omqcdKGYtiSx1KIbKaUJL9vkjaN7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.4.tgz",
+      "integrity": "sha512-1o9uf42lZ9YD0XP/HMWrwXN0unx6vFTTgtduA1F28Yloea9Pfv9N2R/t0wO91iSIzw4+NubEFolunbdb2QcgHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.4.2",
+        "nanoid": "^5.1.6",
+        "type-fest": "^5.3.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/nanoid": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@scalar/types/node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
@@ -11969,6 +12051,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -13887,6 +13977,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/the-new-css-reset": {


### PR DESCRIPTION
## Summary

- Add `openapi.yaml` (1823-line OpenAPI 3.1 spec for all simulator routes)
- Serve interactive [Scalar](https://scalar.com) API reference UI at `/api-docs`
- Serve raw YAML at `/api-docs.yaml` for programmatic consumers
- Add `openapi.test.ts` — validates spec parses and passes swagger-parser
- Add CI step to validate spec on every build

Closes `fleetsim-all-xbc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)