### PR TITLE
feat(adapter): canonical-AVRO Redpanda sink for trajectory.telemetry.raw

### DIFF
--- a/apps/adapter/package.json
+++ b/apps/adapter/package.json
@@ -24,6 +24,7 @@
     "directory": "apps/adapter"
   },
   "dependencies": {
+    "@kafkajs/confluent-schema-registry": "^4.0.8",
     "@moveet/shared-types": "*",
     "compression": "^1.8.1",
     "cors": "^2.8.6",

--- a/apps/adapter/src/plugins/sinks/redpanda.test.ts
+++ b/apps/adapter/src/plugins/sinks/redpanda.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TELEMETRY_LOCATION_AVRO_SUBJECT } from "@moveet/shared-types";
 import { RedpandaSink } from "./redpanda";
 
 // Mock kafkajs so we can intercept producer.send() and admin calls
@@ -32,6 +33,29 @@ vi.mock("kafkajs", () => {
     }
   }
   return { Kafka: MockKafka };
+});
+
+// Mock the Confluent Schema Registry. register() yields a fixed schema id and
+// encode() captures the envelope, returning a sentinel Buffer so the sink's
+// Buffer-valued message path can be asserted without a live registry.
+const mockRegister = vi.fn().mockResolvedValue({ id: 7 });
+const mockEncode = vi.fn(async (_id: number, payload: unknown) =>
+  Buffer.from(JSON.stringify(payload))
+);
+let lastRegistryHost: string | undefined;
+
+vi.mock("@kafkajs/confluent-schema-registry", () => {
+  class MockSchemaRegistry {
+    constructor(args: { host: string }) {
+      lastRegistryHost = args.host;
+    }
+    register = mockRegister;
+    encode = mockEncode;
+  }
+  return {
+    SchemaRegistry: MockSchemaRegistry,
+    SchemaType: { AVRO: "AVRO", JSON: "JSON", PROTOBUF: "PROTOBUF", UNKNOWN: "UNKNOWN" },
+  };
 });
 
 describe("RedpandaSink", () => {
@@ -594,6 +618,160 @@ describe("RedpandaSink", () => {
       expect(payload.ts).toBeLessThanOrEqual(after);
       // Absent connected → ignition derived from speed (36 km/h → 10 m/s > 0.5).
       expect(payload.ignition).toBe(true);
+    });
+  });
+
+  describe("canonical-avro format", () => {
+    it("registers the canonical schema under the platform subject on connect", async () => {
+      await sink.connect({
+        brokers: "localhost:9092",
+        format: "canonical-avro",
+        schemaRegistryUrl: "http://registry:8081",
+      });
+
+      expect(lastRegistryHost).toBe("http://registry:8081");
+      expect(mockRegister).toHaveBeenCalledTimes(1);
+      const [schema, opts] = mockRegister.mock.calls[0];
+      expect(schema.type).toBe("AVRO");
+      // schema is the canonical AVRO JSON string with the expected top-level name.
+      expect(typeof schema.schema).toBe("string");
+      const parsed = JSON.parse(schema.schema);
+      expect(parsed.name).toBe("TelemetryLocationEvent");
+      expect(parsed.namespace).toBe("telemetry.ingest");
+      expect(opts).toEqual({ subject: TELEMETRY_LOCATION_AVRO_SUBJECT });
+    });
+
+    it("defaults schemaRegistryUrl to localhost:18081", async () => {
+      await sink.connect({ brokers: "localhost:9092", format: "canonical-avro" });
+      expect(lastRegistryHost).toBe("http://localhost:18081");
+    });
+
+    it("encodes the canonical envelope and emits a Buffer-valued message", async () => {
+      await sink.connect({
+        brokers: "localhost:9092",
+        format: "canonical-avro",
+        keyField: "device.id",
+        fanOut: "metadata.devices",
+        sourceService: "moveet-simulator",
+        sourceEnvironment: "dev",
+      });
+      const fixTs = 1_700_000_000_000;
+      await sink.publishUpdates([
+        {
+          id: "v1",
+          latitude: -1.2863,
+          longitude: 36.8172,
+          speed: 36, // km/h → 10 m/s
+          heading: 90,
+          accuracy: 12.5,
+          timestamp: fixTs,
+          metadata: { devices: [{ id: "d1", deviceType: "gps" }] },
+        },
+      ]);
+
+      // encode() called with the cached schema id (7 from the mock).
+      expect(mockEncode).toHaveBeenCalledTimes(1);
+      expect(mockEncode.mock.calls[0][0]).toBe(7);
+      const envelope = mockEncode.mock.calls[0][1] as Record<string, any>;
+
+      // Envelope (top-level) shape.
+      expect(envelope.event_type).toBe("telemetry.location.reported");
+      expect(envelope.event_version).toBe(1);
+      expect(typeof envelope.event_id).toBe("string");
+      expect(typeof envelope.occurred_at).toBe("string");
+      expect(envelope.source).toEqual({ service: "moveet-simulator", environment: "dev" });
+      expect(envelope.metadata).toEqual({
+        correlation_id: null,
+        causation_id: null,
+        trace_id: null,
+      });
+
+      // data payload (telemetry mapping).
+      expect(envelope.data).toMatchObject({
+        // device_id is context.id (the vehicle id); the Kafka key is device.id.
+        device_id: "v1",
+        source: "GPS",
+        latitude: -1.2863,
+        longitude: 36.8172,
+        accuracy_meters: 12.5,
+        speed_mps: 10,
+        heading_degrees: 90,
+        ignition_on: true,
+        moving: true,
+        satellites: null,
+        battery_level: null,
+        battery_charging: null,
+        network: null,
+        position_origin: null,
+        sensor_readings: {},
+      });
+      expect(envelope.data.recorded_at).toBe(new Date(fixTs).toISOString());
+
+      // Message: key resolved via keyField (device.id), value is the Buffer.
+      const message = mockSend.mock.calls[0][0].messages[0];
+      expect(message.key).toBe("d1");
+      expect(Buffer.isBuffer(message.value)).toBe(true);
+    });
+
+    it("maps mobile devices to source=MOBILE", async () => {
+      await sink.connect({
+        brokers: "localhost:9092",
+        format: "canonical-avro",
+        keyField: "device.id",
+        fanOut: "metadata.devices",
+      });
+      await sink.publishUpdates([
+        {
+          id: "v1",
+          latitude: 0,
+          longitude: 0,
+          metadata: { devices: [{ id: "d2", deviceType: "mobile" }] },
+        },
+      ]);
+
+      const envelope = mockEncode.mock.calls[0][1] as Record<string, any>;
+      expect(envelope.data.source).toBe("MOBILE");
+    });
+
+    it("fans out one encoded message per device, keyed by device.id", async () => {
+      await sink.connect({
+        brokers: "localhost:9092",
+        format: "canonical-avro",
+        keyField: "device.id",
+        fanOut: "metadata.devices",
+      });
+      await sink.publishUpdates([
+        {
+          id: "v1",
+          latitude: -1.28,
+          longitude: 36.8,
+          metadata: {
+            devices: [
+              { id: "d1", deviceType: "gps" },
+              { id: "d2", deviceType: "mobile" },
+            ],
+          },
+        },
+      ]);
+
+      const messages = mockSend.mock.calls[0][0].messages;
+      expect(messages).toHaveLength(2);
+      expect(messages.map((m: { key: string }) => m.key)).toEqual(["d1", "d2"]);
+      expect(messages.every((m: { value: unknown }) => Buffer.isBuffer(m.value))).toBe(true);
+      expect(mockEncode).toHaveBeenCalledTimes(2);
+    });
+
+    it("emits nothing for an update with no devices when fanOut is set", async () => {
+      await sink.connect({
+        brokers: "localhost:9092",
+        format: "canonical-avro",
+        keyField: "device.id",
+        fanOut: "metadata.devices",
+      });
+      await sink.publishUpdates([{ id: "v1", latitude: 0, longitude: 0 }]);
+
+      expect(mockSend.mock.calls[0][0].messages).toHaveLength(0);
+      expect(mockEncode).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/adapter/src/plugins/sinks/redpanda.ts
+++ b/apps/adapter/src/plugins/sinks/redpanda.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from "node:crypto";
-import type { Admin, Producer } from "kafkajs";
+import type { Admin, Message, Producer } from "kafkajs";
 import { Kafka } from "kafkajs";
+import { SchemaRegistry, SchemaType } from "@kafkajs/confluent-schema-registry";
+import {
+  TELEMETRY_LOCATION_AVRO_SCHEMA,
+  TELEMETRY_LOCATION_AVRO_SUBJECT,
+  TELEMETRY_LOCATION_EVENT_TYPE,
+} from "@moveet/shared-types";
 import type {
   ConfigField,
   DataSink,
@@ -148,7 +154,30 @@ export class RedpandaSink implements DataSink {
       options: [
         { label: "Dispatch (vehicle.position event)", value: "dispatch" },
         { label: "Trajectory-engine telemetry", value: "trajectory" },
+        { label: "Canonical telemetry (Confluent-AVRO)", value: "canonical-avro" },
       ],
+    },
+    {
+      name: "schemaRegistryUrl",
+      label: "Schema Registry URL",
+      type: "string",
+      default: "http://localhost:18081",
+      placeholder: "http://localhost:18081",
+      description: "Confluent Schema Registry endpoint, used by the canonical-avro format.",
+    },
+    {
+      name: "sourceService",
+      label: "Source Service",
+      type: "string",
+      default: "moveet-simulator",
+      description: "Populates source.service in the canonical envelope.",
+    },
+    {
+      name: "sourceEnvironment",
+      label: "Source Environment",
+      type: "string",
+      default: "dev",
+      description: "Populates source.environment in the canonical envelope.",
     },
     {
       name: "keyField",
@@ -192,8 +221,14 @@ export class RedpandaSink implements DataSink {
   private topic = "dispatch.vehicle.positions";
   private batchSize = 500;
   private acks: number = 1;
-  private format: "dispatch" | "trajectory" = "dispatch";
+  private format: "dispatch" | "trajectory" | "canonical-avro" = "dispatch";
   private keyField = "id";
+  // Canonical-AVRO format state (populated in connect() only for that format).
+  private schemaRegistryUrl = "http://localhost:18081";
+  private sourceService = "moveet-simulator";
+  private sourceEnvironment = "dev";
+  private registry: SchemaRegistry | null = null;
+  private schemaId: number | null = null;
   private payloadTemplate: PayloadTemplate | null = null;
   // Optional dot-path to an array in the context. When set, each update fans
   // out to one message per array element. null = disabled.
@@ -217,12 +252,22 @@ export class RedpandaSink implements DataSink {
     this.acks = acks;
 
     const format = (config.format as string) || "dispatch";
-    if (format !== "dispatch" && format !== "trajectory") {
+    if (format !== "dispatch" && format !== "trajectory" && format !== "canonical-avro") {
       throw new Error(
-        `RedpandaSink: invalid format "${format}" (must be "dispatch" or "trajectory")`
+        `RedpandaSink: invalid format "${format}" (must be "dispatch", "trajectory", or "canonical-avro")`
       );
     }
     this.format = format;
+
+    if (format === "canonical-avro") {
+      const url = (config.schemaRegistryUrl as string) || "http://localhost:18081";
+      if (typeof url !== "string" || url.trim() === "") {
+        throw new Error("RedpandaSink: schemaRegistryUrl must be a non-empty string");
+      }
+      this.schemaRegistryUrl = url;
+      this.sourceService = (config.sourceService as string) || "moveet-simulator";
+      this.sourceEnvironment = (config.sourceEnvironment as string) || "dev";
+    }
 
     const keyField = (config.keyField as string) || "id";
     if (typeof keyField !== "string" || keyField.trim() === "") {
@@ -253,6 +298,20 @@ export class RedpandaSink implements DataSink {
     this.producer = this.kafka.producer({ allowAutoTopicCreation: false });
     try {
       await this.producer.connect();
+      // For the canonical-AVRO format, register (idempotent) the canonical
+      // schema with Schema Registry and cache the returned schema id, which
+      // every encode() prefixes onto the wire payload (Confluent framing).
+      if (this.format === "canonical-avro") {
+        this.registry = new SchemaRegistry({ host: this.schemaRegistryUrl });
+        const registered = await this.registry.register(
+          {
+            type: SchemaType.AVRO,
+            schema: JSON.stringify(TELEMETRY_LOCATION_AVRO_SCHEMA),
+          },
+          { subject: TELEMETRY_LOCATION_AVRO_SUBJECT }
+        );
+        this.schemaId = registered.id;
+      }
     } catch (err) {
       // Tear down the half-connected producer so its internal connection/retry
       // machinery doesn't leak — connect() failing means the plugin is never
@@ -260,6 +319,8 @@ export class RedpandaSink implements DataSink {
       await this.producer.disconnect().catch(() => {});
       this.producer = null;
       this.kafka = null;
+      this.registry = null;
+      this.schemaId = null;
       throw err;
     }
   }
@@ -270,6 +331,8 @@ export class RedpandaSink implements DataSink {
       this.producer = null;
     }
     this.kafka = null;
+    this.registry = null;
+    this.schemaId = null;
   }
 
   /**
@@ -404,13 +467,94 @@ export class RedpandaSink implements DataSink {
   }
 
   /**
+   * Map a per-message {@link MessageContext} onto the canonical telemetry
+   * envelope. Fields the simulator can't supply (satellites, battery, network,
+   * position_origin) are left null per the schema's union defaults.
+   * `data.source` is GPS unless the device/update metadata marks it `mobile`.
+   */
+  private buildCanonicalEnvelope(context: MessageContext): Record<string, unknown> {
+    const deviceType =
+      (context.metadata?.deviceType as string | undefined) ??
+      (context.device != null && typeof context.device === "object"
+        ? ((context.device as Record<string, unknown>).deviceType as string | undefined)
+        : undefined);
+    const telemetrySource = deviceType === "mobile" ? "MOBILE" : "GPS";
+
+    return {
+      event_id: randomUUID(),
+      event_type: TELEMETRY_LOCATION_EVENT_TYPE,
+      event_version: 1,
+      occurred_at: new Date().toISOString(),
+      source: { service: this.sourceService, environment: this.sourceEnvironment },
+      metadata: { correlation_id: null, causation_id: null, trace_id: null },
+      data: {
+        device_id: String(context.id),
+        source: telemetrySource,
+        recorded_at: new Date(context.ts).toISOString(),
+        latitude: context.lat,
+        longitude: context.lon,
+        accuracy_meters: context.accuracy,
+        speed_mps: context.speed,
+        heading_degrees: context.heading,
+        altitude_meters: context.altitude,
+        satellites: null,
+        ignition_on: context.ignition,
+        moving: context.speed > 0.5,
+        battery_level: null,
+        battery_charging: null,
+        network: null,
+        position_origin: null,
+        sensor_readings: {},
+      },
+    };
+  }
+
+  /**
+   * Confluent-AVRO-encode one context into a Kafka message. The Kafka key is
+   * resolved via the same `keyField` dot-path as the JSON formats; the value is
+   * the registry-encoded Buffer (5-byte Confluent header + Avro body).
+   */
+  private async buildCanonicalAvroMessage(context: MessageContext): Promise<Message> {
+    if (!this.registry || this.schemaId == null) {
+      throw new Error("RedpandaSink: schema registry not initialized for canonical-avro format");
+    }
+    const keyValue = resolvePath(context, this.keyField);
+    const value = await this.registry.encode(this.schemaId, this.buildCanonicalEnvelope(context));
+    return {
+      key: keyValue === undefined || keyValue === null ? undefined : String(keyValue),
+      value,
+    };
+  }
+
+  /**
+   * Build canonical-AVRO messages for a batch, honouring `fanOut` and
+   * `keyField` exactly like the JSON template path. Each emitted message's
+   * value is a registry-encoded Buffer.
+   */
+  private async buildCanonicalAvroMessages(updates: VehicleUpdate[]): Promise<Message[]> {
+    const ts = Date.now();
+    const contexts: MessageContext[] = updates.flatMap((update) => {
+      const context = this.buildContext(update, ts);
+      if (!this.fanOut) return [context];
+
+      const array = resolvePath(context, this.fanOut);
+      if (!Array.isArray(array) || array.length === 0) return [];
+      return array.map((device) => ({ ...context, device }));
+    });
+    return Promise.all(contexts.map((context) => this.buildCanonicalAvroMessage(context)));
+  }
+
+  /**
    * Build the Kafka messages for a batch of updates. An explicit
    * `payloadTemplate` (or the `trajectory` preset, expressed as a template)
    * drives {@link buildTemplateMessages} (which honours `fanOut`); otherwise
    * the `dispatch` preset's dedicated code path is used (one message per
    * update, no fan-out).
    */
-  private buildMessages(updates: VehicleUpdate[]) {
+  private async buildMessages(updates: VehicleUpdate[]): Promise<Message[]> {
+    if (this.format === "canonical-avro") {
+      return this.buildCanonicalAvroMessages(updates);
+    }
     const template = this.resolveActiveTemplate();
     return template
       ? this.buildTemplateMessages(updates, template)
@@ -420,7 +564,7 @@ export class RedpandaSink implements DataSink {
   async publishUpdates(updates: VehicleUpdate[]): Promise<SinkPublishResult | void> {
     if (!this.producer) return;
 
-    const messages = this.buildMessages(updates);
+    const messages = await this.buildMessages(updates);
 
     if (messages.length <= this.batchSize) {
       await this.producer.send({ topic: this.topic, messages, acks: this.acks });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,10 +38,13 @@ services:
       SOURCE_CONFIG: '{"url":"http://suite_connector:3002/api/fleet/roster","vehiclePath":"assignments","groupBy":"vehicleId","fieldMap":{"id":"deviceId"},"metadataMap":{"deviceType":"deviceType"},"limit":100}'
       SINK_TYPES: redpanda,console
       SINK_CONSOLE_CONFIG: '{"verbose":false}'
-      # Publishes the engine's pure-GPS schema to its input topic on the shared
-      # broker. fanOut emits one message per device in metadata.devices[], all at
-      # the vehicle's shared position, keyed by the real deviceId (device.id).
-      SINK_REDPANDA_CONFIG: '{"brokers":"suite_redpanda:9092","topic":"trajectory.telemetry.raw","keyField":"device.id","defaultAltitude":1650,"defaultAccuracy":5,"fanOut":"metadata.devices","payloadTemplate":{"ts":"ts","deviceId":"device.id","deviceType":"device.deviceType","lat":"lat","lon":"lon","speed":"speed","heading":"heading","altitude":"altitude","accuracy":"accuracy","ignition":"ignition"}}'
+      # Publishes the platform's canonical telemetry envelope (Confluent-AVRO,
+      # registered in the suite Schema Registry) to its input topic on the
+      # shared broker. fanOut emits one message per device in metadata.devices[],
+      # all at the vehicle's shared position, keyed by the real deviceId
+      # (device.id). The suite registry is reachable at http://suite_redpanda:8081
+      # inside suite_network.
+      SINK_REDPANDA_CONFIG: '{"brokers":"suite_redpanda:9092","topic":"trajectory.telemetry.raw","format":"canonical-avro","schemaRegistryUrl":"http://suite_redpanda:8081","keyField":"device.id","fanOut":"metadata.devices","sourceService":"moveet-simulator","sourceEnvironment":"dev"}'
       # Telemetry realism (off by default): correlated GPS noise + connectivity
       # dropouts (store-and-forward) + jittered cadence, applied to all sinks.
       # REALISM_CONFIG: '{"enabled":true,"reportingPeriodMs":5000,"jitterMs":800}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
+        "@kafkajs/confluent-schema-registry": "^4.0.8",
         "@moveet/shared-types": "*",
         "compression": "^1.8.1",
         "cors": "^2.8.6",
@@ -2262,6 +2263,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kafkajs/confluent-schema-registry": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-4.1.0.tgz",
+      "integrity": "sha512-0/OM85fT66zsi+eBE56FnmdI2qAKBkhiXIYKnB4q1jB0AvUucRBvyqmld0l05q0r2FIODa0NG9612dLblxxI5Q==",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "avsc": ">= 5.4.13 < 6",
+        "mappersmith": ">= 2.44.0 < 3",
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/@loaders.gl/3d-tiles": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.2.tgz",
@@ -2868,6 +2883,69 @@
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.1.tgz",
       "integrity": "sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==",
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -11546,7 +11624,6 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -12141,7 +12218,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -12173,7 +12249,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-escapes": {
@@ -12348,6 +12423,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avsc": {
+      "version": "5.7.9",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.9.tgz",
+      "integrity": "sha512-yOA4wFeI7ET3v32Di/sUybQ+ttP20JHSW3mxLuNGeO0uD6PPcvLrIQXSvy/rhJOWU5JrYh7U4OHplWMmtAtjMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.11"
       }
     },
     "node_modules/aws-ssl-profiles": {
@@ -14121,7 +14205,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15877,6 +15960,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mappersmith": {
+      "version": "2.47.1",
+      "resolved": "https://registry.npmjs.org/mappersmith/-/mappersmith-2.47.1.tgz",
+      "integrity": "sha512-OVSkU/ANvclScrTZh7x9SwmK4iZ9fo0AO0a5Nr+Xx4PZ/Kj/B1BixqNLhaKSBBXMyPbOrbjdoasX5SfbGTcsOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "diff": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "tty-table": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "diff": {
+          "optional": true
+        },
+        "tty-table": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -16848,6 +16949,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
@@ -17252,7 +17383,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18438,7 +18568,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -2,6 +2,13 @@
 // Types used by 2 or more apps in the monorepo.
 // App-specific types remain in their own type files.
 
+// Canonical telemetry-ingest AVRO schema + subject (Confluent Schema Registry).
+export {
+  TELEMETRY_LOCATION_AVRO_SCHEMA,
+  TELEMETRY_LOCATION_AVRO_SUBJECT,
+  TELEMETRY_LOCATION_EVENT_TYPE,
+} from "./telemetry-avro.ts";
+
 // ─── Primitives ─────────────────────────────────────────────────────
 
 /**

--- a/packages/shared-types/src/telemetry-avro.ts
+++ b/packages/shared-types/src/telemetry-avro.ts
@@ -1,0 +1,81 @@
+// ─── Canonical Telemetry AVRO Schema ────────────────────────────────
+//
+// The platform's canonical telemetry-ingest envelope, published Confluent-AVRO
+// encoded to `trajectory.telemetry.raw`. Field order and types MUST match the
+// platform's registered schema exactly — do not reorder or retype fields.
+
+/**
+ * Confluent-AVRO schema for the canonical `telemetry.location.reported` event.
+ * Registered under subject `trajectory.telemetry.raw-telemetry.location.reported`.
+ */
+export const TELEMETRY_LOCATION_AVRO_SCHEMA = {
+  type: "record",
+  name: "TelemetryLocationEvent",
+  namespace: "telemetry.ingest",
+  fields: [
+    { name: "event_id", type: "string" },
+    { name: "event_type", type: "string" },
+    { name: "event_version", type: "int" },
+    { name: "occurred_at", type: "string" },
+    {
+      name: "source",
+      type: {
+        type: "record",
+        name: "EventSource",
+        fields: [
+          { name: "service", type: "string" },
+          { name: "environment", type: "string" },
+        ],
+      },
+    },
+    {
+      name: "metadata",
+      type: {
+        type: "record",
+        name: "EventMetadata",
+        fields: [
+          { name: "correlation_id", type: ["null", "string"], default: null },
+          { name: "causation_id", type: ["null", "string"], default: null },
+          { name: "trace_id", type: ["null", "string"], default: null },
+        ],
+      },
+    },
+    {
+      name: "data",
+      type: {
+        type: "record",
+        name: "TelemetryLocationData",
+        fields: [
+          { name: "device_id", type: "string" },
+          { name: "source", type: { type: "enum", name: "TelemetrySource", symbols: ["GPS", "MOBILE"] } },
+          { name: "recorded_at", type: "string" },
+          { name: "latitude", type: "double" },
+          { name: "longitude", type: "double" },
+          { name: "accuracy_meters", type: ["null", "double"], default: null },
+          { name: "speed_mps", type: ["null", "double"], default: null },
+          { name: "heading_degrees", type: ["null", "double"], default: null },
+          { name: "altitude_meters", type: ["null", "double"], default: null },
+          { name: "satellites", type: ["null", "int"], default: null },
+          { name: "ignition_on", type: ["null", "boolean"], default: null },
+          { name: "moving", type: ["null", "boolean"], default: null },
+          { name: "battery_level", type: ["null", "double"], default: null },
+          { name: "battery_charging", type: ["null", "boolean"], default: null },
+          { name: "network", type: ["null", "string"], default: null },
+          {
+            name: "position_origin",
+            type: ["null", { type: "enum", name: "PositionOrigin", symbols: ["GPS", "NETWORK", "PASSIVE", "UNKNOWN"] }],
+            default: null,
+          },
+          { name: "sensor_readings", type: { type: "map", values: "string" }, default: {} },
+        ],
+      },
+    },
+  ],
+} as const;
+
+/** Subject under which the canonical schema is registered in Schema Registry. */
+export const TELEMETRY_LOCATION_AVRO_SUBJECT =
+  "trajectory.telemetry.raw-telemetry.location.reported";
+
+/** Canonical `event_type` for telemetry location reports. */
+export const TELEMETRY_LOCATION_EVENT_TYPE = "telemetry.location.reported";


### PR DESCRIPTION
Adds a `canonical-avro` output format to the adapter's Redpanda sink so moveet publishes the platform's canonical telemetry event (Confluent-AVRO) to `trajectory.telemetry.raw`, replacing the old plain-JSON shape.

## What
- New `packages/shared-types/src/telemetry-avro.ts`: `TELEMETRY_LOCATION_AVRO_SCHEMA` (envelope + `TelemetryLocationData`), subject `trajectory.telemetry.raw-telemetry.location.reported`.
- `apps/adapter` Redpanda sink: `format: "canonical-avro"` — registers the schema via Confluent Schema Registry on connect, encodes the envelope per message (`registry.encode`), supports `fanOut` + `keyField`. Existing JSON formats untouched.
- `VehicleUpdate → TelemetryLocationData` mapping (speed km/h→m/s, ts→ISO `recorded_at`, deviceType→`source` GPS/MOBILE, ignition/moving derived).
- `docker-compose.yml`: adapter switched to `canonical-avro` against `suite_redpanda` + `http://suite_redpanda:8081`.

## Verified
End-to-end in the suite: adapter → 2550 AVRO msgs to `trajectory.telemetry.raw` → trajectory cleaner (AVRO) → `trajectory.telemetry.clean` → ingestor (lag 0) → TimescaleDB rows. 535 adapter tests pass.

Note: the new shared-types re-export uses a `.ts` extension (Node 24 runs workspace packages as raw TS via native type-stripping, which requires explicit extensions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)