### PR TITLE
perf: virtualize vehicle list, centralize sim config, document ws scaling

### DIFF
--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -81,3 +81,12 @@ PATHFIND_COOLDOWN_MS=3000
 # Adapter sync tunables
 # Maximum backoff delay (ms) between adapter sync attempts after consecutive failures
 MAX_SYNC_BACKOFF_MS=60000
+
+# Spatial indexing tunables
+# Size (N x N) of the coarse sector grid used for geographically-uniform random
+# spawn/destination/POI selection
+SECTORS_N=10
+
+# Heat zone tunables
+# How often (ms) heat zones auto-regenerate
+HEAT_ZONE_REGEN_INTERVAL_MS=300000

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -51,33 +51,37 @@ GEOJSON_PATH=./data/network.geojson
 
 All config is parsed and validated through a single zod schema in `src/utils/config.ts`. Invalid values fail fast at startup with a descriptive error.
 
-| Variable                | Description                                                                              | Default                |
-| ----------------------- | ---------------------------------------------------------------------------------------- | ---------------------- |
-| `PORT`                  | HTTP server port                                                                         | 5010                   |
-| `GEOJSON_PATH`          | Path to OpenStreetMap GeoJSON file                                                       | ./data/network.geojson |
-| `UPDATE_INTERVAL`       | Vehicle position update frequency (ms)                                                   | 500                    |
-| `MIN_SPEED`             | Minimum vehicle speed (km/h)                                                             | 20                     |
-| `MAX_SPEED`             | Maximum vehicle speed (km/h); must be greater than `MIN_SPEED`                           | 60                     |
-| `ACCELERATION`          | Speed increase rate (km/h per tick)                                                      | 5                      |
-| `DECELERATION`          | Speed decrease rate (km/h per tick)                                                      | 7                      |
-| `TURN_THRESHOLD`        | Angle to trigger turn slowdown (degrees)                                                 | 30                     |
-| `SPEED_VARIATION`       | Speed randomization factor (0.0-1.0)                                                     | 0.1                    |
-| `HEATZONE_SPEED_FACTOR` | Speed multiplier inside heat zones (0.0-1.0)                                             | 0.5                    |
-| `VEHICLE_COUNT`         | Number of synthetic vehicles when running without an adapter                             | 70                     |
-| `VEHICLE_TYPES`         | Optional JSON vehicle-type distribution override (empty = built-in weighting)            | (built-in)             |
-| `ADAPTER_URL`           | URL of the external adapter service. **Presence enables the adapter**; empty = disabled  | (empty)                |
-| `ADAPTER_SYNC_INTERVAL` | How often (ms) vehicle positions are pushed to the adapter. 0 = follow `UPDATE_INTERVAL` | 0                      |
-| `SYNC_ADAPTER_TIMEOUT`  | Timeout (ms) for each adapter sync request                                               | 5000                   |
-| `PERSISTENCE_ENABLED`   | Enable the SQLite persistence layer                                                      | false                  |
-| `PERSISTENCE_INTERVAL`  | Auto-save snapshot interval (seconds)                                                    | 30                     |
-| `RESTORE_STATE`         | Restore state from the latest snapshot on startup                                        | false                  |
-| `STATE_DB_PATH`         | Path to the SQLite state database                                                        | data/state.db          |
-| `ANALYTICS_INTERVAL`    | How often (ms) the analytics snapshot is broadcast and persisted                         | 5000                   |
-| `LOG_LEVEL`             | Pino log level (`fatal`/`error`/`warn`/`info`/`debug`/`trace`/`silent`)                  | info                   |
-| `WS_TRANSPORT`          | WebSocket fan-out transport: `inprocess` (default) or `redis`                            | inprocess              |
-| `REDIS_URL`             | Redis connection URL; **required when `WS_TRANSPORT=redis`** (and by the gateway)        | (empty)                |
-| `WS_PUBSUB_CHANNEL`     | Redis pub/sub channel the simulator publishes to and the gateway subscribes to           | moveet:ws:broadcast    |
-| `WS_GATEWAY_PORT`       | Port the standalone WS gateway listens on                                                | 5020                   |
+| Variable                      | Description                                                                              | Default                |
+| ----------------------------- | ---------------------------------------------------------------------------------------- | ---------------------- |
+| `PORT`                        | HTTP server port                                                                         | 5010                   |
+| `GEOJSON_PATH`                | Path to OpenStreetMap GeoJSON file                                                       | ./data/network.geojson |
+| `UPDATE_INTERVAL`             | Vehicle position update frequency (ms)                                                   | 500                    |
+| `MIN_SPEED`                   | Minimum vehicle speed (km/h)                                                             | 20                     |
+| `MAX_SPEED`                   | Maximum vehicle speed (km/h); must be greater than `MIN_SPEED`                           | 60                     |
+| `ACCELERATION`                | Speed increase rate (km/h per tick)                                                      | 5                      |
+| `DECELERATION`                | Speed decrease rate (km/h per tick)                                                      | 7                      |
+| `TURN_THRESHOLD`              | Angle to trigger turn slowdown (degrees)                                                 | 30                     |
+| `SPEED_VARIATION`             | Speed randomization factor (0.0-1.0)                                                     | 0.1                    |
+| `HEATZONE_SPEED_FACTOR`       | Speed multiplier inside heat zones (0.0-1.0)                                             | 0.5                    |
+| `VEHICLE_COUNT`               | Number of synthetic vehicles when running without an adapter                             | 70                     |
+| `VEHICLE_TYPES`               | Optional JSON vehicle-type distribution override (empty = built-in weighting)            | (built-in)             |
+| `ADAPTER_URL`                 | URL of the external adapter service. **Presence enables the adapter**; empty = disabled  | (empty)                |
+| `ADAPTER_SYNC_INTERVAL`       | How often (ms) vehicle positions are pushed to the adapter. 0 = follow `UPDATE_INTERVAL` | 0                      |
+| `SYNC_ADAPTER_TIMEOUT`        | Timeout (ms) for each adapter sync request                                               | 5000                   |
+| `PATHFIND_COOLDOWN_MS`        | Minimum time (ms) between pathfinding retries for an unrouted vehicle                    | 3000                   |
+| `MAX_SYNC_BACKOFF_MS`         | Maximum backoff delay (ms) between adapter sync attempts after consecutive failures      | 60000                  |
+| `SECTORS_N`                   | Size (N x N) of the coarse sector grid for geographically-uniform spawn/POI selection    | 10                     |
+| `HEAT_ZONE_REGEN_INTERVAL_MS` | How often (ms) heat zones auto-regenerate                                                | 300000                 |
+| `PERSISTENCE_ENABLED`         | Enable the SQLite persistence layer                                                      | false                  |
+| `PERSISTENCE_INTERVAL`        | Auto-save snapshot interval (seconds)                                                    | 30                     |
+| `RESTORE_STATE`               | Restore state from the latest snapshot on startup                                        | false                  |
+| `STATE_DB_PATH`               | Path to the SQLite state database                                                        | data/state.db          |
+| `ANALYTICS_INTERVAL`          | How often (ms) the analytics snapshot is broadcast and persisted                         | 5000                   |
+| `LOG_LEVEL`                   | Pino log level (`fatal`/`error`/`warn`/`info`/`debug`/`trace`/`silent`)                  | info                   |
+| `WS_TRANSPORT`                | WebSocket fan-out transport: `inprocess` (default) or `redis`                            | inprocess              |
+| `REDIS_URL`                   | Redis connection URL; **required when `WS_TRANSPORT=redis`** (and by the gateway)        | (empty)                |
+| `WS_PUBSUB_CHANNEL`           | Redis pub/sub channel the simulator publishes to and the gateway subscribes to           | moveet:ws:broadcast    |
+| `WS_GATEWAY_PORT`             | Port the standalone WS gateway listens on                                                | 5020                   |
 
 > Note: there is no `USE_ADAPTER` or `SYNC_ADAPTER` flag. The adapter is enabled simply by setting `ADAPTER_URL`.
 
