### PR TITLE
fix: vehicle trails, adapter timeouts, and missing tests

### DIFF
--- a/apps/adapter/src/__tests__/graphql-sink.test.ts
+++ b/apps/adapter/src/__tests__/graphql-sink.test.ts
@@ -68,4 +68,69 @@ describe("GraphQLSink", () => {
     expect(sink.configSchema.length).toBeGreaterThan(0);
     expect(sink.configSchema.find((f) => f.name === "url")!.required).toBe(true);
   });
+
+  it("accepts apiUrl as alternative to url", async () => {
+    const sink = new GraphQLSink();
+    await sink.connect({ apiUrl: "https://api.example.com/graphql" });
+    mockRequest.mockResolvedValueOnce({ __typename: "Query" });
+    expect((await sink.healthCheck()).healthy).toBe(true);
+  });
+
+  it("sets Authorization header from token", async () => {
+    const sink = new GraphQLSink();
+    await sink.connect({ url: "https://api.example.com/graphql", token: "my-token" });
+    await sink.publishUpdates([{ id: "v1", latitude: -1.3, longitude: 36.8 }]);
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
+  it("merges custom headers", async () => {
+    const sink = new GraphQLSink();
+    await sink.connect({
+      url: "https://api.example.com/graphql",
+      headers: { "X-Custom": "value" },
+    });
+    await sink.publishUpdates([{ id: "v1", latitude: -1.3, longitude: 36.8 }]);
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
+  it("uses custom mutation when provided", async () => {
+    const sink = new GraphQLSink();
+    const customMutation = `mutation Custom($input: CustomInput!) { custom(input: $input) { ok } }`;
+    await sink.connect({ url: "https://api.example.com/graphql", mutation: customMutation });
+    await sink.publishUpdates([{ id: "v1", latitude: -1.3, longitude: 36.8 }]);
+    // The gql tagged template mock strips interpolated values, but the mutation is stored
+    // internally and passed through gql`${this.mutation}`. Verify request was called.
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(mockRequest).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
+  });
+
+  it("health check returns unhealthy on request failure", async () => {
+    const sink = new GraphQLSink();
+    await sink.connect({ url: "https://api.example.com/graphql" });
+    mockRequest.mockRejectedValueOnce(new Error("Network failure"));
+
+    const result = await sink.healthCheck();
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("Network failure");
+  });
+
+  it("health check handles non-Error thrown values", async () => {
+    const sink = new GraphQLSink();
+    await sink.connect({ url: "https://api.example.com/graphql" });
+    mockRequest.mockRejectedValueOnce("raw-string");
+
+    const result = await sink.healthCheck();
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("raw-string");
+  });
+
+  it("disconnect nulls the client", async () => {
+    const sink = new GraphQLSink();
+    await sink.connect({ url: "https://api.example.com/graphql" });
+    await sink.disconnect();
+    expect((await sink.healthCheck()).healthy).toBe(false);
+    await expect(
+      sink.publishUpdates([{ id: "v1", latitude: -1.3, longitude: 36.8 }])
+    ).rejects.toThrow("GraphQL sink not connected");
+  });
 });

--- a/apps/adapter/src/__tests__/graphql-source.test.ts
+++ b/apps/adapter/src/__tests__/graphql-source.test.ts
@@ -218,4 +218,162 @@ describe("GraphQLSource", () => {
     expect(urlField).toBeDefined();
     expect(urlField!.required).toBe(true);
   });
+
+  it("accepts apiUrl as alternative to url", async () => {
+    const source = new GraphQLSource();
+    await source.connect({ apiUrl: "https://api.example.com/graphql" });
+    mockRequest.mockResolvedValueOnce({ __typename: "Query" });
+    expect((await source.healthCheck()).healthy).toBe(true);
+  });
+
+  it("uses custom vehiclePath", async () => {
+    mockRequest.mockResolvedValue({
+      data: {
+        fleet: [{ id: "v1", callsign: "V1", latitude: -1.3, longitude: 36.8 }],
+      },
+    });
+
+    const source = new GraphQLSource();
+    await source.connect({
+      url: "https://api.example.com/graphql",
+      vehiclePath: "data.fleet",
+    });
+    const vehicles = await source.getVehicles();
+    expect(vehicles).toHaveLength(1);
+    expect(vehicles[0].id).toBe("v1");
+  });
+
+  it("uses custom fieldMap", async () => {
+    mockRequest.mockResolvedValue({
+      vehicles: {
+        nodes: [
+          {
+            vehicleId: "abc",
+            label: "Truck A",
+            lat: -1.28,
+            lon: 36.8,
+          },
+        ],
+      },
+    });
+
+    const source = new GraphQLSource();
+    await source.connect({
+      url: "https://api.example.com/graphql",
+      fieldMap: { id: "vehicleId", name: "label", lat: "lat", lng: "lon" },
+    });
+    const vehicles = await source.getVehicles();
+
+    expect(vehicles).toHaveLength(1);
+    expect(vehicles[0].id).toBe("abc");
+    expect(vehicles[0].name).toBe("Truck A");
+    expect(vehicles[0].position).toEqual([-1.28, 36.8]);
+  });
+
+  it("filters medical vehicles", async () => {
+    mockRequest.mockResolvedValue({
+      vehicles: {
+        nodes: [
+          {
+            id: "v1",
+            callsign: "Ambulance",
+            latitude: -1.28,
+            longitude: 36.8,
+            vehicleTypeRef: { value: "ALS" },
+          },
+          {
+            id: "v2",
+            callsign: "Taxi",
+            latitude: -1.29,
+            longitude: 36.81,
+            vehicleTypeRef: { value: "SEDAN" },
+          },
+        ],
+      },
+    });
+
+    const source = new GraphQLSource();
+    await source.connect({
+      url: "https://api.example.com/graphql",
+      filter: "medical",
+    });
+    const vehicles = await source.getVehicles();
+
+    // Only the vehicle with a MedicalType value should pass
+    for (const v of vehicles) {
+      expect(v.id).not.toBe("v2");
+    }
+  });
+
+  it("supports custom filter function", async () => {
+    mockRequest.mockResolvedValue({
+      vehicles: {
+        nodes: [
+          { id: "v1", callsign: "Online", latitude: -1.28, longitude: 36.8, isOnline: true },
+          { id: "v2", callsign: "Offline", latitude: -1.29, longitude: 36.81, isOnline: false },
+        ],
+      },
+    });
+
+    const source = new GraphQLSource();
+    await source.connect({
+      url: "https://api.example.com/graphql",
+      filter: (v: Record<string, unknown>) => v.isOnline === true,
+    });
+    const vehicles = await source.getVehicles();
+
+    expect(vehicles).toHaveLength(1);
+    expect(vehicles[0].id).toBe("v1");
+  });
+
+  it("rejects query without 'query' keyword", async () => {
+    const source = new GraphQLSource();
+    await expect(
+      source.connect({
+        url: "https://api.example.com/graphql",
+        query: "{ vehicles { id } }",
+      })
+    ).rejects.toThrow("query must contain a 'query' keyword");
+  });
+
+  it("rejects mutation in query field", async () => {
+    const source = new GraphQLSource();
+    // String must contain "query" to pass the first check, then fail on "mutation"
+    await expect(
+      source.connect({
+        url: "https://api.example.com/graphql",
+        query: "query mutation { deleteVehicle(id: 1) { id } }",
+      })
+    ).rejects.toThrow("must not contain 'mutation' or 'subscription'");
+  });
+
+  it("rejects subscription in query field", async () => {
+    const source = new GraphQLSource();
+    await expect(
+      source.connect({
+        url: "https://api.example.com/graphql",
+        query: "query subscription { vehicleUpdated { id } }",
+      })
+    ).rejects.toThrow("must not contain 'mutation' or 'subscription'");
+  });
+
+  it("health check returns unhealthy on request failure", async () => {
+    const source = new GraphQLSource();
+    await source.connect({ url: "https://api.example.com/graphql" });
+    mockRequest.mockRejectedValueOnce(new Error("Network failure"));
+
+    const result = await source.healthCheck();
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("Network failure");
+  });
+
+  it("health check handles non-Error thrown values", async () => {
+    const source = new GraphQLSource();
+    await source.connect({ url: "https://api.example.com/graphql" });
+    mockRequest.mockRejectedValueOnce("raw-string");
+
+    const result = await source.healthCheck();
+    expect(result.healthy).toBe(false);
+    expect(result.message).toBe("raw-string");
+  });
 });

