### PR TITLE
chore(deps): bump deck.gl/luma.gl, graphql, and tooling to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: release-please-config.json

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -30,7 +30,7 @@
     "@deck.gl/aggregation-layers": "^9.2.11",
     "@deck.gl/core": "^9.2.11",
     "@deck.gl/extensions": "^9.2.11",
-    "@deck.gl/geo-layers": "9.2.11",
+    "@deck.gl/geo-layers": "^9.2.11",
     "@deck.gl/layers": "^9.2.11",
     "@deck.gl/react": "^9.2.11",
     "@luma.gl/core": "^9.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
     },
     "apps/adapter": {
       "name": "@moveet/adapter",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@moveet/shared-types": "*",
@@ -95,7 +95,7 @@
     },
     "apps/simulator": {
       "name": "@moveet/simulator",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@moveet/shared-types": "*",
@@ -139,13 +139,13 @@
     },
     "apps/ui": {
       "name": "@moveet/ui",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/aggregation-layers": "^9.2.11",
         "@deck.gl/core": "^9.2.11",
         "@deck.gl/extensions": "^9.2.11",
-        "@deck.gl/geo-layers": "9.2.11",
+        "@deck.gl/geo-layers": "^9.2.11",
         "@deck.gl/layers": "^9.2.11",
         "@deck.gl/react": "^9.2.11",
         "@luma.gl/core": "^9.2.6",
@@ -1031,37 +1031,35 @@
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.2.11.tgz",
-      "integrity": "sha512-MRFbBHtMcDkOthxXnMPm6nF08DjFDACaIQsJSyHkdWtLUTSLHsWnOTn/8QbB4ka86WyNyfJy3dibLu/m3ei2ow==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.2.tgz",
+      "integrity": "sha512-aOzCmJHPYM95aFEW7s3lyFibTSP+T/fYqCP2RxHyi/IxQwROwJTDrKyn/qPw5GvzZOIgFVxlR1Qc9RY8qYRFBw==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
+        "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
         "d3-hexbin": "^0.2.1"
       },
       "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/layers": "~9.2.0",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.2.11.tgz",
-      "integrity": "sha512-lpdxXQuFSkd6ET7M6QxPI8QMhsLRY6vzLyk83sPGFb7JSb4OhrNHYt9sfIhcA/hxJW7bdBSMWWphf2GvQetVuA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
+      "integrity": "sha512-32Va3np0Zdlz/LBNtDWCs4EkKqdHmXcbGmVp4+7i1Cpdza8y8CFmJs2VPOmSX1fwHvNCGkAZV/SFZOfDb2INsg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/core": "~4.3.4",
-        "@loaders.gl/images": "~4.3.4",
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
-        "@luma.gl/webgl": "~9.2.6",
+        "@loaders.gl/core": "^4.4.1",
+        "@loaders.gl/images": "^4.4.1",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/engine": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/sun": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -1075,64 +1073,64 @@
       }
     },
     "node_modules/@deck.gl/extensions": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.11.tgz",
-      "integrity": "sha512-zlpM4Bg1ifBziW1Juiii9NY5gyW2rEhyVTWnhagH/bpTCZ2E73OhnToYt1ouqmoxL6lMtIjhRXz6LPb7tJbHHQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.3.2.tgz",
+      "integrity": "sha512-P2gPCCmGC5R6HRB3Mv3JraDnsSpvStjFFUGKxW810SXmo2eTft/5xpvliiyJeFGDjqttwo8V4Qk6oD3BNVGvRw==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/constants": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@luma.gl/webgl": "^9.3.3",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.11.tgz",
-      "integrity": "sha512-Mr3yvKyZMPmQ3ho0hSqcJu1p7a881RqQaq/dRaPs2VP56UAkfk1e10zxXnrZ9/Dmo2MR5PH0j8tkOoGR3zKbfA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.2.tgz",
+      "integrity": "sha512-3sndOyq5A3b2DMCBWFCeX9/QkBSp5MD8EUD3eu4hHfCDV4IrbJHtxE/pv60J848Yz8D5u7ftUqXf9gLWnEeBeg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/3d-tiles": "~4.3.4",
-        "@loaders.gl/gis": "~4.3.4",
-        "@loaders.gl/loader-utils": "~4.3.4",
-        "@loaders.gl/mvt": "~4.3.4",
-        "@loaders.gl/schema": "~4.3.4",
-        "@loaders.gl/terrain": "~4.3.4",
-        "@loaders.gl/tiles": "~4.3.4",
-        "@loaders.gl/wms": "~4.3.4",
-        "@luma.gl/gltf": "~9.2.6",
-        "@luma.gl/shadertools": "~9.2.6",
+        "@loaders.gl/3d-tiles": "^4.4.1",
+        "@loaders.gl/gis": "^4.4.1",
+        "@loaders.gl/loader-utils": "^4.4.1",
+        "@loaders.gl/mvt": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@loaders.gl/terrain": "^4.4.1",
+        "@loaders.gl/tiles": "^4.4.1",
+        "@loaders.gl/wms": "^4.4.1",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
         "@types/geojson": "^7946.0.8",