@@ -286,6 +290,7 @@ When `WS_TRANSPORT=redis`, the simulator publishes serialized broadcast envelope
 `WS_PUBSUB_CHANNEL` Redis channel, and this standalone gateway (`src/ws-gateway.ts`, listening
 on `WS_GATEWAY_PORT`, default 5020) subscribes and runs the per-client fan-out against its own
 WS server, so client count scales independently of the simulation thread. Requires `REDIS_URL`.
+See "Scaling WebSocket Clients" below for when to enable it and load-test results.
 
 ### Run Tests
 
@@ -298,6 +303,87 @@ npm test
 ```bash
 npm run lint
 ```
+
+## Scaling WebSocket Clients
+
+The default (`WS_TRANSPORT=inprocess`) fan-out — per-client delta filtering, bbox
+spatial-index pre-filter, backpressure, per-client `JSON.stringify`, and the ping/pong
+heartbeat, all in `ClientFanout` — runs on the simulation's own event loop, once per flush
+(10 Hz by default). Its cost is O(clients x vehicles) per flush, so it is fine for the
+common case (tens to low hundreds of dashboard clients at the default 70-vehicle fleet) but
+competes with the simulation tick for the same thread as client count grows.
+
+### When to enable `WS_TRANSPORT=redis`
+
+Switch to the Redis transport when you need to scale **WebSocket client count**
+independently of the simulation (e.g. serving many dashboard/observer connections, or
+horizontally scaling fan-out across multiple gateway processes/pods). It does not help if
+the bottleneck is vehicle count or simulation tick rate — those still run on the simulator
+process regardless of transport.
+
+Rough guidance from the load test below: the in-process fan-out is comfortably cheap up to
+several hundred concurrent clients at a 70-vehicle fleet (see numbers below). Reach for
+`WS_TRANSPORT=redis` once you expect to exceed roughly **200-500 concurrent WS clients**,
+need to run fan-out on hardware separate from the simulation, or want to scale the gateway
+horizontally behind a load balancer.
+
+### What it requires
+
+- A Redis (or Redis-compatible, e.g. Redpanda's Kafka-compatible brokers do NOT work here —
+  this specifically needs Redis pub/sub) instance reachable from both the simulator and the
+  gateway process.
+- Environment variables (see `.env.example` / Configuration Options above):
+  - `WS_TRANSPORT=redis` on the simulator.
+  - `REDIS_URL` — required on **both** the simulator (publisher) and the gateway
+    (subscriber) when `WS_TRANSPORT=redis`; a zod refine in `config.ts` fails startup fast
+    if it's missing.
+  - `WS_PUBSUB_CHANNEL` (default `moveet:ws:broadcast`) — must match between simulator and
+    gateway (it does by default; only change both together).
+  - `WS_GATEWAY_PORT` (default `5020`) — the port the standalone gateway listens on for its
+    own WS clients.
+- The standalone gateway process running (`npm run dev:gateway` / `start:gateway`, or the
+  `ws-gateway` Docker Compose target — see `docker compose --profile scale up`). `ioredis`
+  is lazy-imported only when this transport is selected, so the default in-process path has
+  no Redis dependency.
+- Clients connect to the **gateway's** port (`WS_GATEWAY_PORT`), not the simulator's, once
+  the gateway is in front of them.
+
+When `WS_TRANSPORT=redis`, the simulator no longer runs `ClientFanout` itself — it hands off
+a lightweight `RedisPubSubTransport` that only serializes once and publishes, so its own
+event loop cost per flush stops scaling with client count. The gateway (a separate process,
+scalable independently) runs the same `ClientFanout` engine against its own clients.
+
+### Load test results
+
+`src/__tests__/ClientFanoutLoad.test.ts` exercises `ClientFanout.fanoutVehicles` directly
+(mocked WebSocket clients, no real sockets, no external Redis — the same mocking boundary
+`WebSocketBroadcaster.test.ts` uses) at increasing client counts with a fixed 70-vehicle
+fleet, and measures per-flush wall-clock time:
+
+| Clients | Per-flush time (mocked) |
+| ------- | ----------------------- |
+| 10      | ~0.18 ms                |
+| 50      | ~0.64 ms                |
+| 100     | ~1.23 ms                |
+| 200     | ~2.06 ms                |
+| 500     | ~5.63 ms                |
+
+(Measured locally; exact numbers vary by machine — see the test file for the harness and
+re-run with `npm test -- ClientFanoutLoad` to reproduce. Scaling is linear in client count
+for a fixed vehicle count, as expected from the O(clients x vehicles) design.)
+
+These numbers use mocked sends (no real socket I/O, no OS-level backpressure) and are a
+**lower bound** — real deployments will see higher per-flush cost from actual `send()`
+syscalls and network stack overhead. Even so, at 500 clients the measured cost is under 6ms
+against a 100ms flush budget (10 Hz), i.e. roughly 6% of one flush interval, so the
+in-process transport has meaningful headroom in the low hundreds of clients before it
+becomes worth moving fan-out off the simulation thread.
+
+**Recommendation:** stay on `WS_TRANSPORT=inprocess` (default) below ~200 concurrent
+clients. Between ~200-500, monitor `/metrics` (WS flush duration, event-loop lag) under
+real load before deciding. Above ~500 concurrent clients, or if the simulation thread shows
+event-loop lag correlated with WS flushes, switch to `WS_TRANSPORT=redis` and run the
+gateway as an independently-scaled process.
 
 ## Architecture
 

