### PR TITLE
fix(simulator): adapter health, unrouted metric, game loop interval fix

### DIFF
--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -73,3 +73,11 @@ REDIS_URL=
 WS_PUBSUB_CHANNEL=moveet:ws:broadcast
 # Port the standalone WS gateway (start:gateway) listens on
 WS_GATEWAY_PORT=5020
+
+# Routing tunables
+# Minimum time (ms) between pathfinding retries for an unrouted vehicle
+PATHFIND_COOLDOWN_MS=3000
+
+# Adapter sync tunables
+# Maximum backoff delay (ms) between adapter sync attempts after consecutive failures
+MAX_SYNC_BACKOFF_MS=60000

--- a/apps/simulator/src/__tests__/AdapterSyncManager.test.ts
+++ b/apps/simulator/src/__tests__/AdapterSyncManager.test.ts
@@ -415,6 +415,94 @@ describe("AdapterSyncManager", () => {
     });
   });
 
+  // ─── Health reporting (isEnabled / isConnected) ────────────────────
+
+  describe("isEnabled / isConnected", () => {
+    it("should report disabled when adapterURL is not configured", () => {
+      expect(syncManager.isEnabled()).toBe(false);
+    });
+
+    it("should report connected when adapter is not configured (nothing to be down)", () => {
+      expect(syncManager.isConnected()).toBe(true);
+    });
+
+    it("should report enabled when adapterURL is configured", () => {
+      (config as any).adapterURL = "http://localhost:5011";
+      syncManager = new AdapterSyncManager();
+      expect(syncManager.isEnabled()).toBe(true);
+    });
+
+    it("should report connected (optimistically) before any sync attempt has settled", () => {
+      (config as any).adapterURL = "http://localhost:5011";
+      syncManager = new AdapterSyncManager();
+      expect(syncManager.isConnected()).toBe(true);
+    });
+
+    it("should report connected after a successful sync", async () => {
+      (config as any).adapterURL = "http://localhost:5011";
+      syncManager = new AdapterSyncManager();
+      const adapter = (syncManager as any).adapter;
+      vi.spyOn(adapter, "sync").mockResolvedValue(undefined);
+
+      vi.useFakeTimers();
+      try {
+        syncManager.startLocationUpdates(1000, function* () {} as any);
+        await vi.advanceTimersByTimeAsync(1000);
+      } finally {
+        syncManager.stopLocationUpdates();
+        vi.useRealTimers();
+      }
+
+      expect(syncManager.isConnected()).toBe(true);
+    });
+
+    it("should report disconnected after a failed sync", async () => {
+      (config as any).adapterURL = "http://localhost:5011";
+      syncManager = new AdapterSyncManager();
+      const adapter = (syncManager as any).adapter;
+      vi.spyOn(adapter, "sync").mockRejectedValue(new Error("adapter down"));
+
+      vi.useFakeTimers();
+      try {
+        syncManager.startLocationUpdates(1000, function* () {} as any);
+        await vi.advanceTimersByTimeAsync(1000);
+      } finally {
+        syncManager.stopLocationUpdates();
+        vi.useRealTimers();
+      }
+
+      expect(syncManager.isConnected()).toBe(false);
+    });
+
+    it("should recover to connected after a subsequent successful sync", async () => {
+      (config as any).adapterURL = "http://localhost:5011";
+      syncManager = new AdapterSyncManager();
+      const adapter = (syncManager as any).adapter;
+      const syncSpy = vi
+        .spyOn(adapter, "sync")
+        .mockRejectedValueOnce(new Error("adapter down"))
+        .mockResolvedValue(undefined);
+
+      // Eliminate jitter so the backed-off retry timing is deterministic.
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+      vi.useFakeTimers();
+      try {
+        syncManager.startLocationUpdates(1000, function* () {} as any);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(syncManager.isConnected()).toBe(false);
+
+        // Next attempt (after 2x backoff, no jitter) succeeds.
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(syncSpy).toHaveBeenCalledTimes(2);
+        expect(syncManager.isConnected()).toBe(true);
+      } finally {
+        syncManager.stopLocationUpdates();
+        vi.useRealTimers();
+        randomSpy.mockRestore();
+      }
+    });
+  });
+
   // ─── Drain ────────────────────────────────────────────────────────
 
   describe("drain", () => {

--- a/apps/simulator/src/__tests__/GameLoop.test.ts
+++ b/apps/simulator/src/__tests__/GameLoop.test.ts
@@ -113,6 +113,41 @@ describe("GameLoop", () => {
       gameLoop.startVehicleMovement("1", 1000); // different interval
       expect(gameLoop.getGameLoopIntervalRef()).not.toBe(firstInterval);
     });
+
+    it("should restart the running interval immediately when setGameLoopIntervalMs changes it, without needing a vehicle state change", () => {
+      gameLoop.startVehicleMovement("0", 500);
+      const firstInterval = gameLoop.getGameLoopIntervalRef();
+      expect(gameLoop.getGameLoopIntervalMs()).toBe(500);
+
+      gameLoop.setGameLoopIntervalMs(1000);
+
+      expect(gameLoop.getGameLoopIntervalMs()).toBe(1000);
+      // The underlying setInterval handle must be a new one — the change
+      // takes effect immediately rather than waiting for the next
+      // activation/deactivation.
+      expect(gameLoop.getGameLoopIntervalRef()).not.toBe(firstInterval);
+      expect(gameLoop.getGameLoopIntervalRef()).not.toBeNull();
+      // Active vehicles must be preserved across the restart.
+      expect(gameLoop.getActiveVehicles().has("0")).toBe(true);
+    });
+
+    it("should not restart the interval when setGameLoopIntervalMs is called with the loop stopped", () => {
+      expect(gameLoop.getGameLoopIntervalRef()).toBeNull();
+
+      gameLoop.setGameLoopIntervalMs(1000);
+
+      expect(gameLoop.getGameLoopIntervalMs()).toBe(1000);
+      expect(gameLoop.getGameLoopIntervalRef()).toBeNull();
+    });
+
+    it("should not restart the interval when setGameLoopIntervalMs is called with an unchanged value", () => {
+      gameLoop.startVehicleMovement("0", 500);
+      const firstInterval = gameLoop.getGameLoopIntervalRef();
+
+      gameLoop.setGameLoopIntervalMs(500);
+
+      expect(gameLoop.getGameLoopIntervalRef()).toBe(firstInterval);
+    });
   });
 
   // ─── gameLoopTick ─────────────────────────────────────────────────