-        "a5-js": "^0.5.0",
-        "h3-js": "^4.1.0",
+        "a5-js": "^0.7.2",
+        "h3-js": "^4.4.0",
         "long": "^3.2.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/extensions": "~9.2.0",
-        "@deck.gl/layers": "~9.2.0",
-        "@deck.gl/mesh-layers": "~9.2.0",
-        "@loaders.gl/core": "~4.3.4",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/extensions": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@deck.gl/mesh-layers": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.2.11.tgz",
-      "integrity": "sha512-2FSb0Qa6YR+Rg6GWhYOGTUug3vtZ4uKcFdnrdiJoVXGyibKJMScKZIsivY0r/yQQZsaBjYqty5QuVJvdtEHxSA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.3.2.tgz",
+      "integrity": "sha512-TeVfhQ/cQU1oTlTn16mCp7268d1uBJ6dwfgmKXThe2TzW9hql3iJaxbYTKg2phDg5YSiGmeEOpXbeBh59jyUcA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "~4.3.4",
-        "@loaders.gl/schema": "~4.3.4",
-        "@luma.gl/shadertools": "~9.2.6",
+        "@loaders.gl/images": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@luma.gl/shadertools": "^9.3.3",
         "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/polygon": "^4.1.0",
@@ -1140,35 +1138,36 @@
         "earcut": "^2.2.4"
       },
       "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@loaders.gl/core": "~4.3.4",
-        "@luma.gl/core": "~9.2.6",
-        "@luma.gl/engine": "~9.2.6"
+        "@deck.gl/core": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
       }
     },
     "node_modules/@deck.gl/react": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.2.11.tgz",
-      "integrity": "sha512-7xrXlM++3A7cKZdDKSW2/EPT6sc0ob7J24sTPaHe3YlIIFvCZTkQ1U1rAT9cN2gjhkI6XsE+TugUsqhx4TGwHQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.3.2.tgz",
+      "integrity": "sha512-XGxoyTQiQWvBHt+q5bATOHlv9INdl0xwt/IxP4eMbbE9XhLreeGTTb0CDGbk+SwDHVwQuLFp5JHZNibUt0J3fA==",
       "license": "MIT",
       "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@deck.gl/widgets": "~9.2.0",
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/widgets": "~9.3.0",
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
       }
     },
     "node_modules/@deck.gl/widgets": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.2.11.tgz",
-      "integrity": "sha512-90HWlQPsiRyTPWR4aYfLwnYDrJdHG2mqCzRcyMUKewWBNQLu4upB//l4ewIkUeXXCzAprjjVeRnNb7wdYj2CXQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.3.2.tgz",
+      "integrity": "sha512-EdNxecpUlZHhfCSD5qpMVva7fjd48u6lDSXMxQRnT2uCGCMHBViZadkCmyK3lPwac4nylM9vRWek/NPSOqPKcQ==",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/dom": "^1.7.5",
         "preact": "^10.17.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "~9.2.0",
-        "@luma.gl/core": "~9.2.6"
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1789,6 +1788,31 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
@@ -1902,27 +1926,27 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
-      "integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
-      "integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1934,16 +1958,16 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
-      "integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1955,21 +1979,21 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
-      "integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
         "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1981,17 +2005,17 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
-      "integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.1.tgz",
+      "integrity": "sha512-NFLxWmTPc2WORINoffcbVwB2+tujeNZ6Cu50HbXvTbk0fHSmhA5PgCckxXuyUniQvX7bhxkZi0nODfJIGsnCdA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/external-editor": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.2",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2003,16 +2027,16 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
-      "integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2024,16 +2048,16 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.2.tgz",
+      "integrity": "sha512-1X+KN2PinUcy/aS3f3OBSKJaWk+jBikMry4Qblj5ysqN4T+8BeA1rNJdTSOlQ2iOmvKg7ZsR4tDQvl1p0PLgKg==",
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
         "iconv-lite": "^0.7.2"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2045,25 +2069,25 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