--- a/apps/simulator/src/__tests__/ClientFanoutLoad.test.ts
+++ b/apps/simulator/src/__tests__/ClientFanoutLoad.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { WebSocket, WebSocketServer } from "ws";
+import { ClientFanout } from "../modules/ws/ClientFanout";
+import type { VehicleDTO } from "../types";
+
+/**
+ * Load test for the WS fan-out hot path (fleetsim-all-7ksg, 2026-07-01
+ * perf/quality audit).
+ *
+ * `ClientFanout.fanoutVehicles` is O(clients x vehicles) per flush - it runs
+ * once per broadcaster flush (10Hz by default) against every connected
+ * client. This test exercises that method directly at increasing synthetic
+ * client counts (mocked WebSocket objects, same boundary
+ * WebSocketBroadcaster.test.ts mocks at) and measures per-flush wall-clock
+ * time, WITHOUT real sockets or an external Redis.
+ *
+ * This is a DETERMINISTIC scaling measurement, not a strict pass/fail perf
+ * budget guard like PerfBudget.test.ts - there is no "correct" absolute
+ * number since it depends on the machine running it. Instead it:
+ *   1. Asserts the cost scales roughly linearly with client count (catches a
+ *      gross algorithmic regression, e.g. an accidental O(n^2) in clients).
+ *   2. Prints a client-count -> per-flush-time table to stdout so the
+ *      numbers can be captured in the PR description / docs as a rough
+ *      guide for when to switch WS_TRANSPORT=redis.
+ *
+ * Vehicle count is fixed at 70 (the documented in-process baseline - see
+ * CLAUDE.md "WebSocket fan-out transport") so the only scaling variable is
+ * client count.
+ */
+
+const VEHICLE_COUNT = 70;
+const CLIENT_COUNTS = [10, 50, 100, 200, 500];
+// Each client gets a distinct lastSent state, so every flush is a real
+// "vehicle changed" pass rather than a cache hit that skips work.
+const FLUSHES_PER_SCALE = 20;
+
+function makeMockClient(): WebSocket {
+  return {
+    readyState: 1, // OPEN
+    bufferedAmount: 0,
+    send: () => {},
+    on: () => {},
+  } as unknown as WebSocket;
+}
+
+function makeMockWss(clients: WebSocket[]): WebSocketServer {
+  return { clients: new Set(clients) } as unknown as WebSocketServer;
+}
+
+function makeVehicles(count: number, tick: number): VehicleDTO[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `v${i}`,
+    name: `Vehicle ${i}`,
+    type: "car",
+    // Perturb position every tick so delta filtering never skips the send -
+    // we want to measure the real per-flush work, not a cache short-circuit.
+    position: [-1.286 + tick * 0.0001, 36.817 + i * 0.0001] as [number, number],
+    speed: 40,
+    heading: 90,
+  }));
+}
+
+interface ScaleResult {
+  clientCount: number;
+  totalMs: number;
+  perFlushMs: number;
+}
+
+describe("ClientFanout load test (fleetsim-all-7ksg)", () => {
+  const fanouts: ClientFanout[] = [];
+  const results: ScaleResult[] = [];
+
+  afterEach(() => {
+    for (const f of fanouts.splice(0)) f.stop();
+  });
+
+  it.each(CLIENT_COUNTS)(
+    "measures fanoutVehicles wall-clock time with %i clients @ 70 vehicles",
+    (clientCount) => {
+      const clients = Array.from({ length: clientCount }, () => makeMockClient());
+      const wss = makeMockWss(clients);
+      const fanout = new ClientFanout(wss, { pingIntervalMs: 0, pongTimeoutMs: 0 });
+      fanouts.push(fanout);
+
+      // Warm up (JIT + first-send-always-included path) before measuring.
+      fanout.fanoutVehicles(makeVehicles(VEHICLE_COUNT, 0));
+
+      const start = performance.now();
+      for (let tick = 1; tick <= FLUSHES_PER_SCALE; tick++) {
+        fanout.fanoutVehicles(makeVehicles(VEHICLE_COUNT, tick));
+      }
+      const totalMs = performance.now() - start;
+      const perFlushMs = totalMs / FLUSHES_PER_SCALE;
+
+      results.push({ clientCount, totalMs, perFlushMs });
+
+      // Not a strict budget assertion (this is a scaling measurement, not a
+      // regression guard) - just a loose sanity ceiling so a genuine hang or
+      // infinite loop still fails the test instead of timing out silently.
+      expect(perFlushMs).toBeLessThan(2000);
+    }
+  );
+
+  it("prints the client-count -> per-flush-time scaling table", () => {
+    // This runs after the it.each block (vitest preserves declaration order),
+    // so `results` is fully populated. Guard in case it ever runs standalone.
+    if (results.length < CLIENT_COUNTS.length) return;
+
+    const rows = results
+      .slice()
+      .sort((a, b) => a.clientCount - b.clientCount)
+      .map((r) => `| ${r.clientCount} | ${r.perFlushMs.toFixed(3)} ms |`);
+
+    console.log(
+      [
+        "\nClientFanout load test results (70 vehicles, mocked WS clients):",
+        "| Clients | Per-flush time |",
+        "| --- | --- |",
+        ...rows,
+        "",
+      ].join("\n")
+    );
+
+    // Sanity: cost should not blow up worse than roughly quadratic between
+    // the smallest and largest scale (catches a gross O(n^2)-in-clients
+    // regression; fanoutVehicles is expected O(clients x vehicles), i.e.
+    // linear in clients for fixed vehicle count).
+    const smallest = results.reduce((a, b) => (a.clientCount < b.clientCount ? a : b));
+    const largest = results.reduce((a, b) => (a.clientCount > b.clientCount ? a : b));
+    const clientRatio = largest.clientCount / smallest.clientCount;
+    // Guard against div-by-zero on an unrealistically fast smallest-scale run.
+    const timeRatio = largest.perFlushMs / Math.max(smallest.perFlushMs, 0.001);
+
+    expect(timeRatio).toBeLessThan(clientRatio * clientRatio);
+  });
+});