--- a/apps/simulator/src/__tests__/RouteManager.test.ts
+++ b/apps/simulator/src/__tests__/RouteManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { RouteManager } from "../modules/RouteManager";
+import { RouteManager, UNROUTED_LOG_SAMPLE_RATE } from "../modules/RouteManager";
 import { VehicleRegistry } from "../modules/VehicleRegistry";
 import { TrafficManager } from "../modules/TrafficManager";
 import { FleetManager } from "../modules/FleetManager";
@@ -7,6 +7,12 @@ import { RoadNetwork } from "../modules/RoadNetwork";
 import { config } from "../utils/config";
 import type { Vehicle, Route, StartOptions } from "../types";
 import path from "path";
+import logger from "../utils/logger";
+import * as metrics from "../metrics";
+
+vi.mock("../utils/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
 
 const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
 
@@ -280,6 +286,80 @@ describe("RouteManager", () => {
     });
   });
 
+  // ─── Unrouted-vehicle metric / sampled warning ─────────────────────
+
+  describe("unrouted vehicle tracking", () => {
+    beforeEach(() => {
+      vi.mocked(logger.warn).mockClear();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("logs a warning and records the gauge on the first unrouted retry", () => {
+      const vehicle = firstVehicle();
+      routeManager.setRandomDestination = vi.fn();
+      const gaugeSpy = vi.spyOn(metrics, "setUnroutedVehicles");
+
+      // No route set -> updateVehicle takes the "unrouted" branch immediately
+      // (lastPathfindAttempt starts empty, so the cooldown gate passes).
+      routeManager.updateVehicle(vehicle, 500, DEFAULT_OPTIONS);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(`Vehicle ${vehicle.id} still unrouted after 1 pathfind attempt`)
+      );
+      expect(gaugeSpy).toHaveBeenCalledWith(1);
+      expect(routeManager.setRandomDestination).toHaveBeenCalledWith(vehicle.id);
+    });
+
+    it("does not spam a warning on every retry, only first + every Nth", () => {
+      const vehicle = firstVehicle();
+      routeManager.setRandomDestination = vi.fn();
+
+      // Drive PATHFIND_COOLDOWN + 1 retries by advancing lastPathfindAttempt
+      // into the past before each call, bypassing real timers.
+      const cooldown = (RouteManager as any).PATHFIND_COOLDOWN as number;
+      const attempts = UNROUTED_LOG_SAMPLE_RATE + 1;
+      for (let i = 0; i < attempts; i++) {
+        (routeManager as any).lastPathfindAttempt.set(vehicle.id, Date.now() - cooldown - 1);
+        routeManager.updateVehicle(vehicle, 500, DEFAULT_OPTIONS);
+      }
+
+      // Only the 1st and the (UNROUTED_LOG_SAMPLE_RATE)th attempts should log.
+      const unroutedWarnings = vi
+        .mocked(logger.warn)
+        .mock.calls.filter((call) => String(call[0]).includes("still unrouted"));
+      expect(unroutedWarnings).toHaveLength(2);
+      expect(unroutedWarnings[0][0]).toContain("after 1 pathfind attempt");
+      expect(unroutedWarnings[1][0]).toContain(
+        `after ${UNROUTED_LOG_SAMPLE_RATE} pathfind attempt`
+      );
+    });
+
+    it("clears the unrouted count once a route is successfully assigned", async () => {
+      const vehicle = firstVehicle();
+      const gaugeSpy = vi.spyOn(metrics, "setUnroutedVehicles");
+
+      // Stub the pathfinder to resolve deterministically (avoids depending on
+      // real worker-pool timing) with a route for the vehicle's current edge.
+      const route: Route = { edges: [vehicle.currentEdge], distance: vehicle.currentEdge.distance };
+      const findRouteSpy = vi.spyOn(network, "findRouteAsync").mockResolvedValue(route);
+
+      // Trigger one failed-cooldown retry to populate unroutedAttempts and
+      // kick off setRandomDestination (which calls findRouteAsync above).
+      routeManager.updateVehicle(vehicle, 500, DEFAULT_OPTIONS);
+      expect(gaugeSpy).toHaveBeenLastCalledWith(1);
+
+      // Let the mocked pathfind promise settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(findRouteSpy).toHaveBeenCalled();
+      expect(gaugeSpy).toHaveBeenLastCalledWith(0);
+    });
+  });
+
   // ─── reset ────────────────────────────────────────────────────────
 
   describe("reset", () => {
@@ -291,6 +371,18 @@ describe("RouteManager", () => {
 
       expect(routeManager.getRoute(vehicle.id)).toBeUndefined();
       expect(routeManager.getDirections()).toHaveLength(0);
+    });
+
+    it("should zero out the unrouted-vehicles gauge", () => {
+      const gaugeSpy = vi.spyOn(metrics, "setUnroutedVehicles");
+      const vehicle = firstVehicle();
+      routeManager.setRandomDestination = vi.fn();
+      routeManager.updateVehicle(vehicle, 500, DEFAULT_OPTIONS);
+      expect(gaugeSpy).toHaveBeenLastCalledWith(1);
+
+      routeManager.reset();
+
+      expect(gaugeSpy).toHaveBeenLastCalledWith(0);
     });
   });
 });