-      "integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
-      "integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.1.tgz",
+      "integrity": "sha512-3wuHoDBBtU+o0TB4uP2R+ACdNrn6SgdZBc1YUaiU9GcfXNaTNUgSM/Ft7eQ3gYWP2H1MiT6glycmfWYpmPzVKw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2075,16 +2099,16 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
-      "integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2096,17 +2120,17 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
-      "integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2118,24 +2142,24 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
-      "integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.1.tgz",
+      "integrity": "sha512-EwbBgs5e3a5MwQglQ736lx0UY/bbirddCbwe32AJMzQVSeAQK1jmwtDu8lwG9Izp+cdPhZ9NvuEt8aFmav6iLw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.1.2",
-        "@inquirer/confirm": "^6.0.10",
-        "@inquirer/editor": "^5.0.10",
-        "@inquirer/expand": "^5.0.10",
-        "@inquirer/input": "^5.0.10",
-        "@inquirer/number": "^4.0.10",
-        "@inquirer/password": "^5.0.10",
-        "@inquirer/rawlist": "^5.2.6",
-        "@inquirer/search": "^4.1.6",
-        "@inquirer/select": "^5.1.2"
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.1",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.1",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2147,16 +2171,16 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
-      "integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2168,17 +2192,17 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
-      "integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2190,18 +2214,18 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
-      "integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/figures": "^2.0.4",
-        "@inquirer/type": "^4.0.4"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2213,12 +2237,12 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
-      "integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -2323,28 +2347,28 @@
       }
     },
     "node_modules/@loaders.gl/3d-tiles": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.3.4.tgz",
-      "integrity": "sha512-JQ3y3p/KlZP7lfobwON5t7H9WinXEYTvuo3SRQM8TBKhM+koEYZhvI2GwzoXx54MbBbY+s3fm1dq5UAAmaTsZw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.2.tgz",
+      "integrity": "sha512-rf2R7x/+t41hQpaQ3iKofooE6unZ0+sGlYUXBo7lYFEnoMmalzrOI6jCs+CV96TALMPQcpfPa566XWF74XkaBQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/compression": "4.3.4",
-        "@loaders.gl/crypto": "4.3.4",
-        "@loaders.gl/draco": "4.3.4",
-        "@loaders.gl/gltf": "4.3.4",
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/math": "4.3.4",
-        "@loaders.gl/tiles": "4.3.4",
-        "@loaders.gl/zip": "4.3.4",
+        "@loaders.gl/compression": "4.4.2",
+        "@loaders.gl/crypto": "4.4.2",
+        "@loaders.gl/draco": "4.4.2",
+        "@loaders.gl/gltf": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/math": "4.4.2",
+        "@loaders.gl/tiles": "4.4.2",
+        "@loaders.gl/zip": "4.4.2",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/geospatial": "^4.1.0",
-        "@probe.gl/log": "^4.0.4",
+        "@probe.gl/log": "^4.1.1",
         "long": "^5.2.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/3d-tiles/node_modules/long": {
@@ -2354,360 +2378,374 @@
       "license": "Apache-2.0"
     },
     "node_modules/@loaders.gl/compression": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.3.4.tgz",
-      "integrity": "sha512-+o+5JqL9Sx8UCwdc2MTtjQiUHYQGJALHbYY/3CT+b9g/Emzwzez2Ggk9U9waRfdHiBCzEgRBivpWZEOAtkimXQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.2.tgz",
+      "integrity": "sha512-/LzblCXn6wOg7ca2zkUOTO0zhjjaPAOqlLp4/kwd57v7KZU8M8aKUNlU1DAuWKW9p/+TpGsLKwDqOCO+hjrOnQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@types/brotli": "^1.3.0",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "@types/pako": "^1.0.1",
         "fflate": "0.7.4",
