### PR TITLE
fix: critical + high audit findings across sim/ui/adapter

### DIFF
--- a/apps/adapter/src/__tests__/mysql-source.test.ts
+++ b/apps/adapter/src/__tests__/mysql-source.test.ts
@@ -111,6 +111,47 @@ describe("MySQLSource", () => {
     expect(source.configSchema.find((f) => f.name === "password")!.type).toBe("password");
   });
 
+  describe("healthCheck", () => {
+    it("releases the connection even when ping fails", async () => {
+      const conn = {
+        ping: vi.fn().mockRejectedValue(new Error("ping timeout")),
+        release: vi.fn(),
+      };
+      mockGetConnection.mockResolvedValue(conn);
+
+      const source = new MySQLSource();
+      await source.connect({
+        host: "localhost",
+        user: "root",
+        password: "pass",
+        database: "fleet",
+      });
+      const result = await source.healthCheck();
+
+      expect(result.healthy).toBe(false);
+      // The pooled connection must be returned even on failure, or the pool
+      // is exhausted after a few failing health checks.
+      expect(conn.release).toHaveBeenCalled();
+    });
+
+    it("releases the connection on a successful ping", async () => {
+      const conn = { ping: vi.fn().mockResolvedValue(undefined), release: vi.fn() };
+      mockGetConnection.mockResolvedValue(conn);
+
+      const source = new MySQLSource();
+      await source.connect({
+        host: "localhost",
+        user: "root",
+        password: "pass",
+        database: "fleet",
+      });
+      const result = await source.healthCheck();
+
+      expect(result.healthy).toBe(true);
+      expect(conn.release).toHaveBeenCalled();
+    });
+  });
+
   describe("coordinate validation", () => {
     it("filters out rows with NaN coordinates", async () => {
       mockExecute.mockResolvedValue([

--- a/apps/adapter/src/__tests__/postgres-source.test.ts
+++ b/apps/adapter/src/__tests__/postgres-source.test.ts
@@ -100,6 +100,36 @@ describe("PostgresSource", () => {
     expect(source.configSchema.find((f) => f.name === "password")!.type).toBe("password");
   });
 
+  describe("healthCheck", () => {
+    it("releases the client even when the probe query fails", async () => {
+      const client = {
+        query: vi.fn().mockRejectedValue(new Error("query failed")),
+        release: vi.fn(),
+      };
+      mockPoolConnect.mockResolvedValue(client);
+
+      const source = new PostgresSource();
+      await source.connect({ connectionString: "postgresql://localhost/fleet" });
+      const result = await source.healthCheck();
+
+      expect(result.healthy).toBe(false);
+      // Must return the client to the pool or it leaks on every failing check.
+      expect(client.release).toHaveBeenCalled();
+    });
+
+    it("releases the client on a successful probe", async () => {
+      const client = { query: vi.fn().mockResolvedValue({ rows: [] }), release: vi.fn() };
+      mockPoolConnect.mockResolvedValue(client);
+
+      const source = new PostgresSource();
+      await source.connect({ connectionString: "postgresql://localhost/fleet" });
+      const result = await source.healthCheck();
+
+      expect(result.healthy).toBe(true);
+      expect(client.release).toHaveBeenCalled();
+    });
+  });
+
   describe("coordinate validation", () => {
     it("filters out rows with NaN coordinates", async () => {
       mockQuery.mockResolvedValue({

--- a/apps/adapter/src/__tests__/redpanda-sink.test.ts
+++ b/apps/adapter/src/__tests__/redpanda-sink.test.ts
@@ -80,6 +80,35 @@ describe("RedpandaSink", () => {
     expect(mockProducerDisconnect).toHaveBeenCalled();
   });
 
+  describe("acks validation", () => {
+    it.each([0, 1, -1])("accepts valid acks value %s", async (acks) => {
+      const sink = new RedpandaSink();
+      await expect(sink.connect({ acks })).resolves.toBeUndefined();
+    });
+
+    it.each([2, "all", "x"])("rejects invalid acks value %s", async (acks) => {
+      const sink = new RedpandaSink();
+      await expect(sink.connect({ acks })).rejects.toThrow(/acks/i);
+    });
+  });
+
+  describe("connect failure cleanup", () => {
+    it("disconnects and clears the producer when producer.connect() fails", async () => {
+      mockProducerConnect.mockRejectedValueOnce(new Error("broker unreachable"));
+
+      const sink = new RedpandaSink();
+      await expect(sink.connect({})).rejects.toThrow("broker unreachable");
+
+      // The half-connected producer must be torn down, not leaked.
+      expect(mockProducerDisconnect).toHaveBeenCalled();
+
+      // A subsequent publish must be a no-op (producer was cleared), not a throw.
+      await expect(
+        sink.publishUpdates([{ id: "v1", latitude: -1.3, longitude: 36.8 }])
+      ).resolves.toBeUndefined();
+    });
+  });
+
   it("has config schema with batchSize field", () => {
     const sink = new RedpandaSink();
     expect(sink.configSchema.length).toBeGreaterThan(0);

--- a/apps/adapter/src/plugins/sinks/redpanda.ts
+++ b/apps/adapter/src/plugins/sinks/redpanda.ts
@@ -53,7 +53,16 @@ export class RedpandaSink implements DataSink {
     const brokers = ((config.brokers as string) || "localhost:19092").split(",");
     this.topic = (config.topic as string) || "dispatch.vehicle.positions";
     this.batchSize = (config.batchSize as number) || 500;
-    this.acks = config.acks != null ? Number(config.acks) : 1;
+
+    // acks must be one of kafkajs's accepted values. Coercing silently (e.g.
+    // "all" → NaN, "2" → 2) produces a producer that throws on every send,
+    // turning the sink into a silent black hole — so validate up front.
+    const acks = config.acks != null ? Number(config.acks) : 1;
+    if (acks !== 0 && acks !== 1 && acks !== -1) {
+      throw new Error(`RedpandaSink: invalid acks value "${config.acks}" (must be 0, 1, or -1)`);
+    }
+    this.acks = acks;
+
     this.healthCheckTimeoutMs =
       (config.healthCheckTimeoutMs as number) || DEFAULT_HEALTH_CHECK_TIMEOUT_MS;
 
@@ -63,7 +72,17 @@ export class RedpandaSink implements DataSink {
     });
 
     this.producer = this.kafka.producer({ allowAutoTopicCreation: false });
-    await this.producer.connect();
+    try {
+      await this.producer.connect();
+    } catch (err) {
+      // Tear down the half-connected producer so its internal connection/retry
+      // machinery doesn't leak — connect() failing means the plugin is never
+      // stored in activeSinks, so disconnect() would never be called otherwise.
+      await this.producer.disconnect().catch(() => {});
+      this.producer = null;
+      this.kafka = null;
+      throw err;
+    }
   }
 
   async disconnect(): Promise<void> {

--- a/apps/adapter/src/plugins/sources/mysql.ts
+++ b/apps/adapter/src/plugins/sources/mysql.ts
@@ -140,9 +140,14 @@ export class MySQLSource implements DataSource {
     if (!this.pool) return { healthy: false, message: "not connected" };
     try {
       const conn = await this.pool.getConnection();
-      await conn.ping();
-      conn.release();
-      return { healthy: true };
+      try {
+        await conn.ping();
+        return { healthy: true };
+      } finally {
+        // Always return the connection to the pool, even if ping() throws —
+        // otherwise repeated failing health checks exhaust the pool.
+        conn.release();
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { healthy: false, message };

--- a/apps/adapter/src/plugins/sources/postgres.ts
+++ b/apps/adapter/src/plugins/sources/postgres.ts
@@ -148,9 +148,14 @@ export class PostgresSource implements DataSource {
     if (!this.pool) return { healthy: false, message: "not connected" };
     try {
       const client = await this.pool.connect();
-      await client.query("SELECT 1");
-      client.release();
-      return { healthy: true };
+      try {
+        await client.query("SELECT 1");
+        return { healthy: true };
+      } finally {
+        // Always return the client to the pool, even if the probe query throws —
+        // otherwise repeated failing health checks exhaust the pool.
+        client.release();
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { healthy: false, message };

--- a/apps/simulator/src/__tests__/RoadNetwork.test.ts
+++ b/apps/simulator/src/__tests__/RoadNetwork.test.ts
@@ -205,6 +205,22 @@ describe("RoadNetwork", () => {
         expect(edge.distance).toBeGreaterThan(0);
       }
     });
+
+    it("should cache results so a repeated identical query is a cache hit", async () => {
+      const start = network.findNearestNode([45.5017, -73.5673]);
+      const end = network.findNearestNode([45.5029, -73.5661]);
+
+      network.clearRouteCache();
+      const hitsBefore = network.routeCacheStats().hits;
+
+      const first = await network.findRouteAsync(start, end);
+      const second = await network.findRouteAsync(start, end);
+
+      expect(first).not.toBeNull();
+      expect(second).not.toBeNull();
+      expect(second!.distance).toBeCloseTo(first!.distance, 6);
+      expect(network.routeCacheStats().hits).toBeGreaterThan(hitsBefore);
+    });
   });
 
   describe("getEdge", () => {

--- a/apps/simulator/src/__tests__/RouteManager.test.ts
+++ b/apps/simulator/src/__tests__/RouteManager.test.ts
@@ -89,6 +89,21 @@ describe("RouteManager", () => {
       expect(nextEdge.bearing).toBe((vehicle.currentEdge.bearing + 180) % 360);
       vi.restoreAllMocks();
     });
+
+    it("should follow the assigned route's next edge, not an arbitrary connected edge", () => {
+      const vehicle = firstVehicle();
+      // Synthetic next edge with a unique id that cannot come from the
+      // connected-edge fallback, so we can prove the route was consulted.
+      const routeNext = { ...vehicle.currentEdge, id: "route-next-edge" };
+      routeManager.setRoute(vehicle.id, {
+        edges: [vehicle.currentEdge, routeNext],
+        distance: 1,
+      });
+      vehicle.edgeIndex = 0;
+
+      const nextEdge = routeManager.peekNextEdge(vehicle);
+      expect(nextEdge.id).toBe("route-next-edge");
+    });
   });
 
   // ─── getNextEdge ──────────────────────────────────────────────────

--- a/apps/simulator/src/__tests__/WebSocketBroadcaster.test.ts
+++ b/apps/simulator/src/__tests__/WebSocketBroadcaster.test.ts
@@ -384,6 +384,21 @@ describe("WebSocketBroadcaster", () => {
       // Should not throw
       expect(() => broadcaster.stop()).not.toThrow();
     });
+
+    it("clearVehicles empties the buffer and the spatial index", () => {
+      const wss = createMockWSS();
+      const broadcaster = new WebSocketBroadcaster(wss as unknown as WebSocketServer);
+
+      broadcaster.queueVehicleUpdate(makeVehicle("v1", { position: [-1.25, 36.85] }));
+      broadcaster.queueVehicleUpdate(makeVehicle("v2", { position: [-1.26, 36.86] }));
+      expect(broadcaster.pendingUpdates).toBe(2);
+      expect(broadcaster.indexedVehicleCount).toBe(2);
+
+      broadcaster.clearVehicles();
+
+      expect(broadcaster.pendingUpdates).toBe(0);
+      expect(broadcaster.indexedVehicleCount).toBe(0);
+    });
   });
 
   describe("sendTo", () => {

--- a/apps/simulator/src/__tests__/setup/eventWiring.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiring.test.ts
@@ -12,6 +12,7 @@ function createMockBroadcaster() {
   return {
     queueVehicleUpdate: vi.fn(),
     broadcast: vi.fn(),
+    clearVehicles: vi.fn(),
   } as unknown as EventWiringContext["broadcaster"];
 }
 
@@ -185,6 +186,11 @@ describe("wireEvents", () => {
       const data = { vehicles: [], directions: [] };
       simulationController.emit("reset", data);
       expect(broadcaster.broadcast).toHaveBeenCalledWith("reset", data);
+    });
+
+    it("should clear the broadcaster's vehicles on reset", () => {
+      simulationController.emit("reset", { vehicles: [], directions: [] });
+      expect(broadcaster.clearVehicles).toHaveBeenCalled();
     });
 
     it("should broadcast clock events", () => {

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -766,7 +766,9 @@ export class RoadNetwork extends EventEmitter {
         const tentativeCost = current.gScore + travelTime;
         const existingCost = gScore.get(edge.end.id);
 
-        if (!existingCost || tentativeCost < existingCost) {
+        // Use === undefined (not falsy) so a legitimate gScore of 0 is not
+        // treated as unvisited; matches the worker-thread A* implementation.
+        if (existingCost === undefined || tentativeCost < existingCost) {
           cameFrom.set(edge.end.id, { prevId: current.id, edge });
           gScore.set(edge.end.id, tentativeCost);
 
@@ -837,6 +839,13 @@ export class RoadNetwork extends EventEmitter {
     end: Node,
     restrictedHighways?: string[]
   ): Promise<Route | null> {
+    // Check cache first — keyed identically to the sync path, plus the
+    // restricted-highway profile (a different profile yields a different route).
+    const highwayKey = restrictedHighways?.length ? restrictedHighways.join(",") : "";
+    const cacheKey = `${start.id}|${end.id}|${this.incidentFingerprint()}|${highwayKey}`;
+    const cached = this.routeCache.get(cacheKey);
+    if (cached) return { edges: [...cached.edges], distance: cached.distance };
+
     // Lazy-init the pool on first async call
     if (!this.pathfindingPool) {
       this.pathfindingPool = new PathfindingPool(this.geojsonPath);
@@ -869,7 +878,9 @@ export class RoadNetwork extends EventEmitter {
       edges.push(edge);
     }
 
-    return { edges, distance: result.distance };
+    const route = { edges, distance: result.distance };
+    this.routeCache.set(cacheKey, route);
+    return { edges: [...route.edges], distance: route.distance };
   }
 
   /**

--- a/apps/simulator/src/modules/RouteManager.ts
+++ b/apps/simulator/src/modules/RouteManager.ts
@@ -111,6 +111,23 @@ export class RouteManager extends EventEmitter {
    */
   peekNextEdge(vehicle: Vehicle): Edge {
     const currentEdge = vehicle.currentEdge;
+
+    // If the vehicle is following a route, the turn it will actually make is
+    // the next edge on that route — not an arbitrary connected edge. Resolve
+    // it without mutating any state (this method must stay side-effect-free).
+    const route = this.routes.get(vehicle.id);
+    if (route && route.edges.length > 0) {
+      let edgeIndex =
+        vehicle.edgeIndex !== undefined && vehicle.edgeIndex >= 0 ? vehicle.edgeIndex : -1;
+      if (edgeIndex < 0) {
+        edgeIndex = route.edges.findIndex((e) => e.id === currentEdge.id);
+      }
+      if (edgeIndex >= 0 && edgeIndex < route.edges.length - 1) {
+        return route.edges[edgeIndex + 1];
+      }
+      // Route exhausted or vehicle off-route → fall through to connected guess.
+    }
+
     const possibleEdges = this.network.getConnectedEdges(currentEdge);
     if (possibleEdges.length === 0) {
       return {

--- a/apps/simulator/src/modules/WebSocketBroadcaster.ts
+++ b/apps/simulator/src/modules/WebSocketBroadcaster.ts
@@ -134,6 +134,17 @@ export class WebSocketBroadcaster {
   }
 
   /**
+   * Drops all buffered updates and clears the spatial index without stopping
+   * the flush/heartbeat timers. Call on simulation reset, when the previous
+   * vehicle set is discarded, to prevent the spatial index from accumulating
+   * stale entries across resets.
+   */
+  clearVehicles(): void {
+    this.vehicleBuffer.clear();
+    this.spatialIndex.clear();
+  }
+
+  /**
    * Sets or clears a subscribe filter for a specific client.
    * Passing null removes the filter (client receives all vehicle updates).
    */
@@ -338,6 +349,14 @@ export class WebSocketBroadcaster {
    */
   get pendingUpdates(): number {
     return this.vehicleBuffer.size;
+  }
+
+  /**
+   * Returns the number of vehicles currently tracked in the spatial index.
+   * Useful for observability and for asserting the index does not leak.
+   */
+  get indexedVehicleCount(): number {
+    return this.spatialIndex.size;
   }
 }
 

--- a/apps/simulator/src/setup/eventWiring.ts
+++ b/apps/simulator/src/setup/eventWiring.ts
@@ -72,7 +72,12 @@ export function wireEvents(ctx: EventWiringContext): {
   vehicleManager.on("route:completed", (data) => broadcaster.broadcast("route:completed", data));
   vehicleManager.on("options", (data) => broadcaster.broadcast("options", data));
   simulationController.on("updateStatus", (data) => broadcaster.broadcast("status", data));
-  simulationController.on("reset", (data) => broadcaster.broadcast("reset", data));
+  simulationController.on("reset", (data) => {
+    // Discard the previous vehicle set so the spatial index does not retain
+    // stale entries across resets (would otherwise grow unbounded).
+    broadcaster.clearVehicles();
+    broadcaster.broadcast("reset", data);
+  });
   simulationController.on("clock", (clockState) => {
     broadcaster.broadcast("clock", clockState);
   });

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -57,6 +57,8 @@ import { isRoad } from "./utils/typeGuards";
 import ErrorBoundary, { SectionErrorFallback } from "./components/ErrorBoundary";
 import { toLatLng } from "./utils/coordinates";
 import { analyticsStore } from "./hooks/analyticsStore";
+import type { AnalyticsSnapshot } from "./hooks/analyticsStore";
+import type { ResetPayload } from "./utils/wsTypes";
 import { useAnalytics } from "./hooks/useAnalytics";
 import { useNetwork } from "./hooks/useNetwork";
 import { useRoads } from "./hooks/useRoads";
@@ -116,6 +118,9 @@ export default function App() {
   useSubscribeFilter(fleets, hiddenFleetIds, hiddenVehicleTypes, viewportBbox);
 
   const onBboxChange = useCallback((bbox: BoundingBox | null) => setViewportBbox(bbox), []);
+  // Stable so the POI IconLayer's onClick-keyed useMemo isn't rebuilt each render
+  // (which would discard deck.gl's in-flight enter/color transitions).
+  const onPOIClick = useCallback((poi: POI) => setSelectedItem(poi), []);
 
   const { network, loading: networkLoading } = useNetwork();
   const { loading: roadsLoading } = useRoads();
@@ -334,46 +339,54 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    client.onConnect(() => {
+    // Register named handlers so cleanup can remove exactly these — passing no
+    // handler to off* deletes the whole handler set for that event type, which
+    // would also wipe handlers other hooks (e.g. useDirections) registered for
+    // the shared "connect"/"reset" events.
+    const handleConnect = () => {
       setConnected(true);
       analyticsStore.clear();
       // Re-fetch full state on reconnect
       client.getVehicles().then((response) => {
         if (response.data) setVehicles(response.data);
       });
-    });
-    client.onDisconnect(() => setConnected(false));
-    client.onAnalytics((snapshot) => analyticsStore.push(snapshot));
-    client.onStatus((data) => {
-      setStatus(data);
-    });
-    client.onReset((data) => {
+    };
+    const handleDisconnect = () => setConnected(false);
+    const handleAnalytics = (snapshot: AnalyticsSnapshot) => analyticsStore.push(snapshot);
+    const handleStatus = (data: SimulationStatus) => setStatus(data);
+    const handleReset = (data: ResetPayload) => {
       setVehicles(data.vehicles);
       setSelectedItem(null);
       setDestination(null);
       onUnselectVehicle();
-    });
+    };
+    const handleGeofenceEvent = (event: GeoFenceEvent) => {
+      setAlerts((prev) => {
+        const next = [event, ...prev];
+        return next.length > 200 ? next.slice(0, 200) : next;
+      });
+    };
+
+    client.onConnect(handleConnect);
+    client.onDisconnect(handleDisconnect);
+    client.onAnalytics(handleAnalytics);
+    client.onStatus(handleStatus);
+    client.onReset(handleReset);
     client.getStatus().then((response) => {
       if (response.data) {
         setStatus(response.data);
       }
     });
-
-    client.onGeofenceEvent((event) => {
-      setAlerts((prev) => {
-        const next = [event, ...prev];
-        return next.length > 200 ? next.slice(0, 200) : next;
-      });
-    });
+    client.onGeofenceEvent(handleGeofenceEvent);
 
     client.connectWebSocket();
     return () => {
-      client.offConnect();
-      client.offDisconnect();
-      client.offAnalytics();
-      client.offStatus();
-      client.offReset();
-      client.offGeofenceEvent();
+      client.offConnect(handleConnect);
+      client.offDisconnect(handleDisconnect);
+      client.offAnalytics(handleAnalytics);
+      client.offStatus(handleStatus);
+      client.offReset(handleReset);
+      client.offGeofenceEvent(handleGeofenceEvent);
       client.disconnect();
     };
   }, [setVehicles, onUnselectVehicle]);
@@ -382,8 +395,13 @@ export default function App() {
   useTracking(vehicles, filters.selected, status.interval);
 
   // Keyboard shortcuts while in dispatch mode: Enter dispatches, Esc exits.
+  // Destructure the specific (stable) fields used so this effect depends on
+  // them rather than the whole `dispatch` object — which is a fresh literal
+  // every render and would otherwise re-subscribe the window listener constantly.
+  const { dispatchMode, dispatchState, handleDone, handleDispatch } = dispatch;
+  const assignmentCount = assignments.length;
   useEffect(() => {
-    if (!dispatch.dispatchMode) return;
+    if (!dispatchMode) return;
     const handler = (e: KeyboardEvent) => {
       // Don't intercept while typing in inputs/textareas.
       const target = e.target as HTMLElement | null;
@@ -395,17 +413,17 @@ export default function App() {
       }
       if (e.key === "Escape") {
         e.preventDefault();
-        dispatch.handleDone();
+        handleDone();
       } else if (e.key === "Enter") {
-        if (dispatch.dispatchState === DispatchState.ROUTE && dispatch.assignments.length > 0) {
+        if (dispatchState === DispatchState.ROUTE && assignmentCount > 0) {
           e.preventDefault();
-          void dispatch.handleDispatch();
+          void handleDispatch();
         }
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [dispatch]);
+  }, [dispatchMode, dispatchState, assignmentCount, handleDone, handleDispatch]);
 
   return (
     <div className={styles.app}>
@@ -545,7 +563,7 @@ export default function App() {
               onClick={onSelectVehicle}
               onMapClick={onMapClick}
               onMapContextClick={onMapContextClick}
-              onPOIClick={(poi) => setSelectedItem(poi)}
+              onPOIClick={onPOIClick}
               vehicleFleetMap={vehicleFleetMap}
               hiddenFleetIds={hiddenFleetIds}
               hiddenVehicleTypes={hiddenVehicleTypes}

--- a/apps/ui/src/Map/Heatmap.tsx
+++ b/apps/ui/src/Map/Heatmap.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { Vehicle } from "@/types";
 import HeatLayer from "@/components/Map/components/HeatLayer";
 
@@ -6,5 +7,9 @@ interface HeatmapProps {
 }
 
 export default function Heatmap({ vehicles }: HeatmapProps) {
-  return <HeatLayer data={vehicles.map((v) => v.position)} />;
+  // Memoize the position array so HeatLayer's layer-building useMemo (keyed on
+  // `data`) isn't busted every render, which would rebuild the deck.gl
+  // HeatmapLayer and discard its aggregation each frame.
+  const data = useMemo(() => vehicles.map((v) => v.position), [vehicles]);
+  return <HeatLayer data={data} />;
 }

--- a/apps/ui/src/components/Map/components/DeckGLMap.tsx
+++ b/apps/ui/src/components/Map/components/DeckGLMap.tsx
@@ -119,6 +119,11 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
 
   const getZoom = useCallback(() => viewState.zoom ?? 0, [viewState.zoom]);
 
+  // Stable accessor for the overlay container — passing a fresh closure each
+  // render would recompute the overlay context value and re-render every
+  // consumer (HTMLMarkers, overlays) on every map render.
+  const getRef = useCallback(() => deckContainerRef.current, []);
+
   const project = useCallback(
     (position: Position): [number, number] | null => {
       if (!viewport) return null;
@@ -170,7 +175,7 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
       project={project}
     >
       <DeckControlsProvider controls={controls}>
-        <DeckOverlayProvider viewport={viewport} getRef={() => deckContainerRef.current}>
+        <DeckOverlayProvider viewport={viewport} getRef={getRef}>
           <DeckLayersContext.Provider value={layerContextValue}>
             <div
               ref={containerRef}

--- a/apps/ui/src/components/Map/providers/OverlayContextProvider.tsx
+++ b/apps/ui/src/components/Map/providers/OverlayContextProvider.tsx
@@ -26,6 +26,11 @@ export const DeckOverlayProvider: React.FC<DeckOverlayProps> = ({ viewport, getR
     return { mapHTMLElement, htmlTransform };
   }, [getRef, htmlTransform]);
 
+  // Published synchronously (not in an effect) on purpose: <Overlay> reads this
+  // module ref during its own render and must see the current frame's transform
+  // for HTML markers to track pan/zoom without a one-frame lag. With getRef now
+  // stable, legacyData only changes when the viewport changes, so this no longer
+  // runs every render.
   setHTMLTransformer(legacyData);
 
   const value = useMemo(() => {

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -550,8 +550,8 @@ class SimulationService {
     this.ws.on("geofence:event", handler);
   }
 
-  offGeofenceEvent(): void {
-    this.ws.off("geofence:event");
+  offGeofenceEvent(handler?: (event: GeoFenceEvent) => void): void {
+    this.ws.off("geofence:event", handler);
   }
 
   subscribe(filter: SubscribeFilter | null): void {

--- a/apps/ui/src/utils/wsClient.test.ts
+++ b/apps/ui/src/utils/wsClient.test.ts
@@ -295,3 +295,43 @@ describe("WebSocketClient connection state", () => {
     expect(stateSequence).toEqual(["connecting", "connected", "reconnecting", "connected"]);
   });
 });
+
+describe("WebSocketClient handler registration", () => {
+  it("off(type, handler) removes only that handler, leaving co-registered handlers active", () => {
+    const client = createClient();
+    client.connect();
+    const ws = mockInstances[0];
+
+    const a = vi.fn();
+    const b = vi.fn();
+    client.on("connect", a);
+    client.on("connect", b);
+
+    // Targeted removal — App relies on this so its cleanup does not wipe
+    // "connect"/"reset" handlers registered by other hooks (e.g. useDirections).
+    client.off("connect", a);
+
+    ws.onopen?.(); // dispatches "connect" to all registered handlers
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("off(type) with no handler removes ALL handlers for that type", () => {
+    const client = createClient();
+    client.connect();
+    const ws = mockInstances[0];
+
+    const a = vi.fn();
+    const b = vi.fn();
+    client.on("connect", a);
+    client.on("connect", b);
+
+    client.off("connect"); // no handler arg → removes the whole set
+
+    ws.onopen?.();
+
+    expect(a).not.toHaveBeenCalled();
+    expect(b).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Addresses the verified Critical + High findings from the codebase audit. Each fix is test-driven (RED→GREEN) where an isolated unit exists.

## Simulator
- **Dead route cache (Critical, perf):** `findRouteAsync` — the only production pathfinding path — never read/wrote the route cache, so every pathfind was a full worker round-trip and the LRU + incident-fingerprint machinery was dead weight. Now caches, keyed identically to the sync path plus the restricted-highway profile.
- **A* `!existingCost` (High):** sync A* used a falsy check that mishandles a legitimate `gScore` of 0; now `=== undefined`, matching the worker.
- **Turn slowdown (High):** `peekNextEdge` followed an arbitrary connected edge instead of the route's next edge — wrong deceleration on routed vehicles. Now route-aware and still side-effect-free.
- **Spatial-index leak (High):** broadcaster `removeVehicle` had no callers and the index was never cleared on reset (unbounded growth). Added `clearVehicles()` + `indexedVehicleCount`; reset now clears it.

## Adapter
- **Pool leaks (High):** MySQL & Postgres `healthCheck()` skipped `release()` when the probe threw — repeated failing checks exhausted the pool and hung. Now release in `finally`.
- **Silent Redpanda misconfig (High):** `acks` was coerced with `Number()` (`"all"`→NaN, `"2"`→2), making every `send()` throw and silently dropping all updates. Now validated to `{0,1,-1}` on connect.
- **Producer leak (High):** a failed `producer.connect()` left a half-connected producer that was never torn down. Now disconnected + nulled on failure.

## UI
- **WS handler leak (Critical):** App.tsx removed handlers with the no-arg `off*` form, deleting the entire handler set for shared `connect`/`reset` events and wiping handlers other hooks register. Now uses named handlers + targeted removal; `offGeofenceEvent` takes an optional handler. Regression test added at the wsClient level.
- **Keydown re-subscribe (High):** the dispatch keyboard effect depended on the whole `dispatch` object (fresh literal each render), re-subscribing the window listener constantly. Now depends on the specific stable fields.
- **deck.gl memo busting (High):** memoized the Heatmap position array, `useCallback`'d the POI click handler, and stabilized `DeckGLMap`'s `getRef` so the HeatmapLayer / POI IconLayer / overlay context aren't rebuilt every render.

## Verification
- simulator: 1465 tests pass · adapter: 449 pass · ui: 598 pass
- typecheck clean across all packages; UI production build succeeds
- Medium-severity findings (recording-snapshot batching, useClock drift, vehicle-list memoization, etc.) intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)