### PR TITLE
fix(ui): add --legacy-peer-deps to Docker build

### DIFF
--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -4,7 +4,7 @@ FROM node:24-alpine AS builder
 WORKDIR /app
 
 COPY package.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- Adds `--legacy-peer-deps` to `npm install` in `apps/ui/Dockerfile`
- `eslint-plugin-react-hooks@7.0.1` requires `eslint@^3-^9` but the project uses `eslint@^10` — no stable release with eslint 10 support exists yet (only canary builds)
- This caused `ERESOLVE` failures during Docker build, breaking CI for all three images (UI failed first, matrix cancelled adapter + simulator)

Fixes https://github.com/ivannovazzi/moveet/actions/runs/23290105512

## Test plan
- [ ] CI docker-publish workflow passes for all three images

🤖 Generated with [Claude Code](https://claude.com/claude-code)