### PR TITLE
fix(ui): snap vehicles after idle/reposition instead of gliding

### DIFF
--- a/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
+++ b/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { IconLayer, ScatterplotLayer } from "@deck.gl/layers";
 import type { Fleet, VehicleType } from "@/types";
 import { vehicleStore } from "../../hooks/vehicleStore";
-import { VEHICLE_INTERPOLATION } from "../../data/constants";
+import { VEHICLE_INTERPOLATION, shouldSnapPosition } from "../../data/constants";
 import { useRegisterLayers } from "../../components/Map/hooks/useDeckLayers";
 import { useMapContext } from "../../components/Map/hooks";
 import { VehicleIconAtlasManager, type VehicleAtlas } from "./vehicleIconAtlas";
@@ -63,8 +63,7 @@ interface VehicleInterp {
   isNew: boolean;
 }
 
-const { DEFAULT_LERP_MS, MIN_LERP_MS, MAX_T, TELEPORT_FACTOR, TELEPORT_MIN_FLOOR_M } =
-  VEHICLE_INTERPOLATION;
+const { DEFAULT_LERP_MS, MIN_LERP_MS, MAX_T } = VEHICLE_INTERPOLATION;
 
 /** Lerp a single value from a to b by t in [0, 1]. */
 function lerp(a: number, b: number, t: number): number {
@@ -163,6 +162,10 @@ export default function VehiclesLayer({
     return atlasManager.build();
   });
   const interpRef = useRef(new Map<string, VehicleInterp>());
+  // Set when the tab regains focus: the rAF loop is paused while hidden, so the
+  // next batch of updates is applied as a snap (not animated) to avoid a glide
+  // from the stale pre-hidden position to the current one.
+  const forceSnapRef = useRef(false);
 
   // Refs for values that change but shouldn't restart the RAF loop
   const selectedRef = useRef(selectedId);
@@ -222,6 +225,9 @@ export default function VehiclesLayer({
 
         const store = vehicleStore.getAll();
         const interps = interpRef.current;
+        // Consumed once per applied batch: force every vehicle to snap this pass.
+        const forceSnap = forceSnapRef.current;
+        forceSnapRef.current = false;
 
         for (const [id, v] of store) {
           const existing = interps.get(id);
@@ -233,19 +239,25 @@ export default function VehiclesLayer({
             const posChanged = lat !== existing.nextLat || lng !== existing.nextLng;
             if (!posChanged) continue;
 
-            // Teleport detection: if the new position is beyond what continuous
-            // motion could produce (bulk reset, WS reconnect resync, dispatch
-            // repositioning), snap instead of animating a fly-across.
+            // Snap (jump) instead of animating when motion can't be continuous:
+            // a teleport/reposition (bulk reset, WS resync, dispatch), a stale
+            // update after a starved rAF loop (backgrounded tab, sleep/wake), or
+            // a forced snap on tab refocus. Otherwise animate the delta normally.
             const elapsed = now - existing.updateTime;
             const speedMps = (v.speed ?? 0) * (1000 / 3600);
-            const maxPlausibleM =
-              speedMps * (elapsed / 1000) * TELEPORT_FACTOR + TELEPORT_MIN_FLOOR_M;
             const distanceM = approxDistanceMeters(existing.nextLat, existing.nextLng, lat, lng);
-            const isTeleport = distanceM > maxPlausibleM;
+            const snap =
+              forceSnap ||
+              shouldSnapPosition({
+                isNew: existing.isNew,
+                elapsedMs: elapsed,
+                distanceM,
+                speedMps,
+              });
 
-            // Snap when spawning or teleporting; reset lerpMs so the next
-            // normal tick doesn't animate using a polluted EMA.
-            if (existing.isNew || isTeleport) {
+            // Snap when spawning, teleporting, or after a continuity gap; reset
+            // lerpMs so the next normal tick doesn't animate using a polluted EMA.
+            if (snap) {
               existing.prevLat = lat;
               existing.prevLng = lng;
               existing.prevHeading = heading;
@@ -258,7 +270,9 @@ export default function VehiclesLayer({
               continue;
             }
 
-            // Update per-vehicle lerp duration via EMA (alpha = 0.3)
+            // Update per-vehicle lerp duration via EMA (alpha = 0.3). The gap
+            // guard above snaps (and resets lerpMs) before `elapsed` can exceed
+            // MAX_CONTINUOUS_GAP_MS, so the EMA stays bounded without a clamp.
             if (elapsed > MIN_LERP_MS) {
               existing.lerpMs =
                 existing.lerpMs === DEFAULT_LERP_MS
@@ -419,6 +433,17 @@ export default function VehiclesLayer({
     return () => cancelAnimationFrame(rafId);
     // atlasManager is created once via useState and never changes identity
   }, [atlasManager]);
+
+  // While the tab is hidden the browser pauses requestAnimationFrame, so the
+  // interpolation state goes stale and WS updates queue up. On refocus, snap the
+  // next applied batch to the true positions instead of animating a fly-across.
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") forceSnapRef.current = true;
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
 
   // Stable click handler
   const handleClick = useCallback((info: { object?: VehicleIconDatum }) => {

--- a/apps/ui/src/data/constants.test.ts
+++ b/apps/ui/src/data/constants.test.ts
@@ -4,6 +4,7 @@ import {
   VEHICLE_RENDER,
   VEHICLE_INTERPOLATION,
   HEAT_LAYER,
+  shouldSnapPosition,
 } from "./constants";
 
 describe("constants", () => {
@@ -77,6 +78,50 @@ describe("constants", () => {
       expect(VEHICLE_INTERPOLATION.MAX_T).toBe(1.15);
       expect(VEHICLE_INTERPOLATION.MAX_T).toBeGreaterThan(1);
       expect(VEHICLE_INTERPOLATION.MAX_T).toBeLessThan(2);
+    });
+
+    it("should set the continuity-gap ceiling above the max supported tick", () => {
+      // Above the 2000 ms max update-interval slider so a normal slow tick still
+      // animates, but well below the seconds-to-minutes gap of a hidden tab.
+      expect(VEHICLE_INTERPOLATION.MAX_CONTINUOUS_GAP_MS).toBe(2500);
+      expect(VEHICLE_INTERPOLATION.MAX_CONTINUOUS_GAP_MS).toBeGreaterThan(2000);
+    });
+  });
+
+  describe("shouldSnapPosition", () => {
+    const speedMps = 40 * (1000 / 3600); // ~11 m/s, a typical moving vehicle
+
+    it("snaps a brand-new vehicle", () => {
+      expect(shouldSnapPosition({ isNew: true, elapsedMs: 500, distanceM: 5, speedMps })).toBe(
+        true
+      );
+    });
+
+    it("animates a normal continuous step", () => {
+      // ~5.5 m in 500 ms at 11 m/s is well within the plausible envelope.
+      expect(shouldSnapPosition({ isNew: false, elapsedMs: 500, distanceM: 5.5, speedMps })).toBe(
+        false
+      );
+    });
+
+    it("snaps after a long continuity gap even when the distance looks plausible", () => {
+      // Backgrounded-tab case: elapsed is minutes, so the speed-scaled envelope
+      // would otherwise be huge. The absolute gap guard must still snap.
+      const elapsedMs = 5 * 60 * 1000; // 5 minutes
+      const distanceM = speedMps * (elapsedMs / 1000); // exactly "plausible" by speed
+      expect(shouldSnapPosition({ isNew: false, elapsedMs, distanceM, speedMps })).toBe(true);
+    });
+
+    it("snaps a teleport/reposition (large jump in a short time)", () => {
+      expect(shouldSnapPosition({ isNew: false, elapsedMs: 500, distanceM: 2000, speedMps })).toBe(
+        true
+      );
+    });
+
+    it("does not snap a small reposition of a stopped vehicle (within the floor)", () => {
+      expect(shouldSnapPosition({ isNew: false, elapsedMs: 500, distanceM: 40, speedMps: 0 })).toBe(
+        false
+      );
     });
   });
 

--- a/apps/ui/src/data/constants.ts
+++ b/apps/ui/src/data/constants.ts
@@ -49,7 +49,40 @@ export const VEHICLE_INTERPOLATION = {
   /** Minimum teleport threshold — ensures stopped vehicles (speed≈0) still accept
    *  small real-world repositions without snapping. */
   TELEPORT_MIN_FLOOR_M: 50,
+  /**
+   * Absolute ceiling (ms) on the gap between consecutive position updates for a
+   * vehicle. Beyond this the continuity assumption is broken — the rAF loop was
+   * starved (backgrounded tab, sleep/wake, long GC stall, resync), so the stored
+   * position is stale and we snap to the truth instead of animating a fly-across.
+   * Independent of speed/distance: the distance-scaled teleport envelope grows
+   * with elapsed and therefore can't catch a long idle gap on its own. Set above
+   * the max supported update interval (2000 ms) so a normal slow tick still
+   * animates; this also implicitly bounds the EMA lerp duration, since any larger
+   * gap snaps (and resets lerpMs) rather than feeding the EMA.
+   */
+  MAX_CONTINUOUS_GAP_MS: 2500,
 } as const;
+
+/**
+ * Decide whether a position update should snap (jump) rather than animate.
+ * Snap when the vehicle is brand-new, when the update follows a continuity gap
+ * (stale frame after a starved rAF loop), or when the delta exceeds what plausible
+ * continuous motion could produce in the elapsed time (teleport / reposition).
+ */
+export function shouldSnapPosition(params: {
+  isNew: boolean;
+  elapsedMs: number;
+  distanceM: number;
+  speedMps: number;
+}): boolean {
+  const { isNew, elapsedMs, distanceM, speedMps } = params;
+  if (isNew) return true;
+  if (elapsedMs > VEHICLE_INTERPOLATION.MAX_CONTINUOUS_GAP_MS) return true;
+  const maxPlausibleM =
+    speedMps * (elapsedMs / 1000) * VEHICLE_INTERPOLATION.TELEPORT_FACTOR +
+    VEHICLE_INTERPOLATION.TELEPORT_MIN_FLOOR_M;
+  return distanceM > maxPlausibleM;
+}
 
 // Heat layer contour density viewport
 export const HEAT_LAYER = {


### PR DESCRIPTION
## Problem

When the browser tab is backgrounded for a while (and on any forced reposition), vehicles do a long animated "fly-across" to their real position instead of snapping there. After the tab regains focus they slowly glide from the stale pre-hidden position to the current one.

## Cause

`VehiclesLayer.tsx`'s RAF interpolation already has teleport detection, but its plausibility envelope is `speed × elapsed × factor + floor` — it **scales with elapsed**. Browsers pause `requestAnimationFrame` on a hidden tab, so `updateTime` goes stale by minutes. On refocus `elapsed` is huge → the envelope is huge → a real jump looks "plausible" → it does **not** snap. The EMA then absorbs that huge `elapsed` into `lerpMs`, producing a multi-second/minute glide.

## Fix

- **Continuity-gap guard:** snap whenever `elapsed` exceeds an absolute ceiling (`MAX_CONTINUOUS_GAP_MS = 2500 ms`), independent of speed/distance. It sits above the 2000 ms max update-interval slider, so a normal slow tick still animates, but a seconds-to-minutes idle gap snaps. This also implicitly bounds the EMA `lerpMs` (any larger gap snaps and resets it rather than feeding the EMA), so no clamp is needed.
- **Centralized, tested decision:** the snap policy moves into a pure `shouldSnapPosition()` helper in `data/constants.ts` with unit tests (normal step animates; long gap / teleport / new vehicle snap; small stopped-vehicle reposition within the floor does not).
- **Deterministic refocus:** a `visibilitychange` listener force-snaps the next applied batch when the tab becomes visible, covering browsers that throttle rAF to ~1 Hz instead of fully pausing.

Genuine dispatch/manual repositions were already caught by the distance-based teleport check; this strengthens the same snap path.

## Validation

UI `tsc -b` clean, eslint 0 errors, **vitest 657 passed (+6 new)**, `vite build` succeeds.

Tracked as `fleetsim-all-bx68`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)