### PR TITLE
fix(ci): build release images from workspace-aware root Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
       matrix:
         include:
           - image: moveet-simulator
-            context: apps/simulator
+            target: simulator
           - image: moveet-adapter
-            context: apps/adapter
+            target: adapter
           - image: moveet-ui
-            context: apps/ui
+            target: ui
 
     steps:
       - uses: actions/checkout@v6
@@ -66,7 +66,12 @@ jobs:
 
       - uses: docker/build-push-action@v7
         with:
-          context: ${{ matrix.context }}
+          # Build from the repo root with the workspace-aware Dockerfile so the
+          # unpublished @moveet/* workspace packages resolve via npm ci. The
+          # per-app Dockerfiles install in isolation and 404 on those packages.
+          context: .
+          file: Dockerfile
+          target: ${{ matrix.target }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Problem

The `docker-publish` job in the Release workflow [failed](https://github.com/ivannovazzi/moveet/actions/runs/28060897839) on the 0.0.8 release:

```
npm error 404 Not Found - GET https://registry.npmjs.org/@moveet%2feslint-config - Not found
ERROR: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
```

Each image was built from its own app context (`apps/simulator`, `apps/adapter`, `apps/ui`) using the **per-app Dockerfiles**, which run `npm install` in isolation. Those installs 404 on the unpublished workspace packages (`@moveet/eslint-config`, `@moveet/shared-types`, referenced as `"*"`).

The repo already has a **workspace-aware root `Dockerfile`** (with `simulator`/`adapter`/`ui` targets) written specifically to solve this — it copies the full workspace and runs `npm ci`. The root `docker-compose.yml` already uses it; CI just wasn't.

## Fix

Point the build matrix at the root Dockerfile's per-app targets with context `.`:

- `context: ${{ matrix.context }}` (`apps/*`) → `context: .` + `file: Dockerfile` + `target: ${{ matrix.target }}`

## Verification

Built the `adapter` target locally — `npm ci` resolves the workspace packages and the image builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)