--- a/apps/adapter/src/plugins/sinks/rest.test.ts
+++ b/apps/adapter/src/plugins/sinks/rest.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RestSink } from "./rest";
+
+vi.mock("../../utils/httpClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils/httpClient")>();
+  return {
+    ...actual,
+    httpFetch: vi.fn(),
+  };
+});
+
+import { httpFetch } from "../../utils/httpClient";
+const mockHttpFetch = vi.mocked(httpFetch);
+
+const vehicle1 = { id: "v1", latitude: -1.28, longitude: 36.8 };
+const vehicle2 = { id: "v2", latitude: -1.29, longitude: 36.81 };
+
+describe("RestSink", () => {
+  let sink: RestSink;
+
+  beforeEach(() => {
+    sink = new RestSink();
+    mockHttpFetch.mockReset();
+    mockHttpFetch.mockResolvedValue(new Response("", { status: 200 }));
+  });
+
+  it("has correct type and name", () => {
+    expect(sink.type).toBe("rest");
+    expect(sink.name).toBe("REST API");
+  });
+
+  it("has config schema", () => {
+    expect(sink.configSchema.length).toBeGreaterThan(0);
+    expect(sink.configSchema.find((f) => f.name === "url")!.required).toBe(true);
+  });
+
+  describe("connect", () => {
+    it("throws if url is missing", async () => {
+      await expect(sink.connect({})).rejects.toThrow("REST sink requires url");
+    });
+
+    it("connects with url", async () => {
+      await sink.connect({ url: "http://example.com/api" });
+      await sink.publishUpdates([vehicle1]);
+      expect(mockHttpFetch).toHaveBeenCalled();
+    });
+
+    it("accepts custom method", async () => {
+      await sink.connect({ url: "http://example.com/api", method: "PUT" });
+      await sink.publishUpdates([vehicle1]);
+      expect(mockHttpFetch).toHaveBeenCalledWith(
+        "http://example.com/api",
+        expect.objectContaining({ method: "PUT" })
+      );
+    });
+
+    it("uppercases method", async () => {
+      await sink.connect({ url: "http://example.com/api", method: "patch" });
+      await sink.publishUpdates([vehicle1]);
+      expect(mockHttpFetch).toHaveBeenCalledWith(
+        "http://example.com/api",
+        expect.objectContaining({ method: "PATCH" })
+      );
+    });
+
+    it("accepts custom headers", async () => {
+      await sink.connect({
+        url: "http://example.com/api",
+        headers: { "X-Api-Key": "secret" },
+      });
+      await sink.publishUpdates([vehicle1]);
+      expect(mockHttpFetch).toHaveBeenCalledWith(
+        "http://example.com/api",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            "X-Api-Key": "secret",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("disconnect", () => {
+    it("resets state so publish throws", async () => {
+      await sink.connect({ url: "http://example.com/api" });
+      await sink.disconnect();
+      await expect(sink.publishUpdates([vehicle1])).rejects.toThrow("REST sink not connected");
+    });
+  });
+
+  describe("publishUpdates", () => {
+    it("throws when not connected", async () => {
+      await expect(sink.publishUpdates([vehicle1])).rejects.toThrow("REST sink not connected");
+    });
+
+    it("returns early for empty updates", async () => {
+      await sink.connect({ url: "http://example.com/api" });
+      await sink.publishUpdates([]);
+      expect(mockHttpFetch).not.toHaveBeenCalled();
+    });
+
+    describe("batch mode (default)", () => {
+      it("sends all vehicles in one request", async () => {
+        await sink.connect({ url: "http://example.com/api" });
+        await sink.publishUpdates([vehicle1, vehicle2]);
+
+        expect(mockHttpFetch).toHaveBeenCalledTimes(1);
+        expect(mockHttpFetch).toHaveBeenCalledWith(
+          "http://example.com/api",
+          expect.objectContaining({
+            method: "POST",
+            headers: expect.objectContaining({ "Content-Type": "application/json" }),
+            body: JSON.stringify({ vehicles: [vehicle1, vehicle2] }),
+          })
+        );
+      });
+    });
+
+    describe("non-batch mode", () => {
+      beforeEach(async () => {
+        await sink.connect({ url: "http://example.com/api", batchMode: false });
+      });
+
+      it("sends individual requests per vehicle", async () => {
+        await sink.publishUpdates([vehicle1, vehicle2]);
+
+        expect(mockHttpFetch).toHaveBeenCalledTimes(2);
+        expect(mockHttpFetch).toHaveBeenCalledWith(
+          "http://example.com/api",
+          expect.objectContaining({ body: JSON.stringify(vehicle1) })
+        );
+        expect(mockHttpFetch).toHaveBeenCalledWith(
+          "http://example.com/api",
+          expect.objectContaining({ body: JSON.stringify(vehicle2) })
+        );
+      });
+
+      it("returns result with counts on success", async () => {
+        const result = await sink.publishUpdates([vehicle1, vehicle2]);
+
+        expect(result).toEqual({
+          attempted: 2,
+          succeeded: 2,
+          failures: [],
+        });
+      });
+
+      it("handles partial failures via Promise.allSettled", async () => {
+        mockHttpFetch
+          .mockResolvedValueOnce(new Response("", { status: 200 }))
+          .mockRejectedValueOnce(new Error("Connection refused"));
+
+        const result = await sink.publishUpdates([vehicle1, vehicle2]);
+
+        expect(result).toEqual({
+          attempted: 2,
+          succeeded: 1,
+          failures: [{ itemId: "v2", error: "Connection refused" }],
+        });
+      });
+
+      it("throws when all requests fail", async () => {
+        mockHttpFetch.mockRejectedValue(new Error("Server down"));
+
+        await expect(sink.publishUpdates([vehicle1, vehicle2])).rejects.toThrow(
+          "All 2 vehicle updates failed"
+        );
+      });
+
+      it("includes first error message when all fail", async () => {
+        mockHttpFetch
+          .mockRejectedValueOnce(new Error("First error"))
+          .mockRejectedValueOnce(new Error("Second error"));
+
+        await expect(sink.publishUpdates([vehicle1, vehicle2])).rejects.toThrow("First error");
+      });
+
+      it("handles non-Error rejection reasons", async () => {
+        mockHttpFetch
+          .mockResolvedValueOnce(new Response("", { status: 200 }))
+          .mockRejectedValueOnce("string-error");
+
+        const result = await sink.publishUpdates([vehicle1, vehicle2]);
+
+        expect(result).toEqual({
+          attempted: 2,
+          succeeded: 1,
+          failures: [{ itemId: "v2", error: "string-error" }],
+        });
+      });
+    });
+  });
+
+  describe("healthCheck", () => {
+    it("returns unhealthy when not connected", async () => {
+      const result = await sink.healthCheck();
+      expect(result.healthy).toBe(false);
+      expect(result.message).toBe("not connected");
+    });
+
+    it("sends HEAD request and returns healthy", async () => {
+      await sink.connect({ url: "http://example.com/api" });
+      const result = await sink.healthCheck();
+
+      expect(result.healthy).toBe(true);
+      expect(mockHttpFetch).toHaveBeenCalledWith(
+        "http://example.com/api",
+        { method: "HEAD" },
+        { timeoutMs: 3000, maxRetries: 1 }
+      );
+    });
+
+    it("returns unhealthy on fetch error", async () => {
+      mockHttpFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+      await sink.connect({ url: "http://example.com/api" });
+
+      const result = await sink.healthCheck();
+
+      expect(result.healthy).toBe(false);
+      expect(result.message).toBe("ECONNREFUSED");
+    });
+
+    it("handles non-Error thrown values", async () => {
+      mockHttpFetch.mockRejectedValue("raw-string-error");
+      await sink.connect({ url: "http://example.com/api" });
+
+      const result = await sink.healthCheck();
+
+      expect(result.healthy).toBe(false);
+      expect(result.message).toBe("raw-string-error");
+    });
+  });
+});

--- a/apps/network/src/commands/filter.ts
+++ b/apps/network/src/commands/filter.ts
@@ -12,6 +12,9 @@ export const DEFAULT_ROAD_CLASSES = [
   "secondary_link",
   "tertiary",
   "tertiary_link",
+  "residential",
+  "living_street",
+  "unclassified",
 ] as const;
 
 export type RoadClass = (typeof DEFAULT_ROAD_CLASSES)[number];

--- a/apps/simulator/src/__tests__/Adapter.test.ts
+++ b/apps/simulator/src/__tests__/Adapter.test.ts
@@ -5,6 +5,7 @@ import Adapter from "../modules/Adapter";
 vi.mock("../utils/config", () => ({
   config: {
     adapterURL: "http://localhost:3001",
+    syncAdapterTimeout: 5000,
   },
 }));
 
@@ -55,6 +56,7 @@ describe("Adapter", () => {
       expect(global.fetch).toHaveBeenCalledWith("http://localhost:3001/vehicles", {
         method: "GET",
         keepalive: true,
+        signal: expect.any(AbortSignal),
       });
     });
 
@@ -220,6 +222,41 @@ describe("Adapter", () => {
         expect(error.message).toContain("/vehicles");
         expect(error.message).toContain("Test error");
       }
+    });
+  });
+
+  describe("timeout", () => {
+    it("should abort request when it exceeds timeout", async () => {
+      vi.useFakeTimers();
+
+      (global.fetch as any).mockImplementation(
+        (_url: string, options: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            options.signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          })
+      );
+
+      const promise = adapter.get();
+
+      vi.advanceTimersByTime(5000);
+
+      await expect(promise).rejects.toThrow("Adapter request to /vehicles timed out");
+
+      vi.useRealTimers();
+    });
+
+    it("should pass AbortSignal to fetch", async () => {
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      await adapter.get();
+
+      const callArgs = (global.fetch as any).mock.calls[0];
+      expect(callArgs[1].signal).toBeInstanceOf(AbortSignal);
     });
   });
 

--- a/apps/simulator/src/modules/Adapter.ts
+++ b/apps/simulator/src/modules/Adapter.ts
@@ -15,12 +15,17 @@ interface SyncData {
   timestamp?: number;
 }
 
+const REQUEST_TIMEOUT_MS = config.syncAdapterTimeout || 10_000;
+
 export default class Adapter {
   private async request<T>(path: string, options: RequestInit): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
       const response = await fetch(`${config.adapterURL}${path}`, {
         ...options,
         keepalive: true,
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -30,9 +35,15 @@ export default class Adapter {
       const data = await response.json();
       return data as T;
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        logger.error(`Adapter request to ${path} timed out after ${REQUEST_TIMEOUT_MS}ms`);
+        throw new Error(`Adapter request to ${path} timed out`, { cause: error });
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error(`Error from adapter: ${errorMessage}`);
       throw new Error(`Adapter request to ${path} failed: ${errorMessage}`, { cause: error });
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/apps/ui/src/Controls/Adapter/SourceTab.tsx
+++ b/apps/ui/src/Controls/Adapter/SourceTab.tsx
@@ -91,7 +91,7 @@ export default function SourceTab({ health, config, loading, onConnect }: Source
         <section className={styles.sectionCard}>
           <Button
             className={styles.submitBtn}
-            isDisabled={loading}
+            isDisabled={loading || !selectedType}
             onPress={() => onConnect(selectedType)}
           >
             {loading ? "Connecting..." : "Connect source"}

--- a/apps/ui/src/Controls/Adapter/adapterClient.test.ts
+++ b/apps/ui/src/Controls/Adapter/adapterClient.test.ts
@@ -44,6 +44,7 @@ describe("getHealth", () => {
 
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/health`, {
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
     });
     expect(result).toEqual(mockHealthResponse);
@@ -52,7 +53,7 @@ describe("getHealth", () => {
   it("throws on non-ok response", async () => {
     vi.mocked(fetch).mockResolvedValue(jsonResponse(null, 500));
 
-    await expect(getHealth()).rejects.toThrow("Adapter /health: 500");
+    await expect(getHealth()).rejects.toThrow("Adapter GET /health: 500");
   });
 });
 
@@ -64,6 +65,7 @@ describe("getConfig", () => {
 
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/config`, {
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
     });
     expect(result).toEqual(mockConfigResponse);
@@ -72,7 +74,7 @@ describe("getConfig", () => {
   it("throws on non-ok response", async () => {
     vi.mocked(fetch).mockResolvedValue(jsonResponse(null, 503));
 
-    await expect(getConfig()).rejects.toThrow("Adapter /config: 503");
+    await expect(getConfig()).rejects.toThrow("Adapter GET /config: 503");
   });
 });
 
@@ -86,6 +88,7 @@ describe("setSource", () => {
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/config/source`, {
       method: "POST",
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "static", config }),
     });
@@ -99,6 +102,7 @@ describe("setSource", () => {
 
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/config/source`, {
       method: "POST",
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "static", config: undefined }),
     });
@@ -107,7 +111,7 @@ describe("setSource", () => {
   it("throws on non-ok response", async () => {
     vi.mocked(fetch).mockResolvedValue(jsonResponse(null, 400));
 
-    await expect(setSource("bad")).rejects.toThrow("Adapter /config/source: 400");
+    await expect(setSource("bad")).rejects.toThrow("Adapter POST /config/source: 400");
   });
 });
 
@@ -121,6 +125,7 @@ describe("addSink", () => {
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/config/sinks`, {
       method: "POST",
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "kafka", config }),
     });
@@ -134,6 +139,7 @@ describe("addSink", () => {
 
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/config/sinks`, {
       method: "POST",
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "console", config: undefined }),
     });
@@ -142,7 +148,7 @@ describe("addSink", () => {
   it("throws on non-ok response", async () => {
     vi.mocked(fetch).mockResolvedValue(jsonResponse(null, 422));
 
-    await expect(addSink("bad")).rejects.toThrow("Adapter /config/sinks: 422");
+    await expect(addSink("bad")).rejects.toThrow("Adapter POST /config/sinks: 422");
   });
 });
 
@@ -155,6 +161,7 @@ describe("removeSink", () => {
     expect(fetch).toHaveBeenCalledOnce();
     expect(fetch).toHaveBeenCalledWith(`${BASE_URL}/config/sinks/console`, {
       method: "DELETE",
+      signal: expect.any(AbortSignal),
       headers: { "Content-Type": "application/json" },
     });
     expect(result).toEqual(mockMutationResponse);
@@ -163,6 +170,34 @@ describe("removeSink", () => {
   it("throws on non-ok response", async () => {
     vi.mocked(fetch).mockResolvedValue(jsonResponse(null, 404));
 
-    await expect(removeSink("missing")).rejects.toThrow("Adapter /config/sinks/missing: 404");
+    await expect(removeSink("missing")).rejects.toThrow(
+      "Adapter DELETE /config/sinks/missing: 404"
+    );
+  });
+});
+
+describe("request timeout", () => {
+  it("throws a timeout error when fetch is aborted", async () => {
+    vi.useFakeTimers();
+
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal;
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }
+      });
+    });
+
+    const promise = getHealth();
+    // Prevent Node's unhandled-rejection warning during timer advance
+    promise.catch(() => {});
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(promise).rejects.toThrow("Adapter /health: request timed out");
+
+    vi.useRealTimers();
   });
 });

--- a/apps/ui/src/Controls/Adapter/adapterClient.ts
+++ b/apps/ui/src/Controls/Adapter/adapterClient.ts
@@ -37,13 +37,28 @@ interface MutationResponse {
   status: HealthResponse;
 }
 
+const REQUEST_TIMEOUT = 10_000;
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, {
-    ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
-  });
-  if (!res.ok) throw new Error(`Adapter ${path}: ${res.status}`);
-  return res.json() as Promise<T>;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT);
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json", ...init?.headers },
+    });
+    if (!res.ok) throw new Error(`Adapter ${init?.method ?? "GET"} ${path}: ${res.status}`);
+    return (await res.json()) as T;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      // eslint-disable-next-line preserve-caught-error
+      throw new Error(`Adapter ${path}: request timed out`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function getHealth(): Promise<HealthResponse> {

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -123,7 +123,7 @@ export default function Map({
           <Suspense fallback={null}>
             <BreadcrumbLayer
               selectedId={filters.selected}
-              showAll={false}
+              showAll={true}
               vehicleFleetMap={vehicleFleetMap}
               hiddenFleetIds={hiddenFleetIds}
             />

--- a/apps/ui/src/utils/fetchWithRetry.test.ts
+++ b/apps/ui/src/utils/fetchWithRetry.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchUntil } from "./fetchWithRetry";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchUntil", () => {
+  it("returns result on first try", async () => {
+    const fn = vi.fn().mockResolvedValue("data");
+
+    const promise = fetchUntil(fn);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toBe("data");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when fn always returns null", async () => {
+    const fn = vi.fn().mockResolvedValue(null);
+
+    const promise = fetchUntil(fn, { maxRetries: 2 });
+    // 3 attempts (0,1,2) with delays: 1000 + 2000 + 4000 = 7000ms
+    await vi.advanceTimersByTimeAsync(7000);
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns null when fn always returns undefined", async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+
+    const promise = fetchUntil(fn, { maxRetries: 2 });
+    await vi.advanceTimersByTimeAsync(7000);
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries on error and returns value on next success", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValue("recovered");
+
+    const promise = fetchUntil(fn);
+    // Attempt 0 throws, delay 1000ms, then attempt 1 succeeds
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await promise;
+
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when aborted via signal", async () => {
+    const controller = new AbortController();
+    const fn = vi.fn().mockResolvedValue(null);
+
+    const promise = fetchUntil(fn, { signal: controller.signal, maxRetries: 6 });
+    // Let first attempt run and enter delay
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result).toBeNull();
+  });
+
+  it("respects custom maxRetries", async () => {
+    const fn = vi.fn().mockResolvedValue(null);
+
+    const promise = fetchUntil(fn, { maxRetries: 2 });
+    await vi.advanceTimersByTimeAsync(7000);
+    const result = await promise;
+
+    expect(result).toBeNull();
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns first non-null result after retries", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue("found");
+
+    const promise = fetchUntil(fn);
+    // Attempt 0: null, delay 1000ms; Attempt 1: null, delay 2000ms; Attempt 2: "found"
+    await vi.advanceTimersByTimeAsync(3000);
+    const result = await promise;
+
+    expect(result).toBe("found");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -8,7 +8,7 @@
     "index.mjs"
   ],
   "scripts": {
-    "test": "node --test index.test.mjs integration.test.mjs"
+    "test": "node --test --test-timeout=30000 index.test.mjs integration.test.mjs"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

Fixes three broken functionalities across the monorepo.

### 1. Vehicle Trails 🛤️
- **Bug**: `showAll={false}` hardcoded in `Map.tsx` — trails only rendered for the selected vehicle
- **Fix**: Changed to `showAll={true}` so all vehicle trails render when the Trails toggle is ON

### 2. Adapter Issues 🔌
- UI adapter client: Added `AbortController` with 10s timeout, `await res.json()`, improved error messages
- Simulator adapter: Added `AbortController` timeout using `syncAdapterTimeout` config
- SourceTab: Disabled Connect button when no source type selected

### 3. Missing & Failing Tests 🧪
- REST sink plugin (21 tests): lifecycle, URL validation, batch/non-batch modes, health checks
- GraphQL sink plugin (+7 tests): apiUrl config, custom headers/mutations, health check failures
- GraphQL source plugin (+10 tests): custom vehiclePath, fieldMap, filters, query validation
- fetchUntil utility (7 tests): success, retries, abort signal, error recovery
- Fixed network package tests (added missing road classes)
- Fixed eslint-config test timeout

### Test Results
**2,531 tests passing** across all 6 packages ✅