-        "lzo-wasm": "^0.0.4",
         "pako": "1.0.11",
         "snappyjs": "^0.6.1"
       },
       "optionalDependencies": {
+        "@types/brotli": "^1.3.0",
         "brotli": "^1.3.2",
         "lz4js": "^0.2.0",
         "zstd-codec": "^0.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/core": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.4.tgz",
-      "integrity": "sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.4.2.tgz",
+      "integrity": "sha512-DZmsTwxdKh3q+mS1vSOW2EXFgwxZ4nIBte4H5g6e4VyQoQ6jAOkk0M6V+Asgy/eqjGTNjhfBA1HIkyBl0A9hcA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2"
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/crypto": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.3.4.tgz",
-      "integrity": "sha512-3VS5FgB44nLOlAB9Q82VOQnT1IltwfRa1miE0mpHCe1prYu1M/dMnEyynusbrsp+eDs3EKbxpguIS9HUsFu5dQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.2.tgz",
+      "integrity": "sha512-3QQxNFmCeznMIsY/ZD4pYO4SvS4i3nq5aJJ993DEIZVB1i0z19OmyJu4TSovvirXXrNWPQRJFPUUwdPxol9wLA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "@types/crypto-js": "^4.0.2"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/draco": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.3.4.tgz",
-      "integrity": "sha512-4Lx0rKmYENGspvcgV5XDpFD9o+NamXoazSSl9Oa3pjVVjo+HJuzCgrxTQYD/3JvRrolW/QRehZeWD/L/cEC6mw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.2.tgz",
+      "integrity": "sha512-UByWIt/yhxMFBIlyoqJYaj0rnTz/wwDWbI4CVQc/MzbLZW7NtUkDyYDcjbjE2SBWpu6Ef4ryojGd/NWIA3Yknw==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "draco3d": "1.5.7"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/geoarrow": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.2.tgz",
+      "integrity": "sha512-FGCtUsvTwdxiNqS8cEtys1FdM/m6pwMzvNEa32sHfrI4Si465Oa2iJkyu2q/XMgL/vhfE/G3EezpVKZARbCzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/polygon": "^4.1.0",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/gis": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.3.4.tgz",
-      "integrity": "sha512-8xub38lSWW7+ZXWuUcggk7agRHJUy6RdipLNKZ90eE0ZzLNGDstGD1qiBwkvqH0AkG+uz4B7Kkiptyl7w2Oa6g==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.2.tgz",
+      "integrity": "sha512-VMs1XcqUCqLczfySsI9VA/L3WDuuNRPqVoHcXU3FZuSe49x++gtwmxF1TEhJCaQINk0CkCOnxBbKOz3I9M1e3w==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
+        "@loaders.gl/geoarrow": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^4.1.0",
         "pbf": "^3.2.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.3.4.tgz",
-      "integrity": "sha512-EiUTiLGMfukLd9W98wMpKmw+hVRhQ0dJ37wdlXK98XPeGGB+zTQxCcQY+/BaMhsSpYt/OOJleHhTfwNr8RgzRg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.2.tgz",
+      "integrity": "sha512-aBvI7P/1GxePdHIvuyTM4A8yt3F5ph4dq0mkyJHmEjBl1Cwh3mDZJI1JSlZAFVilTZ6NxJZOiHUYWe1pBloVvw==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/draco": "4.3.4",
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/textures": "4.3.4",
+        "@loaders.gl/draco": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/textures": "4.4.2",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.3.4.tgz",
-      "integrity": "sha512-qgc33BaNsqN9cWa/xvcGvQ50wGDONgQQdzHCKDDKhV2w/uptZoR5iofJfuG8UUV2vUMMd82Uk9zbopRx2rS4Ag==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.4.2.tgz",
+      "integrity": "sha512-b+1keNvPlyLniWtX4ZaThz2dF2aohi8Q+OEsDF2hJNZYyZJOqP9b/72UhlVk+inxTJfTLRBNARs2TJ2ssBlelg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4"
+        "@loaders.gl/loader-utils": "4.4.2"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.4.2.tgz",
+      "integrity": "sha512-kqwBbyRC7rrQVsnJyKeoaig9hxaa5oj91OKqWm27HPuVn4q2dD67SEhiG0ND62eRp0tLY6jTqEcI5kDzHBZ6MA==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
       }
     },
     "node_modules/@loaders.gl/math": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.3.4.tgz",
-      "integrity": "sha512-UJrlHys1fp9EUO4UMnqTCqvKvUjJVCbYZ2qAKD7tdGzHJYT8w/nsP7f/ZOYFc//JlfC3nq+5ogvmdpq2pyu3TA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.2.tgz",
+      "integrity": "sha512-Pcm1DKrzH3EqC5PkBxQX0oVjmXM3RIm2Gfj0cXQoqly+8c/NBtQrcBA9tl12h2ozZe8Ednue/kockbGsyKAx5A==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/mvt": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.3.4.tgz",
-      "integrity": "sha512-9DrJX8RQf14htNtxsPIYvTso5dUce9WaJCWCIY/79KYE80Be6dhcEYMknxBS4w3+PAuImaAe66S5xo9B7Erm5A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.2.tgz",
+      "integrity": "sha512-yji3TAUofTA3GXvvyemwfrRwbd1ILpv2qe4mRduHdzjJdy2httH1cCKkesavFuLeRQqEuVyhhxYK+aSAbdt9Kg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/gis": "4.3.4",
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
+        "@loaders.gl/gis": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
         "@math.gl/polygon": "^4.1.0",
-        "@probe.gl/stats": "^4.0.0",
+        "@probe.gl/stats": "^4.1.1",
         "pbf": "^3.2.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
