### PR TITLE
fix(simulator): use weighted vehicle type distribution in default mode

### DIFF
--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -25,6 +25,10 @@ HEATZONE_SPEED_FACTOR=0.5
 # Number of default vehicles when running without adapter
 VEHICLE_COUNT=70
 
+# Vehicle type distribution override (JSON).
+# When empty, uses built-in weighted distribution: 60% car, 15% truck, 12% motorcycle, 10% bus, 3% ambulance
+# VEHICLE_TYPES={"car":50,"truck":10,"bus":7,"motorcycle":3}
+
 # Adapter Configuration
 # URL of the external adapter service
 ADAPTER_URL=http://localhost:5011

--- a/apps/simulator/src/__tests__/VehicleRegistry.test.ts
+++ b/apps/simulator/src/__tests__/VehicleRegistry.test.ts
@@ -4,9 +4,11 @@ import { FleetManager } from "../modules/FleetManager";
 import { RoadNetwork } from "../modules/RoadNetwork";
 import { config } from "../utils/config";
 import { getProfile } from "../utils/vehicleProfiles";
+import type { VehicleType } from "../types";
 import path from "path";
 
 const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
+const ALL_TYPES: VehicleType[] = ["car", "truck", "motorcycle", "ambulance", "bus"];
 
 describe("VehicleRegistry", () => {
   let network: RoadNetwork;
@@ -27,9 +29,12 @@ describe("VehicleRegistry", () => {
   // ─── Vehicle loading ──────────────────────────────────────────────
 
   describe("loadFromData", () => {
-    it("should load default vehicle count when no types specified", () => {
+    it("should load default vehicle count with mixed types when no types specified", () => {
       registry.loadFromData();
       expect(registry.getAll().size).toBe(3);
+      for (const v of registry.getAll().values()) {
+        expect(ALL_TYPES).toContain(v.type);
+      }
     });
 
     it("should load specified vehicle types and counts", () => {
@@ -40,9 +45,20 @@ describe("VehicleRegistry", () => {
       expect(vehicles.filter((v) => v.type === "truck")).toHaveLength(1);
     });
 
-    it("should fall back to config.vehicleCount when vehicleTypes is empty", () => {
+    it("should use weighted distribution when vehicleTypes is empty", () => {
+      (config as any).vehicleCount = 10;
       registry.loadFromData({});
-      expect(registry.getAll().size).toBe(3);
+      expect(registry.getAll().size).toBe(10);
+      const types = new Set(Array.from(registry.getAll().values()).map((v) => v.type));
+      expect(types.size).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should assign type-prefixed names", () => {
+      registry.loadFromData({ car: 1, truck: 1 });
+      const vehicles = Array.from(registry.getAll().values());
+      const names = vehicles.map((v) => v.name);
+      expect(names).toContain("Car-1");
+      expect(names).toContain("Truck-1");
     });
 
     it("should invoke onVehicleAdded callback for each vehicle", () => {

--- a/apps/simulator/src/__tests__/vehicleProfiles.test.ts
+++ b/apps/simulator/src/__tests__/vehicleProfiles.test.ts
@@ -56,7 +56,13 @@ describe("distributeByWeight", () => {
   });
 
   it("accepts custom weights", () => {
-    const dist = distributeByWeight(10, { car: 50, truck: 50, motorcycle: 0, ambulance: 0, bus: 0 });
+    const dist = distributeByWeight(10, {
+      car: 50,
+      truck: 50,
+      motorcycle: 0,
+      ambulance: 0,
+      bus: 0,
+    });
     const sum = Object.values(dist).reduce((a, b) => a + b, 0);
     expect(sum).toBe(10);
     // Only car and truck should be present

--- a/apps/simulator/src/__tests__/vehicleProfiles.test.ts
+++ b/apps/simulator/src/__tests__/vehicleProfiles.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  distributeByWeight,
+  DEFAULT_VEHICLE_TYPE_WEIGHTS,
+  VEHICLE_PROFILES,
+  getProfile,
+} from "../utils/vehicleProfiles";
+import type { VehicleType } from "../types";
+
+const ALL_TYPES: VehicleType[] = ["car", "truck", "motorcycle", "ambulance", "bus"];
+
+describe("distributeByWeight", () => {
+  it("returns exact total count", () => {
+    for (const total of [1, 3, 5, 10, 50, 70, 100, 200]) {
+      const dist = distributeByWeight(total);
+      const sum = Object.values(dist).reduce((a, b) => a + b, 0);
+      expect(sum).toBe(total);
+    }
+  });
+
+  it("uses all vehicle types for a large enough count", () => {
+    const dist = distributeByWeight(100);
+    for (const type of ALL_TYPES) {
+      expect(dist[type]).toBeGreaterThan(0);
+    }
+  });
+
+  it("car is the most common type (largest weight)", () => {
+    const dist = distributeByWeight(100);
+    for (const type of ALL_TYPES) {
+      if (type !== "car") {
+        expect(dist.car).toBeGreaterThan(dist[type]!);
+      }
+    }
+  });
+
+  it("ambulance is the rarest type", () => {
+    const dist = distributeByWeight(100);
+    for (const type of ALL_TYPES) {
+      if (type !== "ambulance") {
+        expect(dist[type]!).toBeGreaterThanOrEqual(dist.ambulance!);
+      }
+    }
+  });
+
+  it("produces multiple types for moderate counts", () => {
+    const dist = distributeByWeight(10);
+    const typesPresent = Object.keys(dist).length;
+    expect(typesPresent).toBeGreaterThanOrEqual(2);
+  });
+
+  it("handles count of 1 without error", () => {
+    const dist = distributeByWeight(1);
+    const sum = Object.values(dist).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(1);
+  });
+
+  it("accepts custom weights", () => {
+    const dist = distributeByWeight(10, { car: 50, truck: 50, motorcycle: 0, ambulance: 0, bus: 0 });
+    const sum = Object.values(dist).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(10);
+    // Only car and truck should be present
+    expect((dist.car ?? 0) + (dist.truck ?? 0)).toBe(10);
+  });
+});
+
+describe("DEFAULT_VEHICLE_TYPE_WEIGHTS", () => {
+  it("weights sum to 100", () => {
+    const sum = Object.values(DEFAULT_VEHICLE_TYPE_WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
+  });
+
+  it("has an entry for every VehicleType", () => {
+    for (const type of ALL_TYPES) {
+      expect(DEFAULT_VEHICLE_TYPE_WEIGHTS[type]).toBeDefined();
+      expect(DEFAULT_VEHICLE_TYPE_WEIGHTS[type]).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("VEHICLE_PROFILES", () => {
+  it("has a profile for every vehicle type", () => {
+    for (const type of ALL_TYPES) {
+      expect(VEHICLE_PROFILES[type]).toBeDefined();
+    }
+  });
+});
+
+describe("getProfile", () => {
+  it("returns the correct profile for each type", () => {
+    for (const type of ALL_TYPES) {
+      const profile = getProfile(type);
+      expect(profile.type).toBe(type);
+    }
+  });
+});

--- a/apps/simulator/src/__tests__/vehicleTypes.test.ts
+++ b/apps/simulator/src/__tests__/vehicleTypes.test.ts
@@ -125,10 +125,10 @@ describe("Vehicle Types", () => {
   // 2. Vehicle type assignment
   // ────────────────────────────────────────────────────────────────
   describe("Vehicle type assignment", () => {
-    it("default vehicles are type 'car'", () => {
+    it("default vehicles use weighted distribution (mixed types)", () => {
       const vehicles = getInternalVehicles(manager);
       for (const vehicle of vehicles.values()) {
-        expect(vehicle.type).toBe("car");
+        expect(ALL_TYPES).toContain(vehicle.type);
       }
     });
 
@@ -137,7 +137,7 @@ describe("Vehicle Types", () => {
       expect(dtos.length).toBeGreaterThan(0);
       for (const dto of dtos) {
         expect(dto.type).toBeDefined();
-        expect(dto.type).toBe("car");
+        expect(ALL_TYPES).toContain(dto.type);
       }
     });
 
@@ -153,11 +153,11 @@ describe("Vehicle Types", () => {
   // 3. Type-specific speed bounds
   // ────────────────────────────────────────────────────────────────
   describe("Type-specific speed bounds", () => {
-    it("car vehicles start at car profile minSpeed", () => {
+    it("each vehicle starts at its own profile minSpeed", () => {
       const vehicles = getInternalVehicles(manager);
-      const carProfile = getProfile("car");
       for (const vehicle of vehicles.values()) {
-        expect(vehicle.speed).toBe(carProfile.minSpeed);
+        const profile = getProfile(vehicle.type);
+        expect(vehicle.speed).toBe(profile.minSpeed);
       }
     });
 
@@ -327,39 +327,37 @@ describe("Vehicle Types", () => {
   });
 
   // ────────────────────────────────────────────────────────────────
-  // 7. Backward compatibility
+  // 7. Default distribution (was backward compatibility)
   // ────────────────────────────────────────────────────────────────
-  describe("Backward compatibility", () => {
-    it("defaults to 'car' when no type is specified", () => {
+  describe("Default distribution", () => {
+    it("uses weighted distribution when no type is specified", () => {
       const vehicles = getInternalVehicles(manager);
       expect(vehicles.size).toBe(config.vehicleCount);
-      for (const v of vehicles.values()) {
-        expect(v.type).toBe("car");
-      }
+      const types = new Set([...vehicles.values()].map((v) => v.type));
+      // With 5 vehicles and weighted distribution, we should have at least 2 distinct types
+      expect(types.size).toBeGreaterThanOrEqual(2);
     });
 
-    it("falls back to config.vehicleCount cars when vehicleTypes not provided", () => {
+    it("distributes across config.vehicleCount when vehicleTypes not provided", () => {
       (config as any).vehicleCount = 4;
       cleanupManager(manager);
       manager = createManager(network);
 
       const vehicles = getInternalVehicles(manager);
       expect(vehicles.size).toBe(4);
-      for (const v of vehicles.values()) {
-        expect(v.type).toBe("car");
-      }
+      const types = new Set([...vehicles.values()].map((v) => v.type));
+      expect(types.size).toBeGreaterThanOrEqual(2);
     });
 
-    it("falls back to config.vehicleCount when vehicleTypes is empty", () => {
-      (config as any).vehicleCount = 3;
+    it("distributes across config.vehicleCount when vehicleTypes is empty", () => {
+      (config as any).vehicleCount = 10;
       cleanupManager(manager);
       manager = createManager(network, {});
 
       const vehicles = getInternalVehicles(manager);
-      expect(vehicles.size).toBe(3);
-      for (const v of vehicles.values()) {
-        expect(v.type).toBe("car");
-      }
+      expect(vehicles.size).toBe(10);
+      const types = new Set([...vehicles.values()].map((v) => v.type));
+      expect(types.size).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -169,12 +169,15 @@ export class VehicleManager extends EventEmitter {
   private loadFromData(vehicleTypes?: Partial<Record<VehicleType, number>>): void {
     // Priority: explicit vehicleTypes > env VEHICLE_TYPES > weighted default
     const types = vehicleTypes ?? config.vehicleTypes;
-    this.registry.loadFromData(types as Partial<Record<VehicleType, number>> | undefined, (vehicleId) => {
-      // After a vehicle is added to the registry, register traffic and set destination
-      const vehicle = this.registry.get(vehicleId)!;
-      this.traffic.enter(vehicle.currentEdge.id);
-      this.setRandomDestination(vehicleId);
-    });
+    this.registry.loadFromData(
+      types as Partial<Record<VehicleType, number>> | undefined,
+      (vehicleId) => {
+        // After a vehicle is added to the registry, register traffic and set destination
+        const vehicle = this.registry.get(vehicleId)!;
+        this.traffic.enter(vehicle.currentEdge.id);
+        this.setRandomDestination(vehicleId);
+      }
+    );
   }
 
   private addVehicle(

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -167,7 +167,9 @@ export class VehicleManager extends EventEmitter {
   }
 
   private loadFromData(vehicleTypes?: Partial<Record<VehicleType, number>>): void {
-    this.registry.loadFromData(vehicleTypes, (vehicleId) => {
+    // Priority: explicit vehicleTypes > env VEHICLE_TYPES > weighted default
+    const types = vehicleTypes ?? config.vehicleTypes;
+    this.registry.loadFromData(types as Partial<Record<VehicleType, number>> | undefined, (vehicleId) => {
       // After a vehicle is added to the registry, register traffic and set destination
       const vehicle = this.registry.get(vehicleId)!;
       this.traffic.enter(vehicle.currentEdge.id);

--- a/apps/simulator/src/modules/VehicleRegistry.ts
+++ b/apps/simulator/src/modules/VehicleRegistry.ts
@@ -5,7 +5,7 @@ import { config } from "../utils/config";
 import { CircularBuffer } from "../utils/CircularBuffer";
 import { serializeVehicle } from "../utils/serializer";
 import type { FleetManager } from "./FleetManager";
-import { getProfile } from "../utils/vehicleProfiles";
+import { getProfile, distributeByWeight } from "../utils/vehicleProfiles";
 
 /**
  * Manages vehicle state: add/remove/get/update vehicles, visited edges, and edge spatial index.
@@ -78,23 +78,28 @@ export class VehicleRegistry {
     vehicleTypes?: Partial<Record<VehicleType, number>>,
     onVehicleAdded?: (vehicleId: string) => void
   ): void {
-    if (vehicleTypes && Object.keys(vehicleTypes).length > 0) {
-      let idx = 0;
-      for (const [type, count] of Object.entries(vehicleTypes)) {
-        for (let i = 0; i < (count as number); i++) {
-          this.addVehicle(
-            idx.toString(),
-            `V${idx}`,
-            undefined,
-            type as VehicleType,
-            onVehicleAdded
-          );
-          idx++;
-        }
-      }
-    } else {
-      for (let i = 0; i < config.vehicleCount; i++) {
-        this.addVehicle(i.toString(), `V${i}`, undefined, "car", onVehicleAdded);
+    // When no explicit types provided, use weighted distribution across all types
+    const types =
+      vehicleTypes && Object.keys(vehicleTypes).length > 0
+        ? vehicleTypes
+        : distributeByWeight(config.vehicleCount);
+
+    let idx = 0;
+    const typeCounters: Partial<Record<VehicleType, number>> = {};
+
+    for (const [type, count] of Object.entries(types)) {
+      for (let i = 0; i < (count as number); i++) {
+        const vType = type as VehicleType;
+        typeCounters[vType] = (typeCounters[vType] ?? 0) + 1;
+        const label = type.charAt(0).toUpperCase() + type.slice(1);
+        this.addVehicle(
+          idx.toString(),
+          `${label}-${typeCounters[vType]}`,
+          undefined,
+          vType,
+          onVehicleAdded
+        );
+        idx++;
       }
     }
   }

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -44,6 +44,25 @@ export const envSchema = z
     /** Number of simulated vehicles */
     VEHICLE_COUNT: z.coerce.number().int().min(1).default(70),
 
+    /**
+     * Optional JSON vehicle type distribution override.
+     * e.g. '{"car":50,"truck":10,"bus":7,"motorcycle":3}'
+     * When empty, uses the built-in weighted distribution.
+     */
+    VEHICLE_TYPES: z
+      .string()
+      .default("")
+      .transform((v) => {
+        if (!v) return undefined;
+        try {
+          const parsed = JSON.parse(v);
+          if (typeof parsed !== "object" || parsed === null) return undefined;
+          return parsed as Partial<Record<string, number>>;
+        } catch {
+          return undefined;
+        }
+      }),
+
     /** Path to the GeoJSON road network file */
     GEOJSON_PATH: z.string().default("./data/network.geojson"),
 
@@ -100,6 +119,7 @@ function buildConfig(env: EnvConfig) {
     heatZoneSpeedFactor: env.HEATZONE_SPEED_FACTOR,
     syncAdapterTimeout: env.SYNC_ADAPTER_TIMEOUT,
     vehicleCount: env.VEHICLE_COUNT,
+    vehicleTypes: env.VEHICLE_TYPES,
     geojsonPath: env.GEOJSON_PATH,
     adapterURL: env.ADAPTER_URL,
     persistenceEnabled: env.PERSISTENCE_ENABLED,

--- a/apps/simulator/src/utils/vehicleProfiles.ts
+++ b/apps/simulator/src/utils/vehicleProfiles.ts
@@ -59,6 +59,53 @@ export const FOLLOWING_DISTANCE_BY_SIZE: Record<string, number> = {
   large: 0.03, // 30 meters in km
 };
 
+/**
+ * Default vehicle type distribution (percentages, must sum to 100).
+ * Used when no explicit vehicleTypes map is provided (i.e. non-scenario mode).
+ */
+export const DEFAULT_VEHICLE_TYPE_WEIGHTS: Record<VehicleType, number> = {
+  car: 60,
+  truck: 15,
+  bus: 10,
+  motorcycle: 12,
+  ambulance: 3,
+};
+
+/**
+ * Converts the percentage-based weights into absolute counts for a given total.
+ * Guarantees the sum equals `total` by assigning remainders to the largest type.
+ */
+export function distributeByWeight(
+  total: number,
+  weights: Record<VehicleType, number> = DEFAULT_VEHICLE_TYPE_WEIGHTS
+): Partial<Record<VehicleType, number>> {
+  const weightSum = Object.values(weights).reduce((a, b) => a + b, 0);
+  const result: Partial<Record<VehicleType, number>> = {};
+  let assigned = 0;
+
+  const entries = Object.entries(weights) as [VehicleType, number][];
+  // Sort descending by weight so the largest bucket absorbs rounding remainder
+  entries.sort((a, b) => b[1] - a[1]);
+
+  for (let i = 0; i < entries.length; i++) {
+    const [type, weight] = entries[i];
+    if (i === 0) continue; // skip largest, assign remainder later
+    const count = Math.round((weight / weightSum) * total);
+    if (count > 0) {
+      result[type] = count;
+      assigned += count;
+    }
+  }
+
+  // Largest type gets the remainder to guarantee exact total
+  const remaining = total - assigned;
+  if (remaining > 0) {
+    result[entries[0][0]] = remaining;
+  }
+
+  return result;
+}
+
 export function getProfile(type: VehicleType): VehicleProfile {
   return VEHICLE_PROFILES[type];
 }

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -519,6 +519,7 @@ export default function App() {
               onPOIClick={(poi) => setSelectedItem(poi)}
               vehicleFleetMap={vehicleFleetMap}
               hiddenFleetIds={hiddenFleetIds}
+              hiddenVehicleTypes={hiddenVehicleTypes}
               dispatchState={dispatch.dispatchState}
               assignments={dispatch.assignments}
               incidents={incidents.incidents}

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -9,6 +9,7 @@ import type {
   Road,
   RoadNetwork,
   Vehicle,
+  VehicleType,
 } from "@/types";
 import type { BoundingBox, GeoFence } from "@moveet/shared-types";
 import type { Filters } from "@/hooks/useVehicles";
@@ -45,6 +46,7 @@ interface MapProps {
   onPOIClick: (poi: POI) => void;
   vehicleFleetMap: Map<string, Fleet>;
   hiddenFleetIds: Set<string>;
+  hiddenVehicleTypes: Set<VehicleType>;
   dispatchState?: DispatchState;
   assignments?: DispatchAssignment[];
   incidents?: IncidentDTO[];
@@ -70,6 +72,7 @@ export default function Map({
   onPOIClick,
   vehicleFleetMap,
   hiddenFleetIds,
+  hiddenVehicleTypes,
   dispatchState,
   assignments = [],
   incidents,
@@ -142,6 +145,7 @@ export default function Map({
             scale={1.5}
             vehicleFleetMap={vehicleFleetMap}
             hiddenFleetIds={hiddenFleetIds}
+            hiddenVehicleTypes={hiddenVehicleTypes}
             selectedId={filters.selected}
             hoveredId={filters.hovered}
             onClick={onClick}

--- a/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
+++ b/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { PolygonLayer, ScatterplotLayer } from "@deck.gl/layers";
-import type { Fleet } from "@/types";
+import type { Fleet, VehicleType } from "@/types";
 import { vehicleStore } from "../../hooks/vehicleStore";
 import { VEHICLE_INTERPOLATION } from "../../data/constants";
 import { useRegisterLayers } from "../../components/Map/hooks/useDeckLayers";
@@ -69,6 +69,7 @@ interface VehiclesLayerProps {
   scale: number;
   vehicleFleetMap: Map<string, Fleet>;
   hiddenFleetIds: Set<string>;
+  hiddenVehicleTypes: Set<VehicleType>;
   selectedId?: string;
   hoveredId?: string;
   onClick: (id: string) => void;
@@ -187,6 +188,7 @@ export default function VehiclesLayer({
   scale: _scale,
   vehicleFleetMap,
   hiddenFleetIds,
+  hiddenVehicleTypes,
   selectedId,
   hoveredId,
   onClick,
@@ -204,6 +206,8 @@ export default function VehiclesLayer({
   fleetMapRef.current = vehicleFleetMap;
   const hiddenFleetsRef = useRef(hiddenFleetIds);
   hiddenFleetsRef.current = hiddenFleetIds;
+  const hiddenTypesRef = useRef(hiddenVehicleTypes);
+  hiddenTypesRef.current = hiddenVehicleTypes;
   const onClickRef = useRef(onClick);
   onClickRef.current = onClick;
   const getZoomRef = useRef(getZoom);
@@ -307,6 +311,7 @@ export default function VehiclesLayer({
       const store = vehicleStore.getAll();
       const fleetMap = fleetMapRef.current;
       const hiddenFleets = hiddenFleetsRef.current;
+      const hiddenTypes = hiddenTypesRef.current;
       // Scale = 2^((REF_ZOOM - zoom) * exponent). At REF_ZOOM scale=1 (true size).
       // Exponent < 1 makes vehicles shrink slower than map when zooming out.
       const zoomScale = Math.pow(2, (REFERENCE_ZOOM - currentZoom) * ZOOM_EXPONENT);
@@ -317,6 +322,7 @@ export default function VehiclesLayer({
         if (v.position[0] === 0 && v.position[1] === 0) continue;
         const fleet = fleetMap.get(v.id);
         if (fleet && hiddenFleets.has(fleet.id)) continue;
+        if (hiddenTypes.size > 0 && hiddenTypes.has((v.type as VehicleType) || "car")) continue;
 
         // Interpolate position from stored state
         const state = interps.get(v.id);

--- a/apps/ui/src/__tests__/VehiclesLayer.test.tsx
+++ b/apps/ui/src/__tests__/VehiclesLayer.test.tsx
@@ -46,6 +46,7 @@ const defaultProps = {
   scale: 1.5,
   vehicleFleetMap: new Map<string, Fleet>(),
   hiddenFleetIds: new Set<string>(),
+  hiddenVehicleTypes: new Set<string>(),
   onClick: vi.fn(),
 };
 
@@ -213,6 +214,19 @@ describe("VehiclesLayer (deck.gl)", () => {
 
     const data = getVehiclesLayerData();
     expect(data.length).toBe(0);
+  });
+
+  it("skips vehicles of hidden types", () => {
+    vehicleStore.replace([
+      { id: "v1", name: "Car-1", type: "car", position: [36.82, -1.29], speed: 30, heading: 90 },
+      { id: "v2", name: "Truck-1", type: "truck", position: [36.83, -1.28], speed: 25, heading: 45 },
+    ]);
+
+    renderAndTick({ hiddenVehicleTypes: new Set(["truck"]) });
+
+    const data = getVehiclesLayerData();
+    expect(data.length).toBe(1);
+    expect(data[0].id).toBe("v1");
   });
 
   it("marks selected vehicle in interpolated data", () => {

--- a/apps/ui/src/__tests__/VehiclesLayer.test.tsx
+++ b/apps/ui/src/__tests__/VehiclesLayer.test.tsx
@@ -219,7 +219,14 @@ describe("VehiclesLayer (deck.gl)", () => {
   it("skips vehicles of hidden types", () => {
     vehicleStore.replace([
       { id: "v1", name: "Car-1", type: "car", position: [36.82, -1.29], speed: 30, heading: 90 },
-      { id: "v2", name: "Truck-1", type: "truck", position: [36.83, -1.28], speed: 25, heading: 45 },
+      {
+        id: "v2",
+        name: "Truck-1",
+        type: "truck",
+        position: [36.83, -1.28],
+        speed: 25,
+        heading: 45,
+      },
     ]);
 
     renderAndTick({ hiddenVehicleTypes: new Set(["truck"]) });


### PR DESCRIPTION
## Problem

When the simulator starts without a scenario (the default mode), `VehicleRegistry.loadFromData()` created **all** vehicles as type `"car"`. Trucks, buses, motorcycles, and ambulances never appeared unless a scenario explicitly spawned them.

## Root Cause

The fallback path in `loadFromData()` hardcoded `"car"` for every vehicle:

```typescript
} else {
  for (let i = 0; i < config.vehicleCount; i++) {
    this.addVehicle(i.toString(), `V${i}`, undefined, "car", onVehicleAdded);
  }
}
```

## Fix

### 1. Weighted vehicle type distribution (`vehicleProfiles.ts`)
- Added `DEFAULT_VEHICLE_TYPE_WEIGHTS`: 60% car, 15% truck, 12% motorcycle, 10% bus, 3% ambulance
- Added `distributeByWeight(total)` that converts percentages to exact counts with correct rounding

### 2. Registry uses distribution (`VehicleRegistry.ts`)
- `loadFromData()` now calls `distributeByWeight(config.vehicleCount)` when no explicit types are provided
- Vehicle names reflect type: `Car-1`, `Truck-2`, `Bus-3` instead of generic `V0`, `V1`

### 3. Environment override (`config.ts`)
- Added `VEHICLE_TYPES` env var for custom JSON distribution: `VEHICLE_TYPES='{"car":50,"truck":10}'`
- `VehicleManager` passes `config.vehicleTypes` through to the registry

### 4. Tests
- New `vehicleProfiles.test.ts` with distribution unit tests (sum correctness, type coverage, edge cases)
- Updated `VehicleRegistry.test.ts` and `vehicleTypes.test.ts` to expect mixed types

## Example output (70 vehicles)
```json
{"car": 42, "truck": 11, "motorcycle": 8, "bus": 7, "ambulance": 2}
```

## Test results
All **1361 tests pass** ✅