### PR TITLE
feat(ws): centralize subscribe filter with vehicle type filtering

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -16,6 +16,7 @@ import { useAdapterConfig } from "./Controls/Adapter/useAdapterConfig";
 import useTracking from "./Controls/useTracking";
 import MapView from "./Map/Map";
 import FleetLegend from "./Map/FleetLegend";
+import TypeLegend from "./Map/TypeLegend";
 import SearchBar from "./SearchBar";
 import Zoom from "./Zoom/";
 import GeofencePanel from "./Controls/GeofencePanel";
@@ -33,6 +34,8 @@ import type { GeoFence, GeoFenceEvent, CreateGeoFenceRequest } from "@moveet/sha
 import styles from "./App.module.css";
 import { useVehicles } from "./hooks/useVehicles";
 import { useFleets } from "./hooks/useFleets";
+import { useVehicleTypeFilter } from "./hooks/useVehicleTypeFilter";
+import { useSubscribeFilter } from "./hooks/useSubscribeFilter";
 import { useIncidents } from "./hooks/useIncidents";
 import { useRecording } from "./hooks/useRecording";
 import { useReplay } from "./hooks/useReplay";
@@ -90,6 +93,9 @@ export default function App() {
   } = useVehicles();
 
   const { fleets, createFleet, deleteFleet, hiddenFleetIds, toggleFleetVisibility } = useFleets();
+  const { hiddenVehicleTypes, toggleVehicleType } = useVehicleTypeFilter();
+
+  useSubscribeFilter(fleets, hiddenFleetIds, hiddenVehicleTypes);
 
   const incidents = useIncidents();
   const recording = useRecording();
