### PR TITLE
fix(docker): redpanda sink emits per-vehicle (no fanOut) for simulations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,12 @@ services:
       SINK_TYPES: redpanda,console
       SINK_CONSOLE_CONFIG: '{"verbose":false}'
       # Publishes the engine's pure-GPS schema to its input topic on the shared
-      # broker. fanOut emits one message per device in metadata.devices[], all at
-      # the vehicle's shared position, keyed by the real deviceId (device.id).
-      SINK_REDPANDA_CONFIG: '{"brokers":"suite_redpanda:9092","topic":"trajectory.telemetry.raw","keyField":"device.id","defaultAltitude":1650,"defaultAccuracy":5,"fanOut":"metadata.devices","payloadTemplate":{"ts":"ts","deviceId":"device.id","deviceType":"device.deviceType","lat":"lat","lon":"lon","speed":"speed","heading":"heading","altitude":"altitude","accuracy":"accuracy","ignition":"ignition"}}'
+      # broker. One message per simulated vehicle, keyed by the vehicle id (used
+      # as deviceId). NOTE: no fanOut — generated/recorded simulations have no
+      # metadata.devices, so each vehicle IS the device. For the REAL multi-device
+      # fleet, switch to: "keyField":"device.id","fanOut":"metadata.devices" and a
+      # payloadTemplate sourcing deviceId/deviceType from device.*.
+      SINK_REDPANDA_CONFIG: '{"brokers":"suite_redpanda:9092","topic":"trajectory.telemetry.raw","keyField":"id","defaultAltitude":1650,"defaultAccuracy":5,"payloadTemplate":{"ts":"ts","deviceId":"id","lat":"lat","lon":"lon","speed":"speed","heading":"heading","altitude":"altitude","accuracy":"accuracy","ignition":"ignition"}}'
       # Telemetry realism (off by default): correlated GPS noise + connectivity
       # dropouts (store-and-forward) + jittered cadence, applied to all sinks.
       # REALISM_CONFIG: '{"enabled":true,"reportingPeriodMs":5000,"jitterMs":800}'


### PR DESCRIPTION
## Problem
Emitting a recorded/generated simulation to the redpanda sink produced **zero messages** on `trajectory.telemetry.raw`, even though the emit job reported `done`.

The sink was configured for the real multi-device fleet — `fanOut: "metadata.devices"`, keyed by `device.id`. Generated/recorded simulations carry no `metadata.devices`, so the fan-out resolved to an empty array and `buildTemplateMessages` returned `[]` (no messages). `emitted` counts updates processed, not messages published, hence "done but nothing on the topic."

## Fix
Drop `fanOut` and source `keyField`/`deviceId` from the vehicle `id`, so each simulated vehicle emits exactly one GPS message. Same topic and payload schema otherwise.

```diff
- "keyField":"device.id", ... "fanOut":"metadata.devices",
-   "payloadTemplate":{ "deviceId":"device.id","deviceType":"device.deviceType", ... }
+ "keyField":"id", ...
+   "payloadTemplate":{ "deviceId":"id", ... }
```

The real-fleet (multi-device) config is documented inline for switch-back.

> Note: this changes the **live** real-fleet path too — it would now emit one message per vehicle instead of per device. Only relevant if you also run the live `rest`-source → redpanda flow; for emitting simulations it's correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)