--- a/apps/simulator/src/__tests__/routes/health.test.ts
+++ b/apps/simulator/src/__tests__/routes/health.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../utils/logger", () => ({
 function createApp(overrides?: {
   network?: unknown;
   simulationController?: { getStatus: () => { ready: boolean } };
+  vehicleManager?: { adapterSync: { isConnected: () => boolean } };
 }) {
   const app = express();
   const startTime = Date.now();
@@ -21,6 +22,9 @@ function createApp(overrides?: {
   const network = overrides?.network ?? {};
   const simulationController = overrides?.simulationController ?? {
     getStatus: vi.fn().mockReturnValue({ ready: true }),
+  };
+  const vehicleManager = overrides?.vehicleManager ?? {
+    adapterSync: { isConnected: vi.fn().mockReturnValue(true) },
   };
 
   app.get("/health", (_req, res) => {
@@ -31,6 +35,7 @@ function createApp(overrides?: {
         roadNetwork: !!network,
         simulation: simulationController.getStatus().ready,
       },
+      adapterConnected: vehicleManager.adapterSync.isConnected(),
     });
   });
 
@@ -72,5 +77,20 @@ describe("GET /health", () => {
     });
     const res = await request(app).get("/health");
     expect(res.body.subsystems.simulation).toBe(false);
+  });
+
+  it("should report adapterConnected true when adapter sync is healthy or disabled", async () => {
+    const res = await request(app).get("/health");
+    expect(res.body.adapterConnected).toBe(true);
+  });
+
+  it("should report adapterConnected false when the most recent adapter sync failed", async () => {
+    app = createApp({
+      vehicleManager: {
+        adapterSync: { isConnected: () => false },
+      },
+    });
+    const res = await request(app).get("/health");
+    expect(res.body.adapterConnected).toBe(false);
   });
 });

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -109,6 +109,9 @@ app.get("/health", (_req, res) => {
       roadNetwork: !!network,
       simulation: simulationController.getStatus().ready,
     },
+    // true when adapter integration is disabled, or its most recent sync
+    // attempt succeeded; false only when configured and the last attempt failed.
+    adapterConnected: vehicleManager.adapterSync.isConnected(),
   });
 });
 