+      "integrity": "sha512-mJTZehTHIFl8ed+03nebuPAMnLP8Yp00DKTzCnKT2HNy/uV4+Sw+GrGIuhPHGU8tdQmtBXRURGM2ZxUAxMfGKg==",
       "license": "MIT",
       "dependencies": {
-        "@types/geojson": "^7946.0.7"
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/schema-utils": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema-utils/-/schema-utils-4.4.2.tgz",
+      "integrity": "sha512-yYYRD/POBEO72rhIyLASrqKUUhfIOQuFk/fgInN6Td2qvFgsHbo5UaCM4sTqVUWwNxNvXDQi8ezpbnCa/yi+OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/schema": "4.4.2",
+        "@types/geojson": "^7946.0.7",
+        "apache-arrow": ">= 17.0.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/terrain": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.3.4.tgz",
-      "integrity": "sha512-JszbRJGnxL5Fh82uA2U8HgjlsIpzYoCNNjy3cFsgCaxi4/dvjz3BkLlBilR7JlbX8Ka+zlb4GAbDDChiXLMJ/g==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.2.tgz",
+      "integrity": "sha512-ScE90mhUrIOOf+248+G8bxgg5xfLptE94gVxtYsLysyG8b4Ne2WEb6J2gpvQqmaLz3k9OqgPR7M8F1zI5BVO0w==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
         "@mapbox/martini": "^0.2.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/textures": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.3.4.tgz",
-      "integrity": "sha512-arWIDjlE7JaDS6v9by7juLfxPGGnjT9JjleaXx3wq/PTp+psLOpGUywHXm38BNECos3MFEQK3/GFShWI+/dWPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.2.tgz",
+      "integrity": "sha512-+GKcHEE0GjpuSJ6qbuRsB0CaOSUhJ1epUvhMP5GVK7I6+bwSvG8nqmRRGXFQNmYsbFANwG+wjwKf16wqJwP6vg==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
         "@math.gl/types": "^4.1.0",
         "ktx-parse": "^0.7.0",
         "texture-compressor": "^1.0.2"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/tiles": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.3.4.tgz",
-      "integrity": "sha512-oC0zJfyvGox6Ag9ABF8fxOkx9yEFVyzTa9ryHXl2BqLiQoR1v3p+0tIJcEbh5cnzHfoTZzUis1TEAZluPRsHBQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.2.tgz",
+      "integrity": "sha512-DHqMC38e6IEzWEDc15GfIKsZT82VZH7ocF79xLRScey0eZfCb3qI5nDLeg5adSBBsHkG3Li0S0PEnwxQmKT3qw==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/math": "4.3.4",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/math": "4.4.2",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/geospatial": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
-        "@probe.gl/stats": "^4.0.2"
+        "@probe.gl/stats": "^4.1.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/wms": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.3.4.tgz",
-      "integrity": "sha512-yXF0wuYzJUdzAJQrhLIua6DnjOiBJusaY1j8gpvuH1VYs3mzvWlIRuZKeUd9mduQZKK88H2IzHZbj2RGOauq4w==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.2.tgz",
+      "integrity": "sha512-7uhis6fOTHeqRLIU1EPoC1oqeXVk5p1pM136fSqMw0CbVSNj87b0FFMwlJwzwTfL8Vte8GyKrNcDa47PjaT19Q==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/images": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/xml": "4.3.4",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/xml": "4.4.2",
         "@turf/rewind": "^5.1.5",
         "deep-strict-equal": "^0.2.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
+      "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
       "license": "MIT",
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/xml": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.3.4.tgz",
-      "integrity": "sha512-p+y/KskajsvyM3a01BwUgjons/j/dUhniqd5y1p6keLOuwoHlY/TfTKd+XluqfyP14vFrdAHCZTnFCWLblN10w==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.2.tgz",
+      "integrity": "sha512-OOPqpYH1PK9szuzXh3Oy7aErMXTXB+aiKi79LPCI93Wsb8pdbQiDiRRW8X/op9qABhxpCAMXF5N89eDJv3XdtQ==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.4",
-        "@loaders.gl/schema": "4.3.4",
-        "fast-xml-parser": "^4.2.5"
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "fast-xml-parser": "^5.3.6"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/zip": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.3.4.tgz",
-      "integrity": "sha512-bHY4XdKYJm3vl9087GMoxnUqSURwTxPPh6DlAGOmz6X9Mp3JyWuA2gk3tQ1UIuInfjXKph3WAUfGe6XRIs1sfw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.2.tgz",
+      "integrity": "sha512-KdgmJRNra9+9jt2zzHUvFXnBqwzeN7dW4MEgTmH/NtraGy8bz5Tk5NrIUj8JXPxhx+vP2vxUWbeCEUoLGO/m9A==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/compression": "4.3.4",
-        "@loaders.gl/crypto": "4.3.4",
-        "@loaders.gl/loader-utils": "4.3.4",
+        "@loaders.gl/compression": "4.4.2",
+        "@loaders.gl/crypto": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
         "jszip": "^3.1.5",
         "md5": "^2.3.0"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
+        "@loaders.gl/core": "~4.4.0"
       }
     },
-    "node_modules/@luma.gl/constants": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.2.6.tgz",
-      "integrity": "sha512-rvFFrJuSm5JIWbDHFuR4Q2s4eudO3Ggsv0TsGKn9eqvO7bBiPm/ANugHredvh3KviEyYuMZZxtfJvBdr3kzldg==",
-      "license": "MIT"
-    },
     "node_modules/@luma.gl/core": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.2.6.tgz",