--- a/apps/simulator/src/__tests__/config.test.ts
+++ b/apps/simulator/src/__tests__/config.test.ts
@@ -55,6 +55,26 @@ describe("envSchema / parseEnv", () => {
     expect(cfg.VEHICLE_COUNT).toBe(70);
     expect(cfg.GEOJSON_PATH).toBe("./data/network.geojson");
     expect(cfg.ADAPTER_URL).toBe("");
+    expect(cfg.SECTORS_N).toBe(10);
+    expect(cfg.HEAT_ZONE_REGEN_INTERVAL_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("coerces SECTORS_N and HEAT_ZONE_REGEN_INTERVAL_MS overrides", () => {
+    const cfg = parseEnv(validEnv({ SECTORS_N: "20", HEAT_ZONE_REGEN_INTERVAL_MS: "60000" }));
+    expect(cfg.SECTORS_N).toBe(20);
+    expect(cfg.HEAT_ZONE_REGEN_INTERVAL_MS).toBe(60000);
+  });
+
+  it("rejects SECTORS_N=0 (below min 1)", () => {
+    expect(() => parseEnv(validEnv({ SECTORS_N: "0" }))).toThrow(
+      /Invalid environment configuration/
+    );
+  });
+
+  it("rejects HEAT_ZONE_REGEN_INTERVAL_MS=0 (below min 1)", () => {
+    expect(() => parseEnv(validEnv({ HEAT_ZONE_REGEN_INTERVAL_MS: "0" }))).toThrow(
+      /Invalid environment configuration/
+    );
   });
 
   it("coerces string env values to numbers", () => {

--- a/apps/simulator/src/__tests__/constants.test.ts
+++ b/apps/simulator/src/__tests__/constants.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   WS_BROADCASTER,
   SPATIAL_GRID,
-  TIME_INTERVALS,
   HEAT_ZONE_DEFAULTS,
   VEHICLE_CONSTANTS,
   FLEET_COLORS,
 } from "../constants";
+import { config } from "../utils/config";
 
 describe("constants", () => {
   describe("WS_BROADCASTER", () => {
@@ -62,9 +62,9 @@ describe("constants", () => {
     });
   });
 
-  describe("TIME_INTERVALS", () => {
-    it("should define HEAT_ZONE_REGEN_INTERVAL as 5 minutes in ms", () => {
-      expect(TIME_INTERVALS.HEAT_ZONE_REGEN_INTERVAL).toBe(5 * 60 * 1000);
+  describe("config.heatZoneRegenIntervalMs", () => {
+    it("should default to 5 minutes in ms (migrated from TIME_INTERVALS)", () => {
+      expect(config.heatZoneRegenIntervalMs).toBe(5 * 60 * 1000);
     });
   });
 

--- a/apps/simulator/src/constants.ts
+++ b/apps/simulator/src/constants.ts
@@ -2,12 +2,6 @@
  * Application-wide constants and configuration values
  */
 
-// Time intervals (in milliseconds)
-export const TIME_INTERVALS = {
-  /** Auto heat zone regeneration interval (5 minutes) */
-  HEAT_ZONE_REGEN_INTERVAL: 5 * 60 * 1000,
-} as const;
-
 // Heat zone generation defaults
 export const HEAT_ZONE_DEFAULTS = {
   /** Default number of heat zones to generate */

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -15,7 +15,6 @@ import type {
   TrafficProfile,
   VehicleDTO,
 } from "../types";
-import { TIME_INTERVALS } from "../constants";
 import { config } from "../utils/config";
 import EventEmitter from "events";
 
@@ -198,7 +197,7 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
       this.incidentManager.on("incident:cleared", this._onIncidentCleared);
     }
 
-    // Automatically regenerate heat zones every 5 minutes.
+    // Automatically regenerate heat zones (config.heatZoneRegenIntervalMs, default 5 minutes).
     // Always clear any timer left over from a previous start() so repeated
     // starts never accumulate intervals.
     if (this.autoHeatZoneInterval) {
@@ -209,7 +208,7 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
     this.autoHeatZoneInterval = setInterval(() => {
       // Generate new heat zones
       this.vehicleManager.getNetwork().generateHeatedZones();
-    }, TIME_INTERVALS.HEAT_ZONE_REGEN_INTERVAL);
+    }, config.heatZoneRegenIntervalMs);
 
     // Wire clock hour:changed to broadcast clock events. Only emit when the
     // clock state is actually present so consumers never receive an undefined

--- a/apps/simulator/src/modules/roadnetwork/SpatialIndex.ts
+++ b/apps/simulator/src/modules/roadnetwork/SpatialIndex.ts
@@ -13,8 +13,9 @@ import type { Node, Edge, POI, BoundingBox } from "../../types";
 import * as utils from "../../utils/helpers";
 import { SPATIAL_GRID } from "../../constants";
 import { rng } from "../../utils/rng";
+import { config } from "../../utils/config";
 
-const SECTORS_N = 10;
+const SECTORS_N = config.sectorsN;
 
 export class SpatialIndex {
   private readonly nodes: Map<string, Node>;

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -132,6 +132,24 @@ const envObjectSchema = z.object({
    * AdapterSyncManager so an unhealthy adapter is still retried periodically.
    */
   MAX_SYNC_BACKOFF_MS: z.coerce.number().int().min(0).default(60_000),
+
+  /**
+   * Size (N x N) of the coarse sector grid SpatialIndex divides the network
+   * bbox into for geographically-uniform random spawn/destination/POI
+   * selection. Higher values give finer geographic uniformity at the cost of
+   * more (smaller) sector buckets.
+   */
+  SECTORS_N: z.coerce.number().int().min(1).default(10),
+
+  /**
+   * How often (ms) HeatZoneManager auto-regenerates heat zones. Bounds how
+   * frequently slowdown polygons shuffle without a redeploy.
+   */
+  HEAT_ZONE_REGEN_INTERVAL_MS: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .default(5 * 60 * 1000),
 });
 
 export const envSchema = envObjectSchema
@@ -187,6 +205,8 @@ function buildConfig(env: EnvConfig) {
     wsGatewayPort: env.WS_GATEWAY_PORT,
     pathfindCooldownMs: env.PATHFIND_COOLDOWN_MS,
     maxSyncBackoffMs: env.MAX_SYNC_BACKOFF_MS,
+    sectorsN: env.SECTORS_N,
+    heatZoneRegenIntervalMs: env.HEAT_ZONE_REGEN_INTERVAL_MS,
   } as const;
 }
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -46,6 +46,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-window": "^1.8.11",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.0"
@@ -59,6 +60,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",

--- a/apps/ui/src/Controls/Vehicles.test.tsx
+++ b/apps/ui/src/Controls/Vehicles.test.tsx
@@ -117,99 +117,101 @@ describe("VehicleList", () => {
     expect(screen.getByText("Route 12.4 km")).toBeInTheDocument();
   });
 
-  describe("virtualization", () => {
+  describe("virtualization (fleetsim-all-k8sz)", () => {
     function makeVehicles(count: number) {
       return Array.from({ length: count }, (_, i) =>
         createVehicle({ id: `v${i}`, name: `Vehicle ${i}`, visible: true })
       );
     }
 
-    it("renders only the first 50 vehicles when given 100+", () => {
-      const vehicles = makeVehicles(120);
+    it("only mounts the visible window of DOM rows for an 800-vehicle fleet, not all 800", () => {
+      const vehicles = makeVehicles(800);
       render(<VehicleList {...defaultProps} vehicles={vehicles} />);
 
-      // First 50 should be rendered
+      // The first vehicle is always within the visible window.
       expect(screen.getByText("Vehicle 0")).toBeInTheDocument();
-      expect(screen.getByText("Vehicle 49")).toBeInTheDocument();
 
-      // Vehicle 50 onward should NOT be rendered
-      expect(screen.queryByText("Vehicle 50")).not.toBeInTheDocument();
-      expect(screen.queryByText("Vehicle 119")).not.toBeInTheDocument();
+      // With jsdom's no-op ResizeObserver, the list falls back to a fixed
+      // measured height, giving a small, bounded visible+overscan window —
+      // nowhere near all 800 rows are mounted as real DOM nodes.
+      const renderedRows = screen.getAllByRole("button", { name: /km\/h/ });
+      expect(renderedRows.length).toBeGreaterThan(0);
+      expect(renderedRows.length).toBeLessThan(100);
+
+      // Vehicles far outside the window are not mounted at all.
+      expect(screen.queryByText("Vehicle 799")).not.toBeInTheDocument();
     });
 
-    it("shows 'Show more' button when more than 50 vehicles", () => {
-      const vehicles = makeVehicles(80);
+    it("renders every vehicle's row content correctly at the top of the list", () => {
+      const vehicles = makeVehicles(800);
       render(<VehicleList {...defaultProps} vehicles={vehicles} />);
 
-      const showMoreButton = screen.getByText(/Show more/);
-      expect(showMoreButton).toBeInTheDocument();
-      expect(showMoreButton).toHaveTextContent("Show more (30 remaining)");
-    });
-
-    it("does not show 'Show more' button when 50 or fewer vehicles", () => {
-      const vehicles = makeVehicles(50);
-      render(<VehicleList {...defaultProps} vehicles={vehicles} />);
-
-      expect(screen.queryByText(/Show more/)).not.toBeInTheDocument();
-    });
-
-    it("clicking 'Show more' renders 50 more vehicles", async () => {
-      const vehicles = makeVehicles(120);
-      const user = userEvent.setup();
-      render(<VehicleList {...defaultProps} vehicles={vehicles} />);
-
-      expect(screen.queryByText("Vehicle 50")).not.toBeInTheDocument();
-
-      await user.click(screen.getByText(/Show more/));
-
-      // Now vehicles 0–99 should be visible
-      expect(screen.getByText("Vehicle 50")).toBeInTheDocument();
-      expect(screen.getByText("Vehicle 99")).toBeInTheDocument();
-
-      // Vehicle 100+ still hidden
-      expect(screen.queryByText("Vehicle 100")).not.toBeInTheDocument();
-    });
-
-    it("'Show more' button shows remaining count", async () => {
-      const vehicles = makeVehicles(130);
-      const user = userEvent.setup();
-      render(<VehicleList {...defaultProps} vehicles={vehicles} />);
-
-      expect(screen.getByText(/Show more/)).toHaveTextContent("Show more (80 remaining)");
-
-      await user.click(screen.getByText(/Show more/));
-
-      expect(screen.getByText(/Show more/)).toHaveTextContent("Show more (30 remaining)");
-    });
-
-    it("resets visible count to 50 when filter changes", () => {
-      const vehicles = makeVehicles(120);
-      const { rerender } = render(<VehicleList {...defaultProps} vehicles={vehicles} filter="" />);
-
-      // Initially 50 visible, show more exists
-      expect(screen.queryByText("Vehicle 50")).not.toBeInTheDocument();
-
-      // Change filter — visible count resets to INITIAL_VISIBLE (50)
-      rerender(<VehicleList {...defaultProps} vehicles={vehicles} filter="Vehicle" />);
-
-      // Still only the first 50 are shown
       expect(screen.getByText("Vehicle 0")).toBeInTheDocument();
-      expect(screen.getByText("Vehicle 49")).toBeInTheDocument();
-      expect(screen.queryByText("Vehicle 50")).not.toBeInTheDocument();
+      // The panel header still reports the true total, even though only a
+      // window of rows is mounted.
+      expect(screen.getByText("800 tracked units")).toBeInTheDocument();
     });
 
-    it("hides 'Show more' button after all vehicles are loaded", async () => {
-      const vehicles = makeVehicles(60);
-      const user = userEvent.setup();
-      render(<VehicleList {...defaultProps} vehicles={vehicles} />);
+    it("scopes down to the matching subset when filtered, without a manual load-more step", () => {
+      const vehicles = makeVehicles(3);
+      render(<VehicleList {...defaultProps} filter="Vehicle 1" vehicles={vehicles} />);
 
-      expect(screen.getByText(/Show more/)).toBeInTheDocument();
+      expect(screen.getByText("Vehicle 1")).toBeInTheDocument();
+    });
+  });
 
-      await user.click(screen.getByText(/Show more/));
+  describe("row memoization (fleetsim-all-k8sz)", () => {
+    it("does not re-render unrelated rows when only one vehicle's data changes", async () => {
+      const vehicles = [
+        createVehicle({ id: "v1", name: "Vehicle A", speed: 40, visible: true }),
+        createVehicle({ id: "v2", name: "Vehicle B", speed: 40, visible: true }),
+        createVehicle({ id: "v3", name: "Vehicle C", speed: 40, visible: true }),
+      ];
 
-      // All 60 now visible, button should disappear
-      expect(screen.queryByText(/Show more/)).not.toBeInTheDocument();
-      expect(screen.getByText("Vehicle 59")).toBeInTheDocument();
+      const { rerender } = render(<VehicleList {...defaultProps} vehicles={vehicles} />);
+
+      const rowBBefore = screen.getByText("Vehicle B").closest("button");
+      const rowCBefore = screen.getByText("Vehicle C").closest("button");
+
+      // Only vehicle A's speed changes; B and C keep identical prop values.
+      const updatedVehicles = [
+        createVehicle({ id: "v1", name: "Vehicle A", speed: 55, visible: true }),
+        createVehicle({ id: "v2", name: "Vehicle B", speed: 40, visible: true }),
+        createVehicle({ id: "v3", name: "Vehicle C", speed: 40, visible: true }),
+      ];
+      rerender(<VehicleList {...defaultProps} vehicles={updatedVehicles} />);
+
+      // Vehicle A's row reflects the new speed.
+      expect(screen.getByText("55")).toBeInTheDocument();
+
+      // B and C's DOM nodes are the same element instances — React.memo
+      // bailed out of re-rendering them since their own props didn't change.
+      expect(screen.getByText("Vehicle B").closest("button")).toBe(rowBBefore);
+      expect(screen.getByText("Vehicle C").closest("button")).toBe(rowCBefore);
+    });
+
+    it("re-renders a row when its own speed changes but keeps unrelated DOM stable across repeated updates", () => {
+      const vehicles = [
+        createVehicle({ id: "v1", name: "Vehicle A", speed: 10, visible: true }),
+        createVehicle({ id: "v2", name: "Vehicle B", speed: 10, visible: true }),
+      ];
+      const { rerender } = render(<VehicleList {...defaultProps} vehicles={vehicles} />);
+
+      const rowBBefore = screen.getByText("Vehicle B").closest("button");
+
+      // Simulate several position/speed ticks on vehicle A only, as the
+      // real-time WS feed would produce.
+      for (const speed of [20, 30, 40, 50]) {
+        const updated = [
+          createVehicle({ id: "v1", name: "Vehicle A", speed, visible: true }),
+          createVehicle({ id: "v2", name: "Vehicle B", speed: 10, visible: true }),
+        ];
+        rerender(<VehicleList {...defaultProps} vehicles={updated} />);
+        expect(screen.getByText(String(speed))).toBeInTheDocument();
+      }
+
+      // Vehicle B's row was never touched across four re-renders of A.
+      expect(screen.getByText("Vehicle B").closest("button")).toBe(rowBBefore);
     });
   });
 });

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -1,14 +1,27 @@
 import { cn } from "@/lib/utils";
-import { useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useMemo } from "react";
+import { FixedSizeList, type ListChildComponentProps } from "react-window";
 import type { Fleet, Vehicle, DispatchAssignment, DirectionResult } from "@/types";
 import { DispatchState } from "@/hooks/useDispatchState";
 import { useDirectionContext } from "@/data/useData";
+import { useResizeObserver } from "@/hooks/useResizeObserver";
 import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
 import { Search } from "@/components/Icons";
 import { Input } from "@/components/ui/input";
 
-const INITIAL_VISIBLE = 50;
-const LOAD_MORE_COUNT = 50;
+// Row height (px) for the virtualized list — must match the rendered row's
+// real height (border + padding + content) since FixedSizeList positions
+// rows by index * ROW_HEIGHT. Includes the row's own bottom margin, which
+// replaces the flex `gap` react-window can't apply between absolutely
+// positioned items.
+const ROW_HEIGHT = 62;
+const ROW_GAP = 6;
+
+// jsdom's ResizeObserver polyfill (src/test/setup.ts) never invokes its
+// callback, so useResizeObserver's measured height stays 0 in tests. Fall
+// back to a fixed height so the list still renders a real virtualized
+// window (and is testable) before a real ResizeObserver fires in the browser.
+const FALLBACK_LIST_HEIGHT = 400;
 
 function SpeedBar({ speed, maxSpeed }: { speed: number; maxSpeed: number }) {
   const width = maxSpeed > 0 ? Math.min((speed / maxSpeed) * 100, 100) : 0;
@@ -93,6 +106,230 @@ function ResultBadge({ result }: { result: DirectionResult }) {
   return <span className={okClass}>Dispatched</span>;
 }
 
+/**
+ * A single vehicle row. Kept as a leaf `React.memo` component with a narrow,
+ * mostly-primitive prop shape so a position/heading tick on ONE vehicle
+ * (which changes `vehicles` array identity in the parent) does not force
+ * every other row to re-render — only the row whose own props actually
+ * changed re-renders.
+ */
+interface VehicleRowProps {
+  id: string;
+  name: string;
+  type: string;
+  speed: number;
+  maxSpeed: number;
+  routeDistance: number | undefined;
+  fleetColor: string | undefined;
+  isChecked: boolean;
+  isRowSelected: boolean;
+  showCheckbox: boolean;
+  isDispatch: boolean;
+  isResults: boolean;
+  isRouteState: boolean;
+  assignment: DispatchAssignment | undefined;
+  result: DirectionResult | undefined;
+  style: React.CSSProperties;
+  onSelect: (id: string) => void;
+  onToggleForDispatch: ((id: string) => void) | undefined;
+  onHover: (id: string) => void;
+  onUnhover: () => void;
+}
+
+const VehicleRow = memo(function VehicleRow({
+  id,
+  name,
+  type,
+  speed,
+  maxSpeed,
+  routeDistance,
+  fleetColor,
+  isChecked,
+  isRowSelected,
+  showCheckbox,
+  isDispatch,
+  isResults,
+  isRouteState,
+  assignment,
+  result,
+  style,
+  onSelect,
+  onToggleForDispatch,
+  onHover,
+  onUnhover,
+}: VehicleRowProps) {
+  const isSelected = !showCheckbox && !isResults && isRowSelected;
+  const isDispatchSelected = showCheckbox && isChecked;
+
+  const handleClick = () => {
+    if (showCheckbox && onToggleForDispatch) {
+      onToggleForDispatch(id);
+    } else if (!isDispatch) {
+      onSelect(id);
+    }
+  };
+
+  return (
+    <div style={style} className="px-px">
+      <button
+        className={cn(
+          "grid h-full w-full flex-shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-0.5 overflow-hidden rounded-md border border-white/5 bg-white/[0.03] px-2.5 pb-1.5 pt-2 text-left transition-colors duration-fast ease-standard hover:border-white/10 hover:bg-white/[0.06] focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          isSelected && "border-accent/25 bg-accent/10 shadow-[inset_2px_0_0_var(--color-accent)]",
+          isDispatchSelected &&
+            "border-accent/20 bg-accent/5 shadow-[inset_3px_0_0_var(--color-accent)]"
+        )}
+        style={{
+          gridTemplateAreas: '"name speed" "route route" "bar bar"',
+        }}
+        type="button"
+        onClick={handleClick}
+        onMouseEnter={() => onHover(id)}
+        onMouseLeave={() => onUnhover()}
+        aria-pressed={showCheckbox ? isChecked : isRowSelected}
+        aria-label={`${name}, ${Math.round(speed)} km/h, ${formatRouteDistance(routeDistance)}`}
+        title={`${name} · ${Math.round(speed)} km/h · ${formatRouteDistance(routeDistance)}`}
+      >
+        <span className="flex min-w-0 items-center gap-2" style={{ gridArea: "name" }}>
+          {showCheckbox ? (
+            <span
+              role="checkbox"
+              aria-checked={isChecked}
+              aria-label={`Select ${name}`}
+              className={cn(
+                "size-3.5 flex-shrink-0 rounded-sm border border-foreground/25 transition-colors duration-fast ease-standard",
+                isChecked && "border-accent bg-accent"
+              )}
+            />
+          ) : (
+            <span
+              className="size-2 flex-shrink-0 rounded-full"
+              style={{ backgroundColor: fleetColor ?? "transparent" }}
+            />
+          )}
+          <span className="min-w-0 self-center truncate text-[13px] font-medium text-foreground">
+            {name}
+          </span>
+          {type && type !== "car" && (
+            <span className="ml-2 rounded-sm bg-foreground/10 px-2 py-px text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {VEHICLE_TYPE_LABELS[type] ?? type}
+            </span>
+          )}
+        </span>
+        <span
+          className="flex flex-shrink-0 items-baseline gap-1 justify-self-end text-[13px] font-medium tabular-nums text-foreground"
+          style={{ gridArea: "speed" }}
+        >
+          {Math.round(speed)}
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">km/h</span>
+          {isRouteState && assignment && (
+            <>
+              {" "}
+              <WaypointBadge assignment={assignment} />
+            </>
+          )}
+          {isResults && result && (
+            <>
+              {" "}
+              <ResultBadge result={result} />
+            </>
+          )}
+        </span>
+        <span className="flex items-center gap-3" style={{ gridArea: "route" }}>
+          <span className="text-xs text-muted-foreground">
+            {formatRouteDistance(routeDistance)}
+          </span>
+        </span>
+        <SpeedBar speed={speed} maxSpeed={maxSpeed} />
+      </button>
+    </div>
+  );
+});
+
+interface RowData {
+  vehicles: Vehicle[];
+  directions: ReturnType<typeof useDirectionContext>["directions"];
+  vehicleFleetMap: Map<string, Fleet>;
+  selectedForDispatchSet: Set<string>;
+  assignments: DispatchAssignment[] | undefined;
+  results: DirectionResult[] | undefined;
+  selectedId: string | undefined;
+  maxSpeed: number;
+  showCheckbox: boolean;
+  isDispatch: boolean;
+  isResults: boolean;
+  isRouteState: boolean;
+  onSelectVehicle: (id: string) => void;
+  onToggleVehicleForDispatch: ((id: string) => void) | undefined;
+  onHoverVehicle: (id: string) => void;
+  onUnhoverVehicle: () => void;
+}
+
+/**
+ * Row renderer handed to `FixedSizeList`. Derives per-row values from the
+ * shared `itemData` and forwards a narrow, primitive prop set to the memoized
+ * `VehicleRow` so unrelated vehicle updates don't force a re-render here.
+ */
+function Row({ index, style, data }: ListChildComponentProps<RowData>) {
+  const {
+    vehicles,
+    directions,
+    vehicleFleetMap,
+    selectedForDispatchSet,
+    assignments,
+    results,
+    selectedId,
+    maxSpeed,
+    showCheckbox,
+    isDispatch,
+    isResults,
+    isRouteState,
+    onSelectVehicle,
+    onToggleVehicleForDispatch,
+    onHoverVehicle,
+    onUnhoverVehicle,
+  } = data;
+
+  const vehicle = vehicles[index];
+  const routeDistance = directions.get(vehicle.id)?.route.distance;
+  const vehicleFleet = vehicleFleetMap.get(vehicle.id);
+  const isChecked = selectedForDispatchSet.has(vehicle.id);
+  const assignment = assignments?.find((a) => a.vehicleId === vehicle.id);
+  const result = results?.find((r) => r.vehicleId === vehicle.id);
+
+  // Inset the row within its slot to reproduce the previous flex `gap`
+  // spacing, which react-window's absolutely-positioned items don't get.
+  const insetStyle: React.CSSProperties = {
+    ...style,
+    top: (style.top as number) + ROW_GAP / 2,
+    height: (style.height as number) - ROW_GAP,
+  };
+
+  return (
+    <VehicleRow
+      id={vehicle.id}
+      name={vehicle.name}
+      type={vehicle.type}
+      speed={vehicle.speed}
+      maxSpeed={maxSpeed}
+      routeDistance={routeDistance}
+      fleetColor={vehicleFleet?.color}
+      isChecked={isChecked}
+      isRowSelected={selectedId === vehicle.id}
+      showCheckbox={showCheckbox}
+      isDispatch={isDispatch}
+      isResults={isResults}
+      isRouteState={isRouteState}
+      assignment={assignment}
+      result={result}
+      style={insetStyle}
+      onSelect={onSelectVehicle}
+      onToggleForDispatch={onToggleVehicleForDispatch}
+      onHover={onHoverVehicle}
+      onUnhover={onUnhoverVehicle}
+    />
+  );
+}
+
 export default function VehicleList({
   filter,
   vehicles,
@@ -110,7 +347,7 @@ export default function VehicleList({
   results,
 }: VehicleListProps) {
   const { directions } = useDirectionContext();
-  const visibleVehicles = vehicles.filter((v) => v.visible);
+  const visibleVehicles = useMemo(() => vehicles.filter((v) => v.visible), [vehicles]);
 
   // O(1) membership test per row instead of array.includes() per row.
   const selectedForDispatchSet = useMemo(
@@ -118,18 +355,56 @@ export default function VehicleList({
     [selectedForDispatch]
   );
 
-  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
-  useEffect(() => {
-    setVisibleCount(INITIAL_VISIBLE);
-  }, [filter]);
-  const slicedVehicles = visibleVehicles.slice(0, visibleCount);
-  const hasMore = visibleVehicles.length > visibleCount;
-
   const isSelectOrRoute =
     dispatchState === DispatchState.SELECT || dispatchState === DispatchState.ROUTE;
   const isDispatch = dispatchState === DispatchState.DISPATCH;
   const isResults = dispatchState === DispatchState.RESULTS;
   const showCheckbox = isSelectOrRoute || isDispatch;
+  const isRouteState = dispatchState === DispatchState.ROUTE;
+
+  const [listRef, listSize] = useResizeObserver();
+  const listHeight = listSize.height > 0 ? listSize.height : FALLBACK_LIST_HEIGHT;
+
+  const itemKey = useCallback((index: number, data: RowData) => data.vehicles[index].id, []);
+
+  const itemData: RowData = useMemo(
+    () => ({
+      vehicles: visibleVehicles,
+      directions,
+      vehicleFleetMap,
+      selectedForDispatchSet,
+      assignments,
+      results,
+      selectedId,
+      maxSpeed,
+      showCheckbox,
+      isDispatch,
+      isResults,
+      isRouteState,
+      onSelectVehicle,
+      onToggleVehicleForDispatch,
+      onHoverVehicle,
+      onUnhoverVehicle,
+    }),
+    [
+      visibleVehicles,
+      directions,
+      vehicleFleetMap,
+      selectedForDispatchSet,
+      assignments,
+      results,
+      selectedId,
+      maxSpeed,
+      showCheckbox,
+      isDispatch,
+      isResults,
+      isRouteState,
+      onSelectVehicle,
+      onToggleVehicleForDispatch,
+      onHoverVehicle,
+      onUnhoverVehicle,
+    ]
+  );
 
   return (
     <>
@@ -145,6 +420,7 @@ export default function VehicleList({
 
       <PanelBody
         padded={false}
+        scrollable={false}
         className={cn("gap-1.5 p-3", isDispatch && "pointer-events-none opacity-60")}
       >
         <div className="relative flex items-center">
@@ -176,110 +452,19 @@ export default function VehicleList({
             {filter ? `No vehicles match "${filter}"` : "No vehicles"}
           </PanelEmptyState>
         ) : (
-          slicedVehicles.map((vehicle) => {
-            const routeDistance = directions.get(vehicle.id)?.route.distance;
-            const vehicleFleet = vehicleFleetMap.get(vehicle.id);
-            const isChecked = selectedForDispatchSet.has(vehicle.id);
-            const assignment = assignments?.find((a) => a.vehicleId === vehicle.id);
-            const result = results?.find((r) => r.vehicleId === vehicle.id);
-            const isRowSelected = selectedId === vehicle.id;
-            const isSelected = !showCheckbox && !isResults && isRowSelected;
-            const isDispatchSelected = showCheckbox && isChecked;
-
-            const handleClick = () => {
-              if (showCheckbox && onToggleVehicleForDispatch) {
-                onToggleVehicleForDispatch(vehicle.id);
-              } else if (!isDispatch) {
-                onSelectVehicle(vehicle.id);
-              }
-            };
-
-            return (
-              <button
-                key={vehicle.id}
-                className={cn(
-                  "grid w-full flex-shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-0.5 overflow-hidden rounded-md border border-white/5 bg-white/[0.03] px-2.5 pb-1.5 pt-2 text-left transition-colors duration-fast ease-standard hover:border-white/10 hover:bg-white/[0.06] focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
-                  isSelected &&
-                    "border-accent/25 bg-accent/10 shadow-[inset_2px_0_0_var(--color-accent)]",
-                  isDispatchSelected &&
-                    "border-accent/20 bg-accent/5 shadow-[inset_3px_0_0_var(--color-accent)]"
-                )}
-                style={{
-                  gridTemplateAreas: '"name speed" "route route" "bar bar"',
-                }}
-                type="button"
-                onClick={handleClick}
-                onMouseEnter={() => onHoverVehicle(vehicle.id)}
-                onMouseLeave={() => onUnhoverVehicle()}
-                aria-pressed={showCheckbox ? isChecked : isRowSelected}
-                aria-label={`${vehicle.name}, ${Math.round(vehicle.speed)} km/h, ${formatRouteDistance(routeDistance)}`}
-                title={`${vehicle.name} · ${Math.round(vehicle.speed)} km/h · ${formatRouteDistance(routeDistance)}`}
-              >
-                <span className="flex min-w-0 items-center gap-2" style={{ gridArea: "name" }}>
-                  {showCheckbox ? (
-                    <span
-                      role="checkbox"
-                      aria-checked={isChecked}
-                      aria-label={`Select ${vehicle.name}`}
-                      className={cn(
-                        "size-3.5 flex-shrink-0 rounded-sm border border-foreground/25 transition-colors duration-fast ease-standard",
-                        isChecked && "border-accent bg-accent"
-                      )}
-                    />
-                  ) : (
-                    <span
-                      className="size-2 flex-shrink-0 rounded-full"
-                      style={{ backgroundColor: vehicleFleet?.color ?? "transparent" }}
-                    />
-                  )}
-                  <span className="min-w-0 self-center truncate text-[13px] font-medium text-foreground">
-                    {vehicle.name}
-                  </span>
-                  {vehicle.type && vehicle.type !== "car" && (
-                    <span className="ml-2 rounded-sm bg-foreground/10 px-2 py-px text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      {VEHICLE_TYPE_LABELS[vehicle.type] ?? vehicle.type}
-                    </span>
-                  )}
-                </span>
-                <span
-                  className="flex flex-shrink-0 items-baseline gap-1 justify-self-end text-[13px] font-medium tabular-nums text-foreground"
-                  style={{ gridArea: "speed" }}
-                >
-                  {Math.round(vehicle.speed)}
-                  <span className="text-xs uppercase tracking-wide text-muted-foreground">
-                    km/h
-                  </span>
-                  {dispatchState === DispatchState.ROUTE && assignment && (
-                    <>
-                      {" "}
-                      <WaypointBadge assignment={assignment} />
-                    </>
-                  )}
-                  {isResults && result && (
-                    <>
-                      {" "}
-                      <ResultBadge result={result} />
-                    </>
-                  )}
-                </span>
-                <span className="flex items-center gap-3" style={{ gridArea: "route" }}>
-                  <span className="text-xs text-muted-foreground">
-                    {formatRouteDistance(routeDistance)}
-                  </span>
-                </span>
-                <SpeedBar speed={vehicle.speed} maxSpeed={maxSpeed} />
-              </button>
-            );
-          })
-        )}
-        {hasMore && (
-          <button
-            type="button"
-            className="w-full rounded-md border border-dashed border-accent/20 p-2 text-xs text-accent transition-colors duration-fast ease-standard hover:border-accent/35 hover:bg-accent/5"
-            onClick={() => setVisibleCount((c) => c + LOAD_MORE_COUNT)}
-          >
-            Show more ({visibleVehicles.length - visibleCount} remaining)
-          </button>
+          <div ref={listRef} className="min-h-0 flex-1">
+            <FixedSizeList
+              height={listHeight}
+              width="100%"
+              itemCount={visibleVehicles.length}
+              itemSize={ROW_HEIGHT}
+              itemKey={itemKey}
+              itemData={itemData}
+              overscanCount={6}
+            >
+              {Row}
+            </FixedSizeList>
+          </div>
         )}
       </PanelBody>
     </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,6 +172,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-window": "^1.8.11",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.0"
@@ -185,6 +186,7 @@
         "@types/node": "^26.0.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/react-window": "^1.8.8",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/ui": "^4.1.9",
@@ -12433,6 +12435,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -16783,6 +16795,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -18088,6 +18106,23 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readable-stream": {


### PR DESCRIPTION
## Summary

Three follow-ups from the recent performance and quality review:

- **UI**: virtualize the vehicles panel so large fleets don't force a full list re-render on every update
- **Simulator**: finish moving hardcoded tunables into validated config
- **Simulator**: document and load-test the existing Redis WS gateway path for high client counts

`fleetsim-all-pv8l` (SharedArrayBuffer-backed pathfinding graph) and `fleetsim-all-0oxv` (binary WS payload protocol) are out of scope. Both need a concrete scale target before the added complexity is worth it.

### Virtualize vehicles panel (fleetsim-all-k8sz)

`apps/ui/src/Controls/Vehicles.tsx` capped initial render (`INITIAL_VISIBLE=50`) but still reconciled the full vehicle array on every update, with unmemoized rows. That's fine at around 70 vehicles but becomes a bottleneck past 800.

- No virtualization library existed anywhere in the monorepo, so this adds `react-window` (^1.8.11) and `@types/react-window` as new dependencies. It's the lightest-weight standard option for windowed lists.
- Replaced the manual "load more" pagination with `FixedSizeList`, so only the visible window plus overscan mounts as real DOM nodes, regardless of fleet size.
- Extracted the row into a memoized `VehicleRow` with a narrow, mostly-primitive prop shape (id, name, type, speed, etc. rather than the whole `Vehicle` object), so updating one vehicle no longer forces every other row to re-render.
- Scroll-container height is measured via the existing `useResizeObserver` hook, with a fixed 400px fallback since jsdom's `ResizeObserver` polyfill never fires its callback. That keeps the list deterministically testable.

### Finish config centralization (fleetsim-all-9wyo)

Moved the two tunables left out of a previous config-centralization pass into the Zod-validated `config.ts` schema, following the same pattern as `PATHFIND_COOLDOWN_MS` and `MAX_SYNC_BACKOFF_MS`:

- `SECTORS_N` (`SpatialIndex.ts:17`) becomes `config.sectorsN` (env `SECTORS_N`, default `10`, unchanged)
- `TIME_INTERVALS.HEAT_ZONE_REGEN_INTERVAL` (`constants.ts`) becomes `config.heatZoneRegenIntervalMs` (env `HEAT_ZONE_REGEN_INTERVAL_MS`, default `300000` ms / 5 minutes, unchanged)

Also updated `.env.example` and the README config table, which was missing `PATHFIND_COOLDOWN_MS` and `MAX_SYNC_BACKOFF_MS` from the prior pass, plus schema default/validation tests and `constants.test.ts`.

### Document and load-test the Redis WS gateway (fleetsim-all-7ksg)

No new fanout code, as scoped. Adds a "Scaling WebSocket Clients" section to `apps/simulator/README.md` covering when to enable `WS_TRANSPORT=redis`, what it requires (a Redis instance, env vars, the standalone `ws-gateway.ts` process), and the load-test results below.

Adds `src/__tests__/ClientFanoutLoad.test.ts`, a Vitest perf test (same style and mocking boundary as `WebSocketBroadcaster.test.ts`, no real sockets or external Redis) exercising `ClientFanout.fanoutVehicles` directly at increasing synthetic client counts against a fixed 70-vehicle fleet:

| Clients | Per-flush time (mocked) |
| ------- | ------------------------ |
| 10      | ~0.17 ms                 |
| 50      | ~0.64 ms                 |
| 100     | ~1.29 ms                 |
| 200     | ~2.11 ms                 |
| 500     | ~5.64 ms                 |

Scales linearly with client count, as expected for the O(clients x vehicles) design. These are mocked-send numbers with no real socket I/O, so treat them as a lower bound: real deployments will run higher. Even so, 500 clients costs under 6ms against a 100ms (10Hz) flush budget.

**Recommendation:** stay on `WS_TRANSPORT=inprocess` (default) below roughly 200 concurrent clients, monitor `/metrics` between roughly 200 and 500, and switch to `WS_TRANSPORT=redis` plus the standalone gateway above roughly 500 concurrent clients, or sooner if the sim thread shows WS-flush-correlated event-loop lag.

## Test plan

- [x] `apps/simulator`: `npm run type-check` passes
- [x] `apps/simulator`: `npm test` passes, 1624/1624, including `PerfBudget.test.ts` and `VehicleManagerPerf.test.ts`
- [x] `apps/simulator`: `npm run format:check` passes
- [x] `apps/ui`: `npm run type-check` passes
- [x] `apps/ui`: `npm test` passes, 792/792
- [x] `apps/ui`: `npm run format:check` passes
- [x] New tests: `Vehicles.test.tsx` (row memoization and 800-vehicle virtualization window), `ClientFanoutLoad.test.ts` (WS fanout scaling), `config.test.ts` / `constants.test.ts` (new config fields)

References: fleetsim-all-k8sz, fleetsim-all-9wyo, fleetsim-all-7ksg