### PR TITLE
fix(scenario): ESM __dirname compatibility

### DIFF
--- a/apps/simulator/src/routes/scenarios.ts
+++ b/apps/simulator/src/routes/scenarios.ts
@@ -8,7 +8,7 @@ import { validateBody } from "../middleware/validate";
 import { scenarioSchema } from "../modules/scenario";
 import { convertRecordingToScenario, parseRecording } from "../modules/scenario/convertRecording";
 
-const SCENARIOS_DIR = path.join(__dirname, "../../data/scenarios");
+const SCENARIOS_DIR = path.resolve("data/scenarios");
 const RECORDINGS_DIR = path.resolve("recordings");
 
 /**


### PR DESCRIPTION
## Summary

- Fix `ReferenceError: __dirname is not defined in ES module scope` in `scenarios.ts`
- Replace `path.join(__dirname, "../../data/scenarios")` with `path.resolve("data/scenarios")`
- Matches the pattern used by `recording.ts` for its recordings directory

## Test plan

- [x] 1258 simulator tests pass
- [x] TypeScript type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)