-      "integrity": "sha512-d8KcH8ZZcjDAodSN/G2nueA9YE2X8kMz7Q0OxDGpCww6to1MZXM3Ydate/Jqsb5DDKVgUF6yD6RL8P5jOki9Yw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.3.3.tgz",
+      "integrity": "sha512-jCFm2htvrVpcXIy85TBTF1ROgMfknKnfw2OH+Vydr41hiCFd6nqr79gM3f2uhaNkal0BghFNqF3qDioKiUWtew==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/types": "^4.1.0",
-        "@probe.gl/env": "^4.0.8",
-        "@probe.gl/log": "^4.0.8",
-        "@probe.gl/stats": "^4.0.8",
-        "@types/offscreencanvas": "^2019.6.4"
+        "@probe.gl/env": "^4.1.1",
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1",
+        "@types/offscreencanvas": "^2019.7.3"
       }
     },
     "node_modules/@luma.gl/engine": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.2.6.tgz",
-      "integrity": "sha512-1AEDs2AUqOWh7Wl4onOhXmQF+Rz1zNdPXF+Kxm4aWl92RQ42Sh2CmTvRt2BJku83VQ91KFIEm/v3qd3Urzf+Uw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.3.3.tgz",
+      "integrity": "sha512-StmMTzUcUlpKMU3wvWU48A6OQyphptD9zVGBsSkK6iHIBdtBKlOcmqRkyfvRouo8JHtlrnoJDHLVKhxorwhGAg==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/core": "^4.1.0",
         "@math.gl/types": "^4.1.0",
-        "@probe.gl/log": "^4.0.8",
-        "@probe.gl/stats": "^4.0.8"
+        "@probe.gl/log": "^4.1.1",
+        "@probe.gl/stats": "^4.1.1"
       },
       "peerDependencies": {
-        "@luma.gl/core": "~9.2.0",
-        "@luma.gl/shadertools": "~9.2.0"
+        "@luma.gl/core": "~9.3.0",
+        "@luma.gl/shadertools": "~9.3.0"
       }
     },
     "node_modules/@luma.gl/gltf": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.2.6.tgz",
