### PR TITLE
fix: geofence events, trail visibility, fleet assignment + event naming

### DIFF
--- a/apps/network/package.json
+++ b/apps/network/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
-    "inquirer": "^10.2.2",
+    "inquirer": "^13.3.2",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "zod": "^4.3.6"

--- a/apps/simulator/src/__tests__/GeoFenceManager.test.ts
+++ b/apps/simulator/src/__tests__/GeoFenceManager.test.ts
@@ -135,7 +135,7 @@ describe("GeoFenceManager", () => {
     it("detects a vehicle inside the polygon and emits 'enter'", () => {
       manager.addZone(makeFence());
       const listener = vi.fn();
-      manager.on("geofence-event", listener);
+      manager.on("geofence:event", listener);
 
       const inside = makeVehicle("v1", [0.5, 0.5]); // lat=0.5, lng=0.5 → inside
       manager.checkVehicles([inside]);
@@ -145,13 +145,13 @@ describe("GeoFenceManager", () => {
       expect(event.event).toBe("enter");
       expect(event.vehicleId).toBe("v1");
       expect(event.fenceId).toBe("fence-1");
-      expect(event.type).toBe("geofence-event");
+      expect(event.type).toBe("geofence:event");
     });
 
     it("does not emit for a vehicle outside the polygon", () => {
       manager.addZone(makeFence());
       const listener = vi.fn();
-      manager.on("geofence-event", listener);
+      manager.on("geofence:event", listener);
 
       const outside = makeVehicle("v2", [2.0, 2.0]); // lat=2, lng=2 → outside
       manager.checkVehicles([outside]);
@@ -162,7 +162,7 @@ describe("GeoFenceManager", () => {
     it("emits 'exit' when a vehicle leaves the polygon", () => {
       manager.addZone(makeFence());
       const events: GeoFenceEvent[] = [];
-      manager.on("geofence-event", (e) => events.push(e));
+      manager.on("geofence:event", (e) => events.push(e));
 
       const vehicle = makeVehicle("v3", [0.5, 0.5]); // inside
       manager.checkVehicles([vehicle]);
@@ -179,7 +179,7 @@ describe("GeoFenceManager", () => {
     it("does not emit when a vehicle stays inside across ticks", () => {
       manager.addZone(makeFence());
       const listener = vi.fn();
-      manager.on("geofence-event", listener);
+      manager.on("geofence:event", listener);
 
       const vehicle = makeVehicle("v4", [0.5, 0.5]);
       manager.checkVehicles([vehicle]);
@@ -190,7 +190,7 @@ describe("GeoFenceManager", () => {
     it("does not emit when a vehicle stays outside across ticks", () => {
       manager.addZone(makeFence());
       const listener = vi.fn();
-      manager.on("geofence-event", listener);
+      manager.on("geofence:event", listener);
 
       const vehicle = makeVehicle("v5", [2.0, 2.0]);
       manager.checkVehicles([vehicle]);
@@ -201,7 +201,7 @@ describe("GeoFenceManager", () => {
     it("ignores inactive zones", () => {
       manager.addZone(makeFence({ active: false }));
       const listener = vi.fn();
-      manager.on("geofence-event", listener);
+      manager.on("geofence:event", listener);
 
       const inside = makeVehicle("v6", [0.5, 0.5]);
       manager.checkVehicles([inside]);
@@ -220,7 +220,7 @@ describe("GeoFenceManager", () => {
       manager.addZone(makeFence({ id: "z2", polygon: polygon2 }));
 
       const events: GeoFenceEvent[] = [];
-      manager.on("geofence-event", (e) => events.push(e));
+      manager.on("geofence:event", (e) => events.push(e));
 
       // Vehicle inside zone z1 only
       manager.checkVehicles([makeVehicle("v7", [0.5, 0.5])]);
@@ -233,7 +233,7 @@ describe("GeoFenceManager", () => {
     it("cleans up zone membership when a zone is removed", () => {
       manager.addZone(makeFence());
       const events: GeoFenceEvent[] = [];
-      manager.on("geofence-event", (e) => events.push(e));
+      manager.on("geofence:event", (e) => events.push(e));
 
       manager.checkVehicles([makeVehicle("v8", [0.5, 0.5])]); // enter
       expect(events).toHaveLength(1);

--- a/apps/simulator/src/__tests__/SimulationController.test.ts
+++ b/apps/simulator/src/__tests__/SimulationController.test.ts
@@ -260,10 +260,10 @@ describe("SimulationController lifecycle", () => {
   // ─── stopReplay without an active replay ──────────────────────────
 
   describe("stopReplay without active replay", () => {
-    it("transitions mode back to live and emits replayStatus", () => {
+    it("transitions mode back to live and emits replay:status", () => {
       (controller as unknown as Record<string, unknown>)._mode = "replay";
       const handler = vi.fn();
-      controller.on("replayStatus", handler);
+      controller.on("replay:status", handler);
       controller.stopReplay();
       expect(controller.mode).toBe("live");
       expect(handler).toHaveBeenCalledWith({ mode: "live" });
@@ -359,13 +359,13 @@ describe("SimulationController lifecycle", () => {
   // ─── Event forwarding from ReplayManager ─────────────────────────
 
   describe("replay event forwarding", () => {
-    it("forwards replayStatus events to listeners", async () => {
+    it("forwards replay:status events to listeners", async () => {
       const filePath = tmpFile("test7.ndjson");
       writeTestRecording(filePath);
       const handler = vi.fn();
-      controller.on("replayStatus", handler);
+      controller.on("replay:status", handler);
       await controller.startReplay(filePath);
-      // startReplay calls replay.startReplay which emits replayStatus
+      // startReplay calls replay.startReplay which emits replay:status
       expect(handler).toHaveBeenCalled();
     });
   });

--- a/apps/simulator/src/__tests__/setup/eventWiring.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiring.test.ts
@@ -308,8 +308,8 @@ describe("wireEvents", () => {
 
     it("should broadcast replay status events", () => {
       const data = { mode: "replay", progress: 0.5 };
-      simulationController.emit("replayStatus", data);
-      expect(broadcaster.broadcast).toHaveBeenCalledWith("replayStatus", data);
+      simulationController.emit("replay:status", data);
+      expect(broadcaster.broadcast).toHaveBeenCalledWith("replay:status", data);
     });
   });
 

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -99,7 +99,7 @@ app.use(createGeofenceRoutes(geoFenceManager));
 
 // ─── API documentation ──────────────────────────────────────────────
 
-const specPath = path.join(__dirname, "..", "openapi.yaml");
+const specPath = path.resolve("openapi.yaml");
 app.get("/api-docs.yaml", (_req, res) => {
   if (!fs.existsSync(specPath)) {
     res.status(404).json({ error: "OpenAPI spec not found" });

--- a/apps/simulator/src/modules/GeoFenceManager.ts
+++ b/apps/simulator/src/modules/GeoFenceManager.ts
@@ -31,7 +31,7 @@ function pointInPolygon(point: [number, number], polygon: [number, number][]): b
  * Manages geofence zones and emits enter/exit events as vehicles cross zone
  * boundaries. Uses ray-casting for point-in-polygon checks.
  *
- * Emits: 'geofence-event' (GeoFenceEvent) on each enter/exit transition.
+ * Emits: 'geofence:event' (GeoFenceEvent) on each enter/exit transition.
  */
 export class GeoFenceManager extends EventEmitter {
   /** Active and inactive zones keyed by fence id. */
@@ -93,7 +93,7 @@ export class GeoFenceManager extends EventEmitter {
 
   /**
    * Checks all active zones for each vehicle and detects enter/exit
-   * transitions. Emits `"geofence-event"` for each transition detected.
+   * transitions. Emits `"geofence:event"` for each transition detected.
    *
    * Vehicle position is [lat, lng]; polygon coordinates are [lng, lat].
    * We reorder to [lng, lat] before passing to pointInPolygon.
@@ -119,7 +119,7 @@ export class GeoFenceManager extends EventEmitter {
           // Enter transition
           vehicleFences.add(zone.id);
           const event: GeoFenceEvent = {
-            type: "geofence-event",
+            type: "geofence:event",
             fenceId: zone.id,
             fenceName: zone.name,
             vehicleId: vehicle.id,
@@ -127,12 +127,12 @@ export class GeoFenceManager extends EventEmitter {
             event: "enter",
             timestamp: new Date().toISOString(),
           };
-          this.emit("geofence-event", event);
+          this.emit("geofence:event", event);
         } else if (!isInside && wasInside) {
           // Exit transition
           vehicleFences.delete(zone.id);
           const event: GeoFenceEvent = {
-            type: "geofence-event",
+            type: "geofence:event",
             fenceId: zone.id,
             fenceName: zone.name,
             vehicleId: vehicle.id,
@@ -140,7 +140,7 @@ export class GeoFenceManager extends EventEmitter {
             event: "exit",
             timestamp: new Date().toISOString(),
           };
-          this.emit("geofence-event", event);
+          this.emit("geofence:event", event);
         }
       }
     }

--- a/apps/simulator/src/modules/ReplayManager.ts
+++ b/apps/simulator/src/modules/ReplayManager.ts
@@ -17,7 +17,7 @@ type ReplayEventMap = {
   "simulation:start": [unknown];
   "simulation:stop": [unknown];
   "simulation:reset": [unknown];
-  replayStatus: [ReplayStatus];
+  "replay:status": [ReplayStatus];
   replayEnd: [];
 };
 
@@ -342,7 +342,7 @@ export class ReplayManager extends EventEmitter<ReplayEventMap> {
    * Emits the current replay status.
    */
   private emitStatus(): void {
-    this.emit("replayStatus", this.getStatus());
+    this.emit("replay:status", this.getStatus());
   }
 
   /**

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -27,7 +27,7 @@ interface ResetPayload {
 type EventEmitterMap = {
   updateStatus: [SimulationStatus];
   reset: [ResetPayload];
-  replayStatus: [ReplayStatus];
+  "replay:status": [ReplayStatus];
   replayVehicle: [unknown];
   replayDirection: [unknown];
   "replayIncident:created": [unknown];
@@ -439,7 +439,7 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
       this.replayManager = undefined;
     }
     this._mode = "live";
-    this.emit("replayStatus", { mode: "live" });
+    this.emit("replay:status", { mode: "live" });
   }
 
   /**
@@ -495,8 +495,8 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
       });
     }
 
-    rm.on("replayStatus", (status: ReplayStatus) => {
-      this.emit("replayStatus", status);
+    rm.on("replay:status", (status: ReplayStatus) => {
+      this.emit("replay:status", status);
     });
 
     rm.on("replayEnd", () => {

--- a/apps/simulator/src/routes/scenarios.ts
+++ b/apps/simulator/src/routes/scenarios.ts
@@ -8,7 +8,7 @@ import { validateBody } from "../middleware/validate";
 import { scenarioSchema } from "../modules/scenario";
 import { convertRecordingToScenario, parseRecording } from "../modules/scenario/convertRecording";
 
-const SCENARIOS_DIR = path.join(__dirname, "../../data/scenarios");
+const SCENARIOS_DIR = path.resolve("data/scenarios");
 const RECORDINGS_DIR = path.resolve("recordings");
 
 /**

--- a/apps/simulator/src/setup/eventWiring.ts
+++ b/apps/simulator/src/setup/eventWiring.ts
@@ -56,8 +56,8 @@ export function wireEvents(ctx: EventWiringContext): {
   });
 
   // ─── Geofence event → WS broadcaster ───────────────────────────────
-  geoFenceManager.on("geofence-event", (event) => {
-    broadcaster.broadcast("geofence-event", event);
+  geoFenceManager.on("geofence:event", (event) => {
+    broadcaster.broadcast("geofence:event", event);
   });
 
   // ─── Non-vehicle events (broadcast immediately) ─────────────────────
@@ -131,7 +131,7 @@ export function wireEvents(ctx: EventWiringContext): {
   simulationController.on("replayVehicle:rerouted", (data) =>
     broadcaster.broadcast("vehicle:rerouted", data)
   );
-  simulationController.on("replayStatus", (data) => broadcaster.broadcast("replayStatus", data));
+  simulationController.on("replay:status", (data) => broadcaster.broadcast("replay:status", data));
 
   // ─── Scenario events → WS broadcaster ─────────────────────────────
   scenarioManager.on("scenario:started", (data) => broadcaster.broadcast("scenario:started", data));

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -93,7 +93,15 @@ export default function App() {
     onFilterChange,
   } = useVehicles();
 
-  const { fleets, createFleet, deleteFleet, hiddenFleetIds, toggleFleetVisibility } = useFleets();
+  const {
+    fleets,
+    createFleet,
+    deleteFleet,
+    assignVehicle,
+    unassignVehicle,
+    hiddenFleetIds,
+    toggleFleetVisibility,
+  } = useFleets();
   const { hiddenVehicleTypes, toggleVehicleType } = useVehicleTypeFilter();
 
   useSubscribeFilter(fleets, hiddenFleetIds, hiddenVehicleTypes);
@@ -394,7 +402,14 @@ export default function App() {
                 </>
               )}
               {activePanel === "fleets" && (
-                <Fleets fleets={fleets} onCreateFleet={createFleet} onDeleteFleet={deleteFleet} />
+                <Fleets
+                  fleets={fleets}
+                  vehicles={vehicles}
+                  onCreateFleet={createFleet}
+                  onDeleteFleet={deleteFleet}
+                  onAssignVehicle={assignVehicle}
+                  onUnassignVehicle={unassignVehicle}
+                />
               )}
               {activePanel === "incidents" && (
                 <Incidents

--- a/apps/ui/src/Controls/Fleets.module.css
+++ b/apps/ui/src/Controls/Fleets.module.css
@@ -19,22 +19,40 @@
   gap: var(--space-2);
 }
 
+.fleetCard {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  border: var(--surface-border);
+  overflow: hidden;
+  transition: border-color var(--transition-fast);
+}
+
+.fleetCard:hover {
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
 .fleet {
   display: flex;
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-3);
-  border-radius: var(--radius-sm);
-  background: var(--surface-bg);
-  border: var(--surface-border);
-  transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast);
+  background: transparent;
+  border: none;
+  width: 100%;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  transition: background var(--transition-fast);
 }
 
 .fleet:hover {
   background: var(--surface-bg-hover);
-  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.fleetExpanded {
+  background: var(--surface-bg-hover);
 }
 
 .colorDot {
@@ -101,4 +119,124 @@
   border-color: var(--focus-border);
   box-shadow: var(--focus-ring);
   background: var(--focus-bg);
+}
+
+/* ─── Vehicle assignment section ─────────────────────────────────── */
+
+.vehicleSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.sectionLabel {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-gray);
+  padding-bottom: var(--space-1);
+}
+
+.memberList,
+.addVehicleSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.unassignedList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.memberRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-xs);
+  transition: background var(--transition-fast);
+}
+
+.memberRow:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.memberName {
+  font-size: var(--text-sm);
+  color: var(--color-gray-lightest);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.removeButton,
+.assignButton {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-xs);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-gray);
+  font-size: var(--text-base);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.removeButton:hover {
+  background: rgba(255, 80, 80, 0.12);
+  border-color: rgba(255, 80, 80, 0.2);
+  color: rgba(255, 80, 80, 0.9);
+}
+
+.assignButton:hover {
+  background: rgba(80, 220, 80, 0.12);
+  border-color: rgba(80, 220, 80, 0.2);
+  color: rgba(80, 220, 80, 0.9);
+}
+
+.vehicleFilterInput {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 var(--space-3);
+  height: var(--control-sm);
+  font-size: var(--text-sm);
+  color: var(--color-gray-lightest);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-xs);
+  outline: none;
+  font-family: inherit;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.vehicleFilterInput::placeholder {
+  color: var(--color-gray);
+}
+
+.vehicleFilterInput:focus {
+  border-color: var(--focus-border);
+  background: var(--focus-bg);
+}
+
+.noVehicles {
+  font-size: var(--text-xs);
+  color: var(--color-gray);
+  padding: var(--space-2) 0;
 }

--- a/apps/ui/src/Controls/Fleets.test.tsx
+++ b/apps/ui/src/Controls/Fleets.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Fleets from "./Fleets";
-import type { Fleet } from "@/types";
+import type { Fleet, Vehicle } from "@/types";
 
 const mockFleet = (overrides?: Partial<Fleet>): Fleet => ({
   id: "fleet-1",
@@ -12,7 +12,29 @@ const mockFleet = (overrides?: Partial<Fleet>): Fleet => ({
   ...overrides,
 });
 
+const mockVehicle = (overrides?: Partial<Vehicle>): Vehicle => ({
+  id: "v1",
+  name: "Vehicle 1",
+  speed: 30,
+  position: [36.8, -1.3],
+  heading: 0,
+  status: "moving",
+  visible: true,
+  selected: false,
+  hovered: false,
+  ...overrides,
+});
+
 const noop = vi.fn(() => Promise.resolve());
+
+const defaultProps = {
+  fleets: [] as Fleet[],
+  vehicles: [] as Vehicle[],
+  onCreateFleet: noop,
+  onDeleteFleet: noop,
+  onAssignVehicle: noop,
+  onUnassignVehicle: noop,
+};
 
 describe("Fleets", () => {
   beforeEach(() => {
@@ -20,12 +42,12 @@ describe("Fleets", () => {
   });
 
   it("renders header with title", () => {
-    render(<Fleets fleets={[]} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} />);
     expect(screen.getByRole("heading", { name: "Fleets" })).toBeInTheDocument();
   });
 
   it("shows empty state when no fleets", () => {
-    render(<Fleets fleets={[]} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} />);
     expect(screen.getByText("No fleets defined")).toBeInTheDocument();
   });
 
@@ -34,7 +56,7 @@ describe("Fleets", () => {
       mockFleet({ id: "f1", name: "Alpha", vehicleIds: ["v1", "v2"] }),
       mockFleet({ id: "f2", name: "Bravo", vehicleIds: ["v3"] }),
     ];
-    render(<Fleets fleets={fleets} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} fleets={fleets} />);
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("Bravo")).toBeInTheDocument();
     expect(screen.getByText("2 fleet groups available")).toBeInTheDocument();
@@ -44,13 +66,13 @@ describe("Fleets", () => {
 
   it("shows delete button for local fleets", () => {
     const fleets = [mockFleet({ source: "local" })];
-    render(<Fleets fleets={fleets} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} fleets={fleets} />);
     expect(screen.getByTitle("Delete fleet")).toBeInTheDocument();
   });
 
   it("shows 'ext' label for external fleets", () => {
     const fleets = [mockFleet({ source: "external" })];
-    render(<Fleets fleets={fleets} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} fleets={fleets} />);
     expect(screen.getByText("ext")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Delete fleet" })).not.toBeInTheDocument();
   });
@@ -58,14 +80,14 @@ describe("Fleets", () => {
   it("calls onDeleteFleet when delete clicked", async () => {
     const onDelete = vi.fn(() => Promise.resolve());
     const fleets = [mockFleet({ id: "fleet-42" })];
-    render(<Fleets fleets={fleets} onCreateFleet={noop} onDeleteFleet={onDelete} />);
+    render(<Fleets {...defaultProps} fleets={fleets} onDeleteFleet={onDelete} />);
 
     await userEvent.click(screen.getByTitle("Delete fleet"));
     expect(onDelete).toHaveBeenCalledWith("fleet-42");
   });
 
   it("shows input when '+ New' clicked", async () => {
-    render(<Fleets fleets={[]} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} />);
 
     await userEvent.click(screen.getByRole("button", { name: "+ New" }));
     expect(screen.getByPlaceholderText("Fleet name...")).toBeInTheDocument();
@@ -73,7 +95,7 @@ describe("Fleets", () => {
 
   it("calls onCreateFleet on Enter", async () => {
     const onCreate = vi.fn(() => Promise.resolve());
-    render(<Fleets fleets={[]} onCreateFleet={onCreate} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} onCreateFleet={onCreate} />);
 
     await userEvent.click(screen.getByRole("button", { name: "+ New" }));
     const input = screen.getByPlaceholderText("Fleet name...");
@@ -82,7 +104,7 @@ describe("Fleets", () => {
   });
 
   it("hides input on Escape", async () => {
-    render(<Fleets fleets={[]} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} />);
 
     await userEvent.click(screen.getByRole("button", { name: "+ New" }));
     const input = screen.getByPlaceholderText("Fleet name...");
@@ -96,7 +118,94 @@ describe("Fleets", () => {
     const fleets = Array.from({ length: 10 }, (_, i) =>
       mockFleet({ id: `fleet-${i}`, name: `Fleet ${i}` })
     );
-    render(<Fleets fleets={fleets} onCreateFleet={noop} onDeleteFleet={noop} />);
+    render(<Fleets {...defaultProps} fleets={fleets} />);
     expect(screen.queryByRole("button", { name: "+ New" })).not.toBeInTheDocument();
+  });
+
+  // ─── Vehicle assignment tests ──────────────────────────────────────
+
+  it("expands fleet to show vehicle assignment when clicked", async () => {
+    const fleets = [mockFleet({ id: "f1", name: "Alpha", vehicleIds: [] })];
+    const vehicles = [mockVehicle({ id: "v1", name: "Vehicle 1" })];
+    render(<Fleets {...defaultProps} fleets={fleets} vehicles={vehicles} />);
+
+    // Click the fleet row to expand
+    await userEvent.click(screen.getByLabelText("Alpha, 0 vehicles"));
+
+    // Should show the add vehicles section
+    expect(screen.getByText("Add vehicles")).toBeInTheDocument();
+    expect(screen.getByText("Vehicle 1")).toBeInTheDocument();
+  });
+
+  it("shows assigned vehicles in expanded fleet", async () => {
+    const fleets = [mockFleet({ id: "f1", name: "Alpha", vehicleIds: ["v1"] })];
+    const vehicles = [mockVehicle({ id: "v1", name: "Vehicle 1" })];
+    render(<Fleets {...defaultProps} fleets={fleets} vehicles={vehicles} />);
+
+    await userEvent.click(screen.getByLabelText("Alpha, 1 vehicles"));
+
+    expect(screen.getByText("Assigned")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove Vehicle 1")).toBeInTheDocument();
+  });
+
+  it("calls onAssignVehicle when add button clicked", async () => {
+    const onAssign = vi.fn(() => Promise.resolve());
+    const fleets = [mockFleet({ id: "f1", name: "Alpha", vehicleIds: [] })];
+    const vehicles = [mockVehicle({ id: "v1", name: "Vehicle 1" })];
+    render(
+      <Fleets {...defaultProps} fleets={fleets} vehicles={vehicles} onAssignVehicle={onAssign} />
+    );
+
+    await userEvent.click(screen.getByLabelText("Alpha, 0 vehicles"));
+    await userEvent.click(screen.getByLabelText("Add Vehicle 1"));
+
+    expect(onAssign).toHaveBeenCalledWith("f1", "v1");
+  });
+
+  it("calls onUnassignVehicle when remove button clicked", async () => {
+    const onUnassign = vi.fn(() => Promise.resolve());
+    const fleets = [mockFleet({ id: "f1", name: "Alpha", vehicleIds: ["v1"] })];
+    const vehicles = [mockVehicle({ id: "v1", name: "Vehicle 1" })];
+    render(
+      <Fleets
+        {...defaultProps}
+        fleets={fleets}
+        vehicles={vehicles}
+        onUnassignVehicle={onUnassign}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText("Alpha, 1 vehicles"));
+    await userEvent.click(screen.getByLabelText("Remove Vehicle 1"));
+
+    expect(onUnassign).toHaveBeenCalledWith("f1", "v1");
+  });
+
+  it("hides already-assigned vehicles from unassigned list", async () => {
+    const fleets = [mockFleet({ id: "f1", name: "Alpha", vehicleIds: ["v1"] })];
+    const vehicles = [
+      mockVehicle({ id: "v1", name: "Vehicle 1" }),
+      mockVehicle({ id: "v2", name: "Vehicle 2" }),
+    ];
+    render(<Fleets {...defaultProps} fleets={fleets} vehicles={vehicles} />);
+
+    await userEvent.click(screen.getByLabelText("Alpha, 1 vehicles"));
+
+    // v1 is assigned, so "Add Vehicle 1" should not exist, only "Add Vehicle 2"
+    expect(screen.queryByLabelText("Add Vehicle 1")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Add Vehicle 2")).toBeInTheDocument();
+  });
+
+  it("collapses fleet on second click", async () => {
+    const fleets = [mockFleet({ id: "f1", name: "Alpha", vehicleIds: [] })];
+    const vehicles = [mockVehicle({ id: "v1", name: "Vehicle 1" })];
+    render(<Fleets {...defaultProps} fleets={fleets} vehicles={vehicles} />);
+
+    const fleetButton = screen.getByLabelText("Alpha, 0 vehicles");
+    await userEvent.click(fleetButton);
+    expect(screen.getByText("Add vehicles")).toBeInTheDocument();
+
+    await userEvent.click(fleetButton);
+    expect(screen.queryByText("Add vehicles")).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/Controls/Fleets.tsx
+++ b/apps/ui/src/Controls/Fleets.tsx
@@ -1,5 +1,6 @@
-import { useState, useCallback } from "react";
-import type { Fleet } from "@/types";
+import { useState, useCallback, useMemo } from "react";
+import classNames from "classnames";
+import type { Fleet, Vehicle } from "@/types";
 import { Button, SquaredButton } from "@/components/Inputs";
 import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
 import styles from "./Fleets.module.css";
@@ -7,13 +8,36 @@ import { TextField, Input } from "react-aria-components";
 
 interface FleetsProps {
   fleets: Fleet[];
+  vehicles: Vehicle[];
   onCreateFleet: (name: string) => Promise<void>;
   onDeleteFleet: (id: string) => Promise<void>;
+  onAssignVehicle: (fleetId: string, vehicleId: string) => Promise<void>;
+  onUnassignVehicle: (fleetId: string, vehicleId: string) => Promise<void>;
 }
 
-export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsProps) {
+export default function Fleets({
+  fleets,
+  vehicles,
+  onCreateFleet,
+  onDeleteFleet,
+  onAssignVehicle,
+  onUnassignVehicle,
+}: FleetsProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [newName, setNewName] = useState("");
+  const [expandedFleetId, setExpandedFleetId] = useState<string | null>(null);
+  const [vehicleFilter, setVehicleFilter] = useState("");
+
+  /** Set of all vehicle IDs currently assigned to any fleet */
+  const assignedVehicleIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const fleet of fleets) {
+      for (const vid of fleet.vehicleIds) {
+        set.add(vid);
+      }
+    }
+    return set;
+  }, [fleets]);
 
   const handleSubmit = useCallback(async () => {
     const trimmed = newName.trim();
@@ -33,6 +57,11 @@ export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsP
     },
     [handleSubmit]
   );
+
+  const toggleExpanded = useCallback((fleetId: string) => {
+    setExpandedFleetId((prev) => (prev === fleetId ? null : fleetId));
+    setVehicleFilter("");
+  }, []);
 
   return (
     <>
@@ -59,28 +88,110 @@ export default function Fleets({ fleets, onCreateFleet, onDeleteFleet }: FleetsP
         ) : null}
 
         <div className={styles.fleetList}>
-          {fleets.map((fleet) => (
-            <div key={fleet.id} className={styles.fleet}>
-              <span className={styles.colorDot} style={{ backgroundColor: fleet.color }} />
-              <span className={styles.fleetName}>{fleet.name}</span>
-              <span className={styles.fleetCount}>{fleet.vehicleIds.length}</span>
-              {fleet.source === "external" ? (
-                <PanelBadge className={styles.externalBadge} tone="neutral">
-                  ext
-                </PanelBadge>
-              ) : (
-                <SquaredButton
-                  className={styles.deleteButton}
-                  icon={<span aria-hidden="true">×</span>}
-                  variant="ghost"
-                  tone="danger"
-                  aria-label="Delete fleet"
-                  title="Delete fleet"
-                  onClick={() => onDeleteFleet(fleet.id)}
-                />
-              )}
-            </div>
-          ))}
+          {fleets.map((fleet) => {
+            const isExpanded = expandedFleetId === fleet.id;
+            const memberVehicles = vehicles.filter((v) => fleet.vehicleIds.includes(v.id));
+            const filterLower = vehicleFilter.toLowerCase();
+            const unassignedVehicles = vehicles.filter(
+              (v) =>
+                !assignedVehicleIds.has(v.id) &&
+                (!filterLower || v.name.toLowerCase().includes(filterLower))
+            );
+
+            return (
+              <div key={fleet.id} className={styles.fleetCard}>
+                <button
+                  type="button"
+                  className={classNames(styles.fleet, { [styles.fleetExpanded]: isExpanded })}
+                  onClick={() => toggleExpanded(fleet.id)}
+                  aria-expanded={isExpanded}
+                  aria-label={`${fleet.name}, ${fleet.vehicleIds.length} vehicles`}
+                >
+                  <span className={styles.colorDot} style={{ backgroundColor: fleet.color }} />
+                  <span className={styles.fleetName}>{fleet.name}</span>
+                  <span className={styles.fleetCount}>{fleet.vehicleIds.length}</span>
+                  {fleet.source === "external" ? (
+                    <PanelBadge className={styles.externalBadge} tone="neutral">
+                      ext
+                    </PanelBadge>
+                  ) : (
+                    <SquaredButton
+                      className={styles.deleteButton}
+                      icon={<span aria-hidden="true">&times;</span>}
+                      variant="ghost"
+                      tone="danger"
+                      aria-label="Delete fleet"
+                      title="Delete fleet"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDeleteFleet(fleet.id);
+                      }}
+                    />
+                  )}
+                </button>
+
+                {isExpanded ? (
+                  <div className={styles.vehicleSection}>
+                    {memberVehicles.length > 0 ? (
+                      <div className={styles.memberList}>
+                        <span className={styles.sectionLabel}>Assigned</span>
+                        {memberVehicles.map((v) => (
+                          <div key={v.id} className={styles.memberRow}>
+                            <span className={styles.memberName}>{v.name}</span>
+                            <button
+                              type="button"
+                              className={styles.removeButton}
+                              onClick={() => onUnassignVehicle(fleet.id, v.id)}
+                              aria-label={`Remove ${v.name}`}
+                              title={`Remove ${v.name} from fleet`}
+                            >
+                              &minus;
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    <div className={styles.addVehicleSection}>
+                      <span className={styles.sectionLabel}>Add vehicles</span>
+                      {vehicles.length > 6 ? (
+                        <input
+                          type="text"
+                          className={styles.vehicleFilterInput}
+                          placeholder="Filter vehicles..."
+                          value={vehicleFilter}
+                          onChange={(e) => setVehicleFilter(e.target.value)}
+                          aria-label="Filter unassigned vehicles"
+                        />
+                      ) : null}
+                      {unassignedVehicles.length === 0 ? (
+                        <span className={styles.noVehicles}>
+                          {vehicleFilter ? "No matches" : "All vehicles assigned"}
+                        </span>
+                      ) : (
+                        <div className={styles.unassignedList}>
+                          {unassignedVehicles.map((v) => (
+                            <div key={v.id} className={styles.memberRow}>
+                              <span className={styles.memberName}>{v.name}</span>
+                              <button
+                                type="button"
+                                className={styles.assignButton}
+                                onClick={() => onAssignVehicle(fleet.id, v.id)}
+                                aria-label={`Add ${v.name}`}
+                                title={`Add ${v.name} to fleet`}
+                              >
+                                +
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
 
         {isAdding ? (

--- a/apps/ui/src/Map/Breadcrumb/BreadcrumbLayer.tsx
+++ b/apps/ui/src/Map/Breadcrumb/BreadcrumbLayer.tsx
@@ -53,10 +53,12 @@ export default function BreadcrumbLayer({
   useEffect(() => {
     if (!projection || !map) return;
 
-    // Create the SVG <g> element inside the map's SVG
+    // Create the SVG <g> element inside the markers group (which receives the zoom transform)
+    const markersGroup = map.querySelector("g.markers");
+    if (!markersGroup) return;
     const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
     g.setAttribute("data-layer", "breadcrumbs");
-    map.appendChild(g);
+    markersGroup.appendChild(g);
     gRef.current = g;
 
     let rafId: number;

--- a/apps/ui/src/Map/Breadcrumb/__tests__/BreadcrumbLayer.test.tsx
+++ b/apps/ui/src/Map/Breadcrumb/__tests__/BreadcrumbLayer.test.tsx
@@ -93,8 +93,11 @@ beforeEach(() => {
     (pos: Position) => [pos[0] * 10, pos[1] * 10] as [number, number]
   );
 
-  // Create a fresh SVG element for the map
+  // Create a fresh SVG element for the map with a markers group inside
   mockMapEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  const markersGroup = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  markersGroup.setAttribute("class", "markers");
+  mockMapEl.appendChild(markersGroup);
 
   // Mock RAF to capture callbacks
   rafCallbacks = [];

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -384,7 +384,7 @@ class SimulationService {
   }
 
   onReplayStatus(handler: (data: ReplayStatus) => void): void {
-    this.ws.on("replayStatus", handler);
+    this.ws.on("replay:status", handler);
   }
 
   // ─── Simulation Clock ──────────────────────────────────────────
@@ -455,11 +455,11 @@ class SimulationService {
   }
 
   onGeofenceEvent(handler: (event: GeoFenceEvent) => void): void {
-    this.ws.on("geofence-event", handler);
+    this.ws.on("geofence:event", handler);
   }
 
   offGeofenceEvent(): void {
-    this.ws.off("geofence-event");
+    this.ws.off("geofence:event");
   }
 
   subscribe(filter: SubscribeFilter | null): void {

--- a/apps/ui/src/utils/wsTypes.ts
+++ b/apps/ui/src/utils/wsTypes.ts
@@ -9,7 +9,9 @@ import type {
   ReplayStatus,
   ClockState,
   TrafficEdge,
+  ScenarioEventPayload,
 } from "@/types";
+import type { GeoFenceEvent } from "@moveet/shared-types";
 import type { AnalyticsSnapshot } from "@/hooks/analyticsStore";
 
 export interface ResetPayload {
@@ -57,10 +59,17 @@ export type WebSocketMessage =
   | { type: "incident:created"; data: IncidentDTO }
   | { type: "incident:cleared"; data: IncidentClearedPayload }
   | { type: "vehicle:rerouted"; data: VehicleReroutedPayload }
-  | { type: "replayStatus"; data: ReplayStatus }
+  | { type: "replay:status"; data: ReplayStatus }
   | { type: "clock"; data: ClockState }
   | { type: "traffic"; data: TrafficEdge[] }
-  | { type: "analytics"; data: AnalyticsSnapshot };
+  | { type: "analytics"; data: AnalyticsSnapshot }
+  | { type: "geofence:event"; data: GeoFenceEvent }
+  | { type: "scenario:started"; data: ScenarioEventPayload }
+  | { type: "scenario:event"; data: ScenarioEventPayload }
+  | { type: "scenario:paused"; data: ScenarioEventPayload }
+  | { type: "scenario:resumed"; data: ScenarioEventPayload }
+  | { type: "scenario:completed"; data: ScenarioEventPayload }
+  | { type: "scenario:stopped"; data: ScenarioEventPayload };
 
 /**
  * Type guard to validate WebSocket message structure
@@ -93,10 +102,17 @@ export function isValidMessage(msg: unknown): msg is WebSocketMessage {
     case "incident:created":
     case "incident:cleared":
     case "vehicle:rerouted":
-    case "replayStatus":
+    case "replay:status":
     case "clock":
     case "traffic":
     case "analytics":
+    case "geofence:event":
+    case "scenario:started":
+    case "scenario:event":
+    case "scenario:paused":
+    case "scenario:resumed":
+    case "scenario:completed":
+    case "scenario:stopped":
       return "data" in message;
     default:
       return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
       "version": "0.1.0",
       "dependencies": {
         "commander": "^12.1.0",
-        "inquirer": "^10.2.2",
+        "inquirer": "^13.3.2",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "zod": "^4.3.6"
@@ -1822,252 +1822,348 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
+      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
     "node_modules/@inquirer/checkbox": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
-      "integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
+      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-      "integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
+      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
+      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.6",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.5",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4",
         "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/@inquirer/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+      "peerDependencies": {
+        "@types/node": ">=18"
       },
-      "engines": {
-        "node": ">=8"
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
-      "integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
+      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "external-editor": "^3.1.0"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/external-editor": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
-      "integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
+      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
+      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
+      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
-      "integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
+      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
-      "integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
+      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
+      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz",
-      "integrity": "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
+      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^2.5.0",
-        "@inquirer/confirm": "^3.2.0",
-        "@inquirer/editor": "^2.2.0",
-        "@inquirer/expand": "^2.3.0",
-        "@inquirer/input": "^2.3.0",
-        "@inquirer/number": "^1.1.0",
-        "@inquirer/password": "^2.2.0",
-        "@inquirer/rawlist": "^2.3.0",
-        "@inquirer/search": "^1.1.0",
-        "@inquirer/select": "^2.5.0"
+        "@inquirer/checkbox": "^5.1.2",
+        "@inquirer/confirm": "^6.0.10",
+        "@inquirer/editor": "^5.0.10",
+        "@inquirer/expand": "^5.0.10",
+        "@inquirer/input": "^5.0.10",
+        "@inquirer/number": "^4.0.10",
+        "@inquirer/password": "^5.0.10",
+        "@inquirer/rawlist": "^5.2.6",
+        "@inquirer/search": "^4.1.6",
+        "@inquirer/select": "^5.1.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
-      "integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
+      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
-      "integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
+      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
-      "integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
+      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/figures": "^2.0.4",
+        "@inquirer/type": "^4.0.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
+      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
       "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@internationalized/date": {
@@ -7344,15 +7440,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -7455,12 +7542,6 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -7881,13 +7962,6 @@
         "vitest": "4.1.0"
       }
     },
-    "node_modules/@vitest/ui/node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@vitest/utils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
@@ -7979,21 +8053,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -8007,6 +8066,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8325,9 +8385,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "license": "MIT"
     },
     "node_modules/chokidar": {
@@ -8484,6 +8544,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -8496,6 +8557,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -9438,6 +9500,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -9921,32 +9984,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -9977,6 +10014,21 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -9993,6 +10045,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -10081,9 +10142,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/form-data": {
@@ -10609,22 +10670,29 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-10.2.2.tgz",
-      "integrity": "sha512-tyao/4Vo36XnUItZ7DnUXX4f1jVao2mSrleV/5IPtW/XAEA26hRVsbc68nuTEKWcr5vMP/1mVoT2O7u8H4v1Vg==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.3.2.tgz",
+      "integrity": "sha512-bh/OjBGxNR9qvfQj1n5bxtIF58mbOTp2InN5dKuwUK03dXcDGFsjlDinQRuXMZ4EGiJaFieUWHCAaxH2p7iUBw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/prompts": "^5.5.0",
-        "@inquirer/type": "^1.5.3",
-        "@types/mute-stream": "^0.0.4",
-        "ansi-escapes": "^4.3.2",
-        "mute-stream": "^1.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
+        "@inquirer/ansi": "^2.0.4",
+        "@inquirer/core": "^11.1.7",
+        "@inquirer/prompts": "^8.3.2",
+        "@inquirer/type": "^4.0.4",
+        "mute-stream": "^3.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/internmap": {
@@ -10701,6 +10769,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11857,12 +11926,12 @@
       "license": "MIT"
     },
     "node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/mysql2": {
@@ -12074,15 +12143,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -13007,9 +13067,9 @@
       }
     },
     "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -13843,6 +13903,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -13857,6 +13918,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14077,18 +14139,6 @@
       "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -14323,18 +14373,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -14589,7 +14627,6 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -14895,18 +14932,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
       "prettier --write"
     ]
   },
+  "overrides": {
+    "flatted": "3.4.2"
+  },
   "packageManager": "npm@11.11.1"
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -223,7 +223,7 @@ export interface GeoFence {
 }
 
 export interface GeoFenceEvent {
-  type: "geofence-event";
+  type: "geofence:event";
   fenceId: string;
   fenceName: string;
   vehicleId: string;


### PR DESCRIPTION
## Summary

- **Geofence events not triggering**: UI WebSocket validator rejected `geofence-event` and `scenario:*` message types — added them to the allowlist in `wsTypes.ts`
- **Trails not visible**: `BreadcrumbLayer` appended SVG to root instead of `<g class="markers">` group, so trails had no zoom/pan transform
- **Fleet vehicle assignment**: Backend was fully wired but `Fleets.tsx` had no assign/unassign UI — added expandable fleet cards with add/remove vehicle controls
- **Event naming consistency**: Normalized `geofence-event` → `geofence:event` and `replayStatus` → `replay:status` so all WS events use the `domain:action` convention

## Test plan

- [x] 1258 simulator tests pass
- [x] 477 UI tests pass
- [x] TypeScript type-check clean across all packages
- [ ] Manual: create geofence, verify enter/exit events fire in UI
- [ ] Manual: toggle trails, verify they render and follow zoom/pan
- [ ] Manual: create fleet, assign/unassign vehicles
- [ ] Manual: load scenario, verify WS events arrive in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)