--- a/apps/simulator/src/metrics.ts
+++ b/apps/simulator/src/metrics.ts
@@ -63,6 +63,15 @@ const adapterSyncDurationSeconds = new Histogram({
   registers: [registry],
 });
 
+// ─── Routing metrics ────────────────────────────────────────────────────
+
+/** Vehicles currently without an active route because pathfinding has been failing repeatedly. */
+const unroutedVehiclesGauge = new Gauge({
+  name: "moveet_unrouted_vehicles",
+  help: "Number of vehicles currently without an active route due to repeated pathfinding failures",
+  registers: [registry],
+});
+
 // ─── HTTP metrics ───────────────────────────────────────────────────────
 
 /** HTTP request duration in seconds, labelled by method/route/status. */
@@ -106,6 +115,11 @@ export function recordWsBackpressureDisconnect(): void {
 export function recordAdapterSync(result: "success" | "failure", durationSeconds: number): void {
   adapterSyncTotal.inc({ result });
   adapterSyncDurationSeconds.observe({ result }, durationSeconds);
+}
+
+/** Sets the unrouted-vehicles gauge to the current count. */
+export function setUnroutedVehicles(count: number): void {
+  unroutedVehiclesGauge.set(count);
 }
 
 /** Observes an HTTP request's duration with method/route/status labels. */

--- a/apps/simulator/src/modules/AdapterSyncManager.ts
+++ b/apps/simulator/src/modules/AdapterSyncManager.ts
@@ -4,9 +4,6 @@ import Adapter from "./Adapter";
 import { recordAdapterSync } from "../metrics";
 import logger from "../utils/logger";
 
-/** Maximum backoff delay between sync attempts after consecutive failures (ms). */
-const MAX_SYNC_BACKOFF_MS = 60_000;
-
 /** Consecutive-failure count at which a persistent-failure error is logged. */
 const PERSISTENT_FAILURE_THRESHOLD = 5;
 
@@ -19,6 +16,34 @@ export class AdapterSyncManager {
   private syncTimer: NodeJS.Timeout | null = null;
   private syncSession = 0;
   private inFlightSync: Promise<void> | null = null;
+  /**
+   * Outcome of the most recently *settled* periodic sync attempt, or `null`
+   * before the first attempt has completed. Read by health reporting to
+   * answer "is the adapter currently reachable" without re-deriving it from
+   * Prometheus counters.
+   */
+  private lastSyncResult: "success" | "failure" | null = null;
+
+  /**
+   * Whether adapter integration is configured (ADAPTER_URL set). Health
+   * reporting treats an unconfigured adapter as "connected" (there is
+   * nothing to be disconnected from) rather than surfacing a false alarm.
+   */
+  isEnabled(): boolean {
+    return !!config.adapterURL;
+  }
+
+  /**
+   * Best-effort adapter connectivity signal for /health:
+   *  - not configured → true (nothing to report as down)
+   *  - configured, no sync attempted yet → true (optimistic until proven otherwise)
+   *  - configured, most recent attempt succeeded → true
+   *  - configured, most recent attempt failed → false
+   */
+  isConnected(): boolean {
+    if (!this.isEnabled()) return true;
+    return this.lastSyncResult !== "failure";
+  }
 
   /**
    * Fetches vehicles from the adapter and invokes the callback for each.
@@ -85,7 +110,7 @@ export class AdapterSyncManager {
    * Starts periodic synchronization of vehicle locations to external adapter.
    *
    * Implemented as a self-scheduling timeout chain so that consecutive sync
-   * failures back off exponentially (with jitter, capped at MAX_SYNC_BACKOFF_MS)
+   * failures back off exponentially (with jitter, capped at config.maxSyncBackoffMs)
    * instead of hammering an unhealthy adapter at the fixed cadence. The delay
    * resets to `intervalMs` on the first successful sync.
    */
@@ -123,8 +148,10 @@ export class AdapterSyncManager {
           correlationId
         );
         recordAdapterSync("success", Number(process.hrtime.bigint() - start) / 1e9);
+        this.lastSyncResult = "success";
       } catch (error) {
         recordAdapterSync("failure", Number(process.hrtime.bigint() - start) / 1e9);
+        this.lastSyncResult = "failure";
         throw error;
       }
     };