@@ -480,6 +486,7 @@ export default function App() {
               hiddenFleetIds={hiddenFleetIds}
               onToggle={toggleFleetVisibility}
             />
+            <TypeLegend hiddenVehicleTypes={hiddenVehicleTypes} onToggle={toggleVehicleType} />
             <BottomDock
               status={status}
               connected={connected}

--- a/apps/ui/src/Map/TypeLegend.module.css
+++ b/apps/ui/src/Map/TypeLegend.module.css
@@ -1,0 +1,46 @@
+.legend {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: rgba(17, 17, 17, 0.85);
+  backdrop-filter: blur(8px);
+  border: var(--surface-border);
+  border-radius: var(--radius-md);
+  pointer-events: auto;
+  z-index: 10;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-xs);
+  transition: background var(--transition-fast);
+}
+
+.item:hover {
+  background: var(--surface-bg-hover);
+}
+
+.hidden {
+  opacity: 0.4;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.name {
+  font-size: var(--text-sm);
+  color: var(--color-gray-lightest);
+  white-space: nowrap;
+}

--- a/apps/ui/src/Map/TypeLegend.tsx
+++ b/apps/ui/src/Map/TypeLegend.tsx
@@ -1,0 +1,34 @@
+import classNames from "classnames";
+import type { VehicleType } from "@/types";
+import styles from "./TypeLegend.module.css";
+
+const VEHICLE_TYPES: { type: VehicleType; label: string; color: string }[] = [
+  { type: "car", label: "Car", color: "#dcdcdc" },
+  { type: "truck", label: "Truck", color: "#f59e0b" },
+  { type: "motorcycle", label: "Moto", color: "#8b5cf6" },
+  { type: "ambulance", label: "Ambulance", color: "#ef4444" },
+  { type: "bus", label: "Bus", color: "#3b82f6" },
+];
+
+interface TypeLegendProps {
+  hiddenVehicleTypes: Set<VehicleType>;
+  onToggle: (type: VehicleType) => void;
+}
+
+export default function TypeLegend({ hiddenVehicleTypes, onToggle }: TypeLegendProps) {
+  return (
+    <div className={styles.legend}>
+      {VEHICLE_TYPES.map(({ type, label, color }) => (
+        <div
+          key={type}
+          className={classNames(styles.item, { [styles.hidden]: hiddenVehicleTypes.has(type) })}
+          onClick={() => onToggle(type)}
+          title={hiddenVehicleTypes.has(type) ? `Show ${label}` : `Hide ${label}`}
+        >
+          <span className={styles.dot} style={{ backgroundColor: color }} />
+          <span className={styles.name}>{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/useFleets.ts
+++ b/apps/ui/src/hooks/useFleets.ts
@@ -72,15 +72,6 @@ export function useFleets(): UseFleets {
     });
   }, []);
 
-  useEffect(() => {
-    if (hiddenFleetIds.size === 0) {
-      client.subscribe(null);
-    } else {
-      const visibleFleetIds = fleets.map((f) => f.id).filter((id) => !hiddenFleetIds.has(id));
-      client.subscribe({ fleetIds: visibleFleetIds });
-    }
-  }, [hiddenFleetIds, fleets]);
-
   return {
     fleets,
     createFleet,

--- a/apps/ui/src/hooks/useSubscribeFilter.test.ts
+++ b/apps/ui/src/hooks/useSubscribeFilter.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useSubscribeFilter } from "./useSubscribeFilter";
+import client from "@/utils/client";
+import type { VehicleType } from "@/types";
+
+vi.mock("@/utils/client", () => ({
+  default: {
+    subscribe: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/Map/providers/contexts", () => ({
+  MapContext: {
+    _currentValue: {
+      transform: null,
+      getBoundingBox: () => [
+        [0, 0],
+        [0, 0],
+      ],
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const fleets = [{ id: "fleet-a" }, { id: "fleet-b" }, { id: "fleet-c" }];
+
+describe("useSubscribeFilter", () => {
+  it("sends null when no filters are active", () => {
+    renderHook(() => useSubscribeFilter(fleets, new Set(), new Set()));
+
+    vi.advanceTimersByTime(200);
+    expect(client.subscribe).toHaveBeenCalledWith(null);
+  });
+
+  it("sends fleetIds filter when fleets are hidden", () => {
+    const hidden = new Set(["fleet-b"]);
+
+    renderHook(() => useSubscribeFilter(fleets, hidden, new Set()));
+
+    vi.advanceTimersByTime(200);
+    expect(client.subscribe).toHaveBeenCalledWith({
+      fleetIds: ["fleet-a", "fleet-c"],
+    });
+  });
+
+  it("sends vehicleTypes filter when types are hidden", () => {
+    const hiddenTypes = new Set<VehicleType>(["truck", "bus"]);
+
+    renderHook(() => useSubscribeFilter(fleets, new Set(), hiddenTypes));
+
+    vi.advanceTimersByTime(200);
+    expect(client.subscribe).toHaveBeenCalledWith({
+      vehicleTypes: ["car", "motorcycle", "ambulance"],
+    });
+  });
+
+  it("sends combined filter when both fleet and type are hidden", () => {
+    const hiddenFleets = new Set(["fleet-a"]);
+    const hiddenTypes = new Set<VehicleType>(["ambulance"]);
+
+    renderHook(() => useSubscribeFilter(fleets, hiddenFleets, hiddenTypes));
+
+    vi.advanceTimersByTime(200);
+    expect(client.subscribe).toHaveBeenCalledWith({
+      fleetIds: ["fleet-b", "fleet-c"],
+      vehicleTypes: ["car", "truck", "motorcycle", "bus"],
+    });
+  });
+
+  it("debounces rapid changes", () => {
+    const { rerender } = renderHook(
+      ({ hidden }: { hidden: Set<string> }) => useSubscribeFilter(fleets, hidden, new Set()),
+      { initialProps: { hidden: new Set<string>() } }
+    );
+
+    // Rapid changes before debounce fires
+    rerender({ hidden: new Set(["fleet-a"]) });
+    rerender({ hidden: new Set(["fleet-a", "fleet-b"]) });
+
+    // Only the last one should fire
+    vi.advanceTimersByTime(200);
+    expect(client.subscribe).toHaveBeenCalledTimes(1);
+    expect(client.subscribe).toHaveBeenCalledWith({
+      fleetIds: ["fleet-c"],
+    });
+  });
+});

--- a/apps/ui/src/hooks/useSubscribeFilter.ts
+++ b/apps/ui/src/hooks/useSubscribeFilter.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+import client from "@/utils/client";
+import type { VehicleType } from "@/types";
+import type { SubscribeFilter } from "@moveet/shared-types";
+
+/**
+ * Centralizes all subscribe filter dimensions (fleet, type) into a
+ * single WebSocket subscribe call. Debounces to coalesce rapid changes.
+ */
+export function useSubscribeFilter(
+  fleets: { id: string }[],
+  hiddenFleetIds: Set<string>,
+  hiddenVehicleTypes: Set<VehicleType>
+): void {
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(() => {
+      const filter = buildFilter(fleets, hiddenFleetIds, hiddenVehicleTypes);
+      client.subscribe(filter);
+    }, 150);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [hiddenFleetIds, hiddenVehicleTypes, fleets]);
+}
+
+const ALL_VEHICLE_TYPES: VehicleType[] = ["car", "truck", "motorcycle", "ambulance", "bus"];
+
+function buildFilter(
+  fleets: { id: string }[],
+  hiddenFleetIds: Set<string>,
+  hiddenVehicleTypes: Set<VehicleType>
+): SubscribeFilter | null {
+  const hasFleetFilter = hiddenFleetIds.size > 0;
+  const hasTypeFilter = hiddenVehicleTypes.size > 0;
+
+  // No filters active → null (receive everything)
+  if (!hasFleetFilter && !hasTypeFilter) return null;
+
+  const filter: SubscribeFilter = {};
+
+  if (hasFleetFilter) {
+    filter.fleetIds = fleets.map((f) => f.id).filter((id) => !hiddenFleetIds.has(id));
+  }
+
+  if (hasTypeFilter) {
+    filter.vehicleTypes = ALL_VEHICLE_TYPES.filter((t) => !hiddenVehicleTypes.has(t));
+  }
+
+  return filter;
+}

--- a/apps/ui/src/hooks/useVehicleTypeFilter.test.ts
+++ b/apps/ui/src/hooks/useVehicleTypeFilter.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useVehicleTypeFilter } from "./useVehicleTypeFilter";
+
+describe("useVehicleTypeFilter", () => {
+  it("initializes with empty hidden set", () => {
+    const { result } = renderHook(() => useVehicleTypeFilter());
+    expect(result.current.hiddenVehicleTypes).toEqual(new Set());
+  });
+
+  it("toggles a type on and off", () => {
+    const { result } = renderHook(() => useVehicleTypeFilter());
+
+    act(() => {
+      result.current.toggleVehicleType("truck");
+    });
+    expect(result.current.hiddenVehicleTypes.has("truck")).toBe(true);
+
+    act(() => {
+      result.current.toggleVehicleType("truck");
+    });
+    expect(result.current.hiddenVehicleTypes.has("truck")).toBe(false);
+  });
+
+  it("tracks multiple hidden types independently", () => {
+    const { result } = renderHook(() => useVehicleTypeFilter());
+
+    act(() => {
+      result.current.toggleVehicleType("truck");
+      result.current.toggleVehicleType("bus");
+    });
+
+    expect(result.current.hiddenVehicleTypes.has("truck")).toBe(true);
+    expect(result.current.hiddenVehicleTypes.has("bus")).toBe(true);
+    expect(result.current.hiddenVehicleTypes.has("car")).toBe(false);
+
+    act(() => {
+      result.current.toggleVehicleType("truck");
+    });
+
+    expect(result.current.hiddenVehicleTypes.has("truck")).toBe(false);
+    expect(result.current.hiddenVehicleTypes.has("bus")).toBe(true);
+  });
+});

--- a/apps/ui/src/hooks/useVehicleTypeFilter.ts
+++ b/apps/ui/src/hooks/useVehicleTypeFilter.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from "react";
+import type { VehicleType } from "@/types";
+
+export interface UseVehicleTypeFilter {
+  hiddenVehicleTypes: Set<VehicleType>;
+  toggleVehicleType: (type: VehicleType) => void;
+}
+
+export function useVehicleTypeFilter(): UseVehicleTypeFilter {
+  const [hiddenVehicleTypes, setHiddenVehicleTypes] = useState<Set<VehicleType>>(new Set());
+
+  const toggleVehicleType = useCallback((type: VehicleType) => {
+    setHiddenVehicleTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) next.delete(type);
+      else next.add(type);
+      return next;
+    });
+  }, []);
+
+  return { hiddenVehicleTypes, toggleVehicleType };
+}


### PR DESCRIPTION
## Summary
- Move subscribe call from `useFleets` into centralized `useSubscribeFilter` hook that combines fleet + vehicle type filters into a single debounced WebSocket subscribe message
- Add `TypeLegend` component (bottom-left map overlay) for toggling vehicle type visibility — clicking a type hides it server-side via subscribe filter
- Add `useVehicleTypeFilter` hook for managing hidden vehicle types state

## Test plan
- [x] All 469 UI tests pass (8 new)
- [x] TypeScript type-check clean
- [ ] Manual: toggle fleet visibility still sends subscribe with fleetIds
- [ ] Manual: click vehicle type in TypeLegend → server stops sending that type
- [ ] Manual: rapid toggling debounces correctly (single subscribe call)

Closes fleetsim-all-hpo.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)