-      "integrity": "sha512-is3YkiGsWqWTmwldMz6PRaIUleufQfUKYjJTKpsF5RS1OnN+xdAO0mJq5qJTtOQpppWAU0VrmDFEVZ6R3qvm0A==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.3.3.tgz",
+      "integrity": "sha512-/wty4PHYeQelXvDJesyuMdqtAfpL1XcyEQffcEAwKwu9w7JdkygSShdUwTT1iF7no0uGKuWgq824dVC9WBBQcw==",
       "license": "MIT",
       "dependencies": {
-        "@loaders.gl/core": "^4.2.0",
-        "@loaders.gl/gltf": "^4.2.0",
-        "@loaders.gl/textures": "^4.2.0",
+        "@loaders.gl/core": "~4.4.0",
+        "@loaders.gl/gltf": "~4.4.0",
+        "@loaders.gl/textures": "~4.4.0",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
-        "@luma.gl/constants": "~9.2.0",
-        "@luma.gl/core": "~9.2.0",
-        "@luma.gl/engine": "~9.2.0",
-        "@luma.gl/shadertools": "~9.2.0"
+        "@luma.gl/core": "~9.3.0",
+        "@luma.gl/engine": "~9.3.0",
+        "@luma.gl/shadertools": "~9.3.0"
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz",
-      "integrity": "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.3.3.tgz",
+      "integrity": "sha512-4ZfG4/Utix951vqyiG/JIx+Eg+GMNwOxgr/07/i0gf7bK1gJZIEQ5BxVcDw4MCQfdoVlGPGzl0cQKbdqBvaCAQ==",
       "license": "MIT",
       "dependencies": {
         "@math.gl/core": "^4.1.0",
-        "@math.gl/types": "^4.1.0",
-        "wgsl_reflect": "^1.2.0"
+        "@math.gl/types": "^4.1.0"
       },
       "peerDependencies": {
-        "@luma.gl/core": "~9.2.0"
+        "@luma.gl/core": "~9.3.0"
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.2.6.tgz",
-      "integrity": "sha512-NGBTdxJMk7j8Ygr1zuTyAvr1Tw+EpupMIQo7RelFjEsZXg6pujFqiDMM+rgxex8voCeuhWBJc7Rs+MoSqd46UQ==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.3.3.tgz",
+      "integrity": "sha512-X+aavdP5o6VFHSA0es9gKZTT145jfcFbhKJt/gwJrptnKNoIW4+Y37ZEpCo1AzAnr+FQCxjgcM2kOCpoWMfSVA==",
       "license": "MIT",
       "dependencies": {
-        "@luma.gl/constants": "9.2.6",
         "@math.gl/types": "^4.1.0",
-        "@probe.gl/env": "^4.0.8"
+        "@probe.gl/env": "^4.1.1"
       },
       "peerDependencies": {
-        "@luma.gl/core": "~9.2.0"
+        "@luma.gl/core": "~9.3.0"
       }
     },
     "node_modules/@mapbox/martini": {
@@ -2849,6 +2887,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
@@ -5274,52 +5324,76 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@scalar/core": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@scalar/core/-/core-0.4.4.tgz",
-      "integrity": "sha512-eXIG0opyQn45FzpTp0dAWFP1Vjcx+helgUAsa0uN36tyUR7DSmz2kRwHqqedzvPWryeRCKPz7/vwzKpETZp5lg==",
+    "node_modules/@scalar/client-side-rendering": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.12.tgz",
+      "integrity": "sha512-prwHK4ozTU268BHZ/5OstoKB23JSidDuvddAOp0bVz9c29ZxsyzzxPtPcVgF7X16LiZnS1OzY030FoDCM+iC9Q==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/types": "0.7.4"
+        "@scalar/schemas": "0.3.2",
+        "@scalar/types": "0.12.2",
+        "@scalar/validation": "0.6.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/express-api-reference": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.4.tgz",
-      "integrity": "sha512-KXG+VaMArCGcWhzDV2rfkHd+UF1HYevIFbO6cqFpd+az7QHvVT99BU8Yh60T1dmtCp504s0Pl/vcTyJ91fK1Ug==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/@scalar/express-api-reference/-/express-api-reference-0.9.19.tgz",
+      "integrity": "sha512-JJLV20D83z9uuPl/bEGgkvfsrUQllMIEBcXDliD8/uPTDCzVUwq0T0xT+FVTzLsmGVja9KLh6uUa132lAnBiYQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/core": "0.4.4"
+        "@scalar/client-side-rendering": "0.1.12"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.4.2.tgz",
-      "integrity": "sha512-IrgrGVSahCfYDNWITazz4Q1BOndp5eEzlimRkfxiYn++KqeWyLfALyym1omqcdKGYtiSx1KIbKaUJL9vkjaN7w==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.0.tgz",
+      "integrity": "sha512-gmOC6VravNB9VDl6wnt/GOj4K/hn48tj5bpW4AM4MhH8Ubil6uu7g1DSoKHwltu8Ks79KEtR6JmOrROi9R7jaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@scalar/types": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.7.4.tgz",
-      "integrity": "sha512-1o9uf42lZ9YD0XP/HMWrwXN0unx6vFTTgtduA1F28Yloea9Pfv9N2R/t0wO91iSIzw4+NubEFolunbdb2QcgHA==",
+    "node_modules/@scalar/schemas": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.3.2.tgz",
+      "integrity": "sha512-iadXBgJ02XUU5C5s6/xh/PmGLzUPd7X8upXIvPWBXDcQ4FHACNgkG8PPZ/beYM8UPDDkTUPM3ygEs0G6jKwGjQ==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.4.2",
+        "@scalar/helpers": "0.8.0",
+        "@scalar/validation": "0.6.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.12.2.tgz",
+      "integrity": "sha512-EzLkubCb7xioiTm9eYnmn/032akaq4kkrrdclgV2uezwtniR8ErQICjhMl2AjBWL6nstHiFZ9RnPZm2Z2/KM0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.8.0",
         "nanoid": "^5.1.6",
         "type-fest": "^5.3.1",
         "zod": "^4.3.5"
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/validation": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.0.tgz",
+      "integrity": "sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@simple-libs/child-process-utils": {
@@ -10820,6 +10894,7 @@
       "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.5.tgz",
       "integrity": "sha512-9xoNr+bcxT236/7ZgcWw/6Pb2RRetE13p4bFy1xYSckKwyOiRfmInay8baUWZgH7/284Wl6IPe7+nOI9+OQg/A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -10834,6 +10909,18 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
     },
     "node_modules/@types/compression": {
       "version": "1.8.1",
@@ -10983,6 +11070,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -11102,19 +11190,19 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
-      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/type-utils": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/type-utils": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11124,9 +11212,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.2",
+        "@typescript-eslint/parser": "^8.60.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -11139,15 +11227,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -11159,17 +11247,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.2",
-        "@typescript-eslint/types": "^8.57.2",
+        "@typescript-eslint/tsconfig-utils": "^8.60.0",
+        "@typescript-eslint/types": "^8.60.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -11180,17 +11268,17 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11201,9 +11289,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11213,20 +11301,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
-      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11237,13 +11325,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11254,20 +11342,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.2",
-        "@typescript-eslint/tsconfig-utils": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/project-service": "8.60.0",
+        "@typescript-eslint/tsconfig-utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11277,19 +11365,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
-      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2"
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11300,16 +11388,16 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/types": "8.60.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -11520,9 +11608,9 @@
       }
     },
     "node_modules/a5-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.5.0.tgz",
-      "integrity": "sha512-VAw19sWdYadhdovb0ViOIi1SdKx6H6LwcGMRFKwMfgL5gcmL/1fKJHfgsNgNaJ7xC/eEyjs6VK+VVd4N0a+peg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.7.3.tgz",
+      "integrity": "sha512-3aoMwHmNkyuMDHS4q6GRRInpOawamen2pokIbc0MQmR9cqG0Y9+B0bZpzswwetjrSG2ckbYtShH+nKru6+3O5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "gl-matrix": "^3.4.3"
@@ -11654,6 +11742,41 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/arc": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/arc/-/arc-0.2.0.tgz",
@@ -11676,6 +11799,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/array-ify": {
@@ -11782,9 +11914,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -11792,7 +11924,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bidi-js": {
@@ -12047,6 +12179,52 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -12258,7 +12436,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -12271,7 +12448,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -12298,6 +12474,44 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/commander": {
@@ -12810,9 +13024,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -13421,18 +13635,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.5.tgz",
-      "integrity": "sha512-cK9c5I/DwIOI7/Q7AlGN3DuTdwN61gwSfL8rvuVPK+0mcCNHHGxRrpiFtaZZRfRMJL3Gl8B2AFlBG6qXf03w9A==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -13441,7 +13655,27 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -13510,6 +13744,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -13540,6 +13791,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -13871,9 +14128,9 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
-      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -13906,7 +14163,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14177,15 +14433,15 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.3.2.tgz",
-      "integrity": "sha512-bh/OjBGxNR9qvfQj1n5bxtIF58mbOTp2InN5dKuwUK03dXcDGFsjlDinQRuXMZ4EGiJaFieUWHCAaxH2p7iUBw==",
+      "version": "13.4.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.4.3.tgz",
+      "integrity": "sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.4",
-        "@inquirer/core": "^11.1.7",
-        "@inquirer/prompts": "^8.3.2",
-        "@inquirer/type": "^4.0.4",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.10",
+        "@inquirer/prompts": "^8.4.3",
+        "@inquirer/type": "^4.0.5",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6",
         "rxjs": "^7.8.2"
@@ -14500,6 +14756,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-buffer": {
@@ -14948,7 +15212,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -15084,12 +15347,6 @@
       "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/lzo-wasm": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/lzo-wasm/-/lzo-wasm-0.0.4.tgz",
-      "integrity": "sha512-VKlnoJRFrB8SdJhlVKvW5vI1gGwcZ+mvChEXcSX6r2xDNc/Q2FD9esfBmGCuPZdrJ1feO+YcVFd2PTk0c137Gw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -15375,9 +15632,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
-      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
       "funding": [
         {
           "type": "github",
@@ -15645,6 +15902,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -16094,9 +16366,9 @@
       "license": "MIT"
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -17511,9 +17783,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -17562,7 +17834,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -17608,6 +17879,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tagged-tag": {
@@ -17938,9 +18222,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -17981,15 +18265,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
-      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
+      "integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.2",
-        "@typescript-eslint/parser": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2"
+        "@typescript-eslint/eslint-plugin": "8.60.0",
+        "@typescript-eslint/parser": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -18000,7 +18284,16 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/undici": {
@@ -18017,6 +18310,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -18283,12 +18577,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/wgsl_reflect": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.3.tgz",
-      "integrity": "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q==",
-      "license": "MIT"
-    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -18355,6 +18643,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/wrap-ansi": {
@@ -18435,6 +18732,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {


### PR DESCRIPTION
Bumps the dependencies behind the currently-open dependabot PRs to their latest in-range versions, so those PRs become redundant and can be auto-closed.

## Bumps
| Package | From | To |
|---|---|---|
| `@deck.gl/*` | 9.2.11 | 9.3.2 (geo-layers unpinned) |
| `@luma.gl/*` | 9.2.6 | 9.3.3 |
| `graphql` | 16.13.1 | 16.14.0 |
| `better-sqlite3` | 12.8.0 | 12.10.0 |
| `dotenv` | 17.3.1 | 17.4.2 |
| `inquirer` | 13.3.2 | 13.4.3 |
| `@scalar/express-api-reference` | 0.9.4 | 0.9.19 |
| `typescript-eslint` | 8.57.2 | 8.60.0 |
| `googleapis/release-please-action` | v4 | v5 |

Most were already caret ranges (only the lockfile lagged); `@deck.gl/geo-layers` was pinned exact and is now aligned with its siblings.

Supersedes dependabot PRs: #137, #133, #129, #127, #126, #125, #124, #123, #122, #121, #117, #115, #112.

## Verification
- `npm run type-check` clean across all 5 packages
- Test suites pass: simulator 1461 · adapter 438 · ui 596 · network 14
- UI production build (`vite build`) succeeds on deck.gl/luma.gl 9.3.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)