### PR TITLE
fix(ui): per-vehicle direction memo, Set-based fleet lookup

### DIFF
--- a/apps/ui/src/Map/Direction.test.tsx
+++ b/apps/ui/src/Map/Direction.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { Route } from "@/types";
+import type * as UseDirectionsModule from "@/hooks/useDirections";
+import type { DirectionState } from "@/hooks/useDirections";
+
+// ---------------------------------------------------------------------------
+// Capture registered layers via useRegisterLayers mock
+// ---------------------------------------------------------------------------
+const { registeredLayers } = vi.hoisted(() => {
+  const registeredLayers = new Map<string, unknown[]>();
+  return { registeredLayers };
+});
+
+vi.mock("@/components/Map/hooks/useDeckLayers", () => ({
+  useRegisterLayers: (id: string, layers: unknown[]) => {
+    registeredLayers.set(id, layers);
+  },
+  useDeckLayersContext: () => ({
+    registerLayers: () => {},
+    unregisterLayers: () => {},
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useDirections so the test controls the Map reference/content directly,
+// simulating the `new Map(prev)` reference churn produced on every WS update.
+// ---------------------------------------------------------------------------
+const { directionsRef } = vi.hoisted(() => {
+  return { directionsRef: { current: new Map<string, unknown>() } };
+});
+
+vi.mock("@/hooks/useDirections", async () => {
+  const actual = await vi.importActual<typeof UseDirectionsModule>("@/hooks/useDirections");
+  return {
+    ...actual,
+    useDirections: () => directionsRef.current,
+  };
+});
+
+import DirectionMap from "./Direction";
+
+function createRoute(distance: number): Route {
+  return { edges: [], distance };
+}
+
+function createDirection(distance: number): DirectionState {
+  return { route: createRoute(distance) };
+}
+
+function getLayers(): { props: Record<string, unknown> }[] {
+  return (registeredLayers.get("directions") ?? []) as { props: Record<string, unknown> }[];
+}
+
+function getLayer(id: string) {
+  return getLayers().find((l) => l.props.id === id);
+}
+
+describe("DirectionMap", () => {
+  beforeEach(() => {
+    registeredLayers.clear();
+    directionsRef.current = new Map();
+  });
+
+  it("registers no layers when neither selected nor hovered is set", () => {
+    directionsRef.current = new Map([["v1", createDirection(100)]]);
+    render(<DirectionMap />);
+    expect(getLayers().length).toBe(0);
+  });
+
+  it("builds a path layer with data for the selected vehicle", () => {
+    directionsRef.current = new Map([["v1", createDirection(100)]]);
+    render(<DirectionMap selected="v1" />);
+
+    const pathLayer = getLayer("direction-paths");
+    expect(pathLayer).toBeTruthy();
+    expect((pathLayer!.props.data as unknown[]).length).toBe(1);
+  });
+
+  it("does not rebuild the layer instances when an unrelated vehicle's direction changes", () => {
+    directionsRef.current = new Map([
+      ["v1", createDirection(100)],
+      ["v2", createDirection(200)],
+    ]);
+
+    const { rerender } = render(<DirectionMap selected="v1" />);
+    const firstLayers = getLayers();
+    const firstPathLayer = getLayer("direction-paths");
+    expect(firstPathLayer).toBeTruthy();
+
+    // Simulate useDirections producing a brand-new Map reference (as the real
+    // hook does on every WS update) but where only vehicle v2 — which is
+    // neither selected nor hovered — actually changed content.
+    const nextMap = new Map(directionsRef.current);
+    nextMap.set("v2", createDirection(999));
+    directionsRef.current = nextMap;
+
+    rerender(<DirectionMap selected="v1" />);
+    const secondLayers = getLayers();
+    const secondPathLayer = getLayer("direction-paths");
+
+    // The layer array reference and the path layer instance itself should be
+    // unchanged since v1's data (the only rendered vehicle) didn't change.
+    expect(secondLayers).toBe(firstLayers);
+    expect(secondPathLayer).toBe(firstPathLayer);
+  });
+
+  it("rebuilds the layers when the selected vehicle's own direction changes", () => {
+    directionsRef.current = new Map([["v1", createDirection(100)]]);
+
+    const { rerender } = render(<DirectionMap selected="v1" />);
+    const firstPathLayer = getLayer("direction-paths");
+
+    const nextMap = new Map(directionsRef.current);
+    nextMap.set("v1", createDirection(150));
+    directionsRef.current = nextMap;
+
+    rerender(<DirectionMap selected="v1" />);
+    const secondPathLayer = getLayer("direction-paths");
+
+    expect(secondPathLayer).not.toBe(firstPathLayer);
+    const data = secondPathLayer!.props.data as { direction: DirectionState }[];
+    expect(data[0].direction.route.distance).toBe(150);
+  });
+
+  it("builds separate colored entries for hovered and selected vehicles", () => {
+    directionsRef.current = new Map([
+      ["v1", createDirection(100)],
+      ["v2", createDirection(200)],
+    ]);
+
+    render(<DirectionMap selected="v1" hovered="v2" />);
+
+    const pathLayer = getLayer("direction-paths");
+    expect(pathLayer).toBeTruthy();
+    const data = pathLayer!.props.data as { id: string }[];
+    expect(data.map((d) => d.id).sort()).toEqual(["v1--selected", "v2--hovered"]);
+  });
+});

--- a/apps/ui/src/Map/Direction.tsx
+++ b/apps/ui/src/Map/Direction.tsx
@@ -48,15 +48,22 @@ interface DirectionProps {
 export default function DirectionMap({ selected, hovered }: DirectionProps) {
   const directions = useDirections();
 
+  // Only the selected/hovered vehicles are ever rendered (at most 2 entries).
+  // Key the memo on THEIR direction data rather than the whole `directions`
+  // Map reference — `useDirections` hands back a new Map reference on every
+  // WS update to ANY vehicle, so keying on it directly rebuilds every
+  // path/waypoint layer whenever an unrelated vehicle reroutes, even though
+  // the selected/hovered vehicle's own data didn't change.
+  const hoveredDirection = hovered ? directions.get(hovered) : undefined;
+  const selectedDirection = selected ? directions.get(selected) : undefined;
+
   const layers = useMemo(() => {
     const items: DirectionData[] = [];
-    if (hovered) {
-      const d = directions.get(hovered);
-      if (d) items.push({ id: `${hovered}--hovered`, direction: d, color: "#f93" });
+    if (hovered && hoveredDirection) {
+      items.push({ id: `${hovered}--hovered`, direction: hoveredDirection, color: "#f93" });
     }
-    if (selected) {
-      const d = directions.get(selected);
-      if (d) items.push({ id: `${selected}--selected`, direction: d, color: "#39f" });
+    if (selected && selectedDirection) {
+      items.push({ id: `${selected}--selected`, direction: selectedDirection, color: "#39f" });
     }
 
     if (items.length === 0) return [];
@@ -188,7 +195,7 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
     return [pathLayer, scatterLayer, waypointTextLayer, distanceTextLayer].filter(
       (l): l is NonNullable<typeof l> => l !== null
     );
-  }, [directions, selected, hovered]);
+  }, [hovered, hoveredDirection, selected, selectedDirection]);
 
   useRegisterLayers("directions", layers);
 

--- a/apps/ui/src/hooks/useFleets.ts
+++ b/apps/ui/src/hooks/useFleets.ts
@@ -55,9 +55,10 @@ export function useFleets(): UseFleets {
       fleetId: string | null;
       vehicleIds: string[];
     }) => {
+      const vehicleIdSet = new Set(vehicleIds);
       setFleets((prev) =>
         prev.map((f) => {
-          const filtered = f.vehicleIds.filter((vid) => !vehicleIds.includes(vid));
+          const filtered = f.vehicleIds.filter((vid) => !vehicleIdSet.has(vid));
           if (f.id === fleetId) {
             return { ...f, vehicleIds: [...filtered, ...vehicleIds] };
           }


### PR DESCRIPTION
## Summary
- `apps/ui/src/Map/Direction.tsx`: the layer-building `useMemo` was keyed on the whole `directions` Map reference from `useDirections`. Since that hook returns a brand-new Map on every WS update to *any* vehicle, a single vehicle rerouting rebuilt every path/waypoint/label deck.gl layer — even though only the selected/hovered vehicle's data is ever rendered (at most 2 entries). The memo is now keyed on the actual `DirectionState` values for `selected`/`hovered`, so unrelated vehicle updates are no-ops and only a change to the rendered vehicle's own data triggers a rebuild.
- `apps/ui/src/hooks/useFleets.ts`: `onFleetAssigned` filtered each fleet's `vehicleIds` with `.filter(vid => !vehicleIds.includes(vid))`, an O(n*m) scan repeated per fleet. Replaced with a `Set` built once per event and `.has()` for O(1) membership checks.

Refs: fleetsim-all-c8m7, fleetsim-all-8zj9

## Test plan
- [x] Added `apps/ui/src/Map/Direction.test.tsx`, including a test that asserts the registered `direction-paths` layer instance (and the layers array reference) is unchanged when an unrelated vehicle's direction changes, and a companion test that it *does* rebuild when the selected vehicle's own data changes.
- [x] `npm run type-check` (workspace-wide via turbo, and `apps/ui` directly) — passes
- [x] `npm run test` in `apps/ui` — 787/787 tests pass (68 files, including new Direction tests and existing useFleets/useDirections tests)
- [x] `npx eslint` on changed files — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)