@@ -148,14 +175,14 @@ export class AdapterSyncManager {
         } catch (error) {
           failures++;
           logger.error(`Failed to sync vehicles to adapter: ${error}`);
-          // Cap the exponential backoff at MAX_SYNC_BACKOFF_MS. Using min() (not
+          // Cap the exponential backoff at config.maxSyncBackoffMs. Using min() (not
           // max()) is essential: with max(), an intervalMs above the cap would
           // make the cap == intervalMs and silently defeat the 60s ceiling.
-          const backoff = Math.min(intervalMs * 2 ** failures, MAX_SYNC_BACKOFF_MS);
+          const backoff = Math.min(intervalMs * 2 ** failures, config.maxSyncBackoffMs);
           const jitter = Math.floor(Math.random() * backoff * 0.1);
           if (failures === PERSISTENT_FAILURE_THRESHOLD) {
             logger.error(
-              `Adapter sync failing persistently (${failures} consecutive failures); backing off up to ${MAX_SYNC_BACKOFF_MS}ms between attempts`
+              `Adapter sync failing persistently (${failures} consecutive failures); backing off up to ${config.maxSyncBackoffMs}ms between attempts`
             );
           }
           scheduleNext(backoff + jitter);

--- a/apps/simulator/src/modules/GameLoop.ts
+++ b/apps/simulator/src/modules/GameLoop.ts
@@ -176,8 +176,18 @@ export class GameLoop extends EventEmitter {
     return this.gameLoopIntervalMs;
   }
 
+  /**
+   * Updates the tick-rate. If the loop is currently running with a different
+   * interval, restarts it immediately so the change takes effect on this call
+   * rather than waiting for the next vehicle activation/deactivation (which is
+   * the only other path that calls restartGameLoop/startGameLoop).
+   */
   setGameLoopIntervalMs(intervalMs: number): void {
+    const changed = intervalMs !== this.gameLoopIntervalMs;
     this.gameLoopIntervalMs = intervalMs;
+    if (changed && this.gameLoopInterval) {
+      this.restartGameLoop(intervalMs);
+    }
   }
 
   // ─── Accessors for internals (used by setOptions) ─────────────────

--- a/apps/simulator/src/modules/RouteManager.ts
+++ b/apps/simulator/src/modules/RouteManager.ts
@@ -18,6 +18,16 @@ import * as utils from "../utils/helpers";
 import { getProfile, FOLLOWING_DISTANCE_BY_SIZE } from "../utils/vehicleProfiles";
 import { rng } from "../utils/rng";
 import logger from "../utils/logger";
+import { setUnroutedVehicles } from "../metrics";
+import { config } from "../utils/config";
+
+/**
+ * After the first "vehicle still unrouted" warning is logged for a vehicle,
+ * repeat warnings are only logged every Nth retry so a vehicle stuck with no
+ * reachable destination doesn't flood the logs. Mirrors GameLoop's
+ * FAILURE_LOG_SAMPLE_RATE pattern.
+ */
+export const UNROUTED_LOG_SAMPLE_RATE = 100;
 
 /**
  * Manages route/waypoint tracking, pathfinding, and route-based movement.
@@ -27,7 +37,9 @@ export class RouteManager extends EventEmitter {
   private routes: Map<string, Route> = new Map();
   private waypointRoutes: Map<string, MultiStopRoute> = new Map();
   private lastPathfindAttempt: Map<string, number> = new Map();
-  private static readonly PATHFIND_COOLDOWN = 3000;
+  private static readonly PATHFIND_COOLDOWN = config.pathfindCooldownMs;
+  /** Consecutive pathfind-retry count per vehicle, cleared once a route is set. */
+  private unroutedAttempts: Map<string, number> = new Map();
 
   /**
    * Per-vehicle cache of the lean, serialized (non-circular) route. Built once
@@ -137,6 +149,9 @@ export class RouteManager extends EventEmitter {
         if (route) {
           this.setRouteFor(vehicleId, route);
           vehicle.edgeIndex = -1;
+          if (this.unroutedAttempts.delete(vehicleId)) {
+            setUnroutedVehicles(this.countUnroutedVehicles());
+          }
           this.emit("direction", {
             vehicleId,
             route: this.getSerializedRoute(vehicleId, route),
@@ -280,6 +295,11 @@ export class RouteManager extends EventEmitter {
     this.waypointRoutes.delete(vehicle.id);
   }
 
+  /** Current count of vehicles with at least one pending unrouted pathfind attempt. */
+  private countUnroutedVehicles(): number {
+    return this.unroutedAttempts.size;
+  }
+
   // ─── Position update core ─────────────────────────────────────────
 
   /**
@@ -358,6 +378,17 @@ export class RouteManager extends EventEmitter {
       const lastAttempt = this.lastPathfindAttempt.get(vehicle.id) ?? 0;
       if (now - lastAttempt > RouteManager.PATHFIND_COOLDOWN) {
         this.lastPathfindAttempt.set(vehicle.id, now);
+
+        const attempts = (this.unroutedAttempts.get(vehicle.id) ?? 0) + 1;
+        this.unroutedAttempts.set(vehicle.id, attempts);
+        if (attempts === 1 || attempts % UNROUTED_LOG_SAMPLE_RATE === 0) {
+          const unroutedForMs = attempts * RouteManager.PATHFIND_COOLDOWN;
+          logger.warn(
+            `Vehicle ${vehicle.id} still unrouted after ${attempts} pathfind attempt(s) (~${unroutedForMs}ms)`
+          );
+        }
+        setUnroutedVehicles(this.countUnroutedVehicles());
+
         this.setRandomDestination(vehicle.id);
       }
     } else {
@@ -702,5 +733,7 @@ export class RouteManager extends EventEmitter {
       clearTimeout(this.rerouteDrainTimer);
       this.rerouteDrainTimer = null;
     }
+    this.unroutedAttempts.clear();
+    setUnroutedVehicles(0);
   }
 }

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -261,18 +261,12 @@ export class VehicleManager extends EventEmitter {
     if (vehicleTypes) {
       this.pendingVehicleTypes = vehicleTypes;
     }
-    const prevInterval = this.options.updateInterval;
     const prevSyncInterval = this.options.adapterSyncInterval;
     this.options = { ...this.options, ...startOptions };
 
-    if (
-      startOptions.updateInterval &&
-      startOptions.updateInterval !== prevInterval &&
-      this.gameLoop.getActiveVehicles().size > 0
-    ) {
-      this.gameLoop.restartGameLoop(startOptions.updateInterval);
-    }
-
+    // setGameLoopIntervalMs restarts the running loop itself when the
+    // interval actually changes, so no separate restartGameLoop call is
+    // needed here.
     this.gameLoop.setGameLoopIntervalMs(this.options.updateInterval);
 
     // Restart the adapter-sync timer at the new cadence if it changed while a

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -118,6 +118,20 @@ const envObjectSchema = z.object({
 
   /** Port the standalone WS gateway listens on (used by ws-gateway entrypoint). */
   WS_GATEWAY_PORT: z.coerce.number().int().min(1).max(65535).default(5020),
+
+  /**
+   * Minimum time (ms) between pathfinding retry attempts for a vehicle that
+   * currently has no route. Bounds how aggressively RouteManager re-invokes
+   * A* for a vehicle stuck without a reachable destination.
+   */
+  PATHFIND_COOLDOWN_MS: z.coerce.number().int().min(0).default(3000),
+
+  /**
+   * Maximum backoff delay (ms) between adapter sync attempts after
+   * consecutive failures. Caps the exponential backoff in
+   * AdapterSyncManager so an unhealthy adapter is still retried periodically.
+   */
+  MAX_SYNC_BACKOFF_MS: z.coerce.number().int().min(0).default(60_000),
 });
 
 export const envSchema = envObjectSchema
@@ -171,6 +185,8 @@ function buildConfig(env: EnvConfig) {
     redisUrl: env.REDIS_URL,
     wsPubSubChannel: env.WS_PUBSUB_CHANNEL,
     wsGatewayPort: env.WS_GATEWAY_PORT,
+    pathfindCooldownMs: env.PATHFIND_COOLDOWN_MS,
+    maxSyncBackoffMs: env.MAX_SYNC_BACKOFF_MS,
   } as const;
 }
 


### PR DESCRIPTION
## Summary

Three related perf/quality audit fixes from the 2026-07-01 review, bundled because they touch overlapping simulator files:

- **fleetsim-all-d90k** — `GET /health` now reports `adapterConnected`, derived from `AdapterSyncManager` tracking the outcome of the most recent sync attempt (`true` when adapter integration is disabled or the last attempt succeeded, `false` only when configured and the last attempt failed). `RouteManager` now logs a sampled "still unrouted" warning (first attempt, then every 100th, mirroring `GameLoop`'s `FAILURE_LOG_SAMPLE_RATE` pattern) and exposes a `moveet_unrouted_vehicles` Prometheus gauge for vehicles stuck in the pathfind-retry loop.
- **fleetsim-all-ac38** — `GameLoop.setGameLoopIntervalMs()` now restarts the running interval immediately (via the existing `restartGameLoop()`) when the loop is active and the interval actually changed, instead of waiting for the next vehicle activation/deactivation. Removed the now-redundant explicit restart call in `VehicleManager.setOptions` since `setGameLoopIntervalMs` handles it.
- **fleetsim-all-9wyo** (partial — scoped to files touched by the two fixes above, to keep this PR focused) — moved `PATHFIND_COOLDOWN` (`RouteManager.ts`) and `MAX_SYNC_BACKOFF_MS` (`AdapterSyncManager.ts`) into the Zod-validated `config.ts` as `PATHFIND_COOLDOWN_MS` / `MAX_SYNC_BACKOFF_MS` env vars, defaults unchanged (3000ms / 60000ms). `SECTORS_N` (`SpatialIndex.ts`) and `HEAT_ZONE_REGEN_INTERVAL` (`constants.ts`) are intentionally out of scope; fleetsim-all-9wyo remains **open** for that remaining work (notes added on the issue).

## Test plan

- [x] `npm run type-check` in `apps/simulator` — passes
- [x] `npm test` in `apps/simulator` — 76 files / 1615 tests passing, including `PerfBudget.test.ts` and `VehicleManagerPerf.test.ts`
- [x] New/updated tests: `AdapterSyncManager.test.ts` (isEnabled/isConnected health signal), `routes/health.test.ts` (adapterConnected field), `RouteManager.test.ts` (sampled unrouted warning + gauge), `GameLoop.test.ts` (interval restarts immediately, no-op when stopped/unchanged)
- [x] `.env.example` updated with `PATHFIND_COOLDOWN_MS` / `MAX_SYNC_BACKOFF_MS` (required by `config.test.ts`'s completeness check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)