### PR TITLE
feat(ui): professional map interaction, overlay, and visual polish pass

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -130,6 +130,12 @@ export default function App() {
   // (which would discard deck.gl's in-flight enter/color transitions).
   const onPOIClick = useCallback((poi: POI) => setSelectedItem(poi), [setSelectedItem]);
 
+  // Canvas hover on a vehicle mirrors the sidebar list's onMouseEnter/Leave pair.
+  const onHoverMapVehicle = useCallback(
+    (id: string | undefined) => (id ? onHoverVehicle(id) : onUnhoverVehicle()),
+    [onHoverVehicle, onUnhoverVehicle]
+  );
+
   // ─── WebSocket connection / simulation status ───────────────────
   const { connected, status } = useSimulationConnection({
     setVehicles,
@@ -314,6 +320,8 @@ export default function App() {
               onMapClick={onMapClick}
               onMapContextClick={onMapContextClick}
               onPOIClick={onPOIClick}
+              onHoverVehicle={onHoverMapVehicle}
+              onEscape={resetSelection}
               vehicleFleetMap={vehicleFleetMap}
               hiddenFleetIds={hiddenFleetIds}
               hiddenVehicleTypes={hiddenVehicleTypes}

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -136,6 +136,16 @@ export default function App() {
     [onHoverVehicle, onUnhoverVehicle]
   );
 
+  // Escape-to-deselect defers entirely to dispatch mode / geofence drawing —
+  // both already own Escape via their own window-level shortcut handlers
+  // (useDispatchShortcuts, GeofenceDrawTool), which fire independently of
+  // this one; without this guard a single Escape press while the map has
+  // focus would both exit that mode AND clear the current selection.
+  const onMapEscape = useCallback(() => {
+    if (dispatch.dispatchMode || geofences.drawingActive) return;
+    resetSelection();
+  }, [dispatch.dispatchMode, geofences.drawingActive, resetSelection]);
+
   // ─── WebSocket connection / simulation status ───────────────────
   const { connected, status } = useSimulationConnection({
     setVehicles,
@@ -321,7 +331,7 @@ export default function App() {
               onMapContextClick={onMapContextClick}
               onPOIClick={onPOIClick}
               onHoverVehicle={onHoverMapVehicle}
-              onEscape={resetSelection}
+              onEscape={onMapEscape}
               vehicleFleetMap={vehicleFleetMap}
               hiddenFleetIds={hiddenFleetIds}
               hiddenVehicleTypes={hiddenVehicleTypes}

--- a/apps/ui/src/Controls/Fleets.tsx
+++ b/apps/ui/src/Controls/Fleets.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import type { Fleet, Vehicle } from "@/types";
 import { Button, SquaredButton } from "@/components/Inputs";
 import { Input } from "@/components/ui/input";
+import { LayersIcon } from "@/components/Icons";
 import {
   PanelBadge,
   PanelBody,
@@ -86,13 +87,13 @@ export default function Fleets({
         {error ? <PanelErrorState>{error}</PanelErrorState> : null}
         {fleets.length < 10 ? (
           <div className="flex justify-end">
-            <Button size="sm" onClick={() => setIsAdding(true)} type="button">
+            <Button size="sm" variant="default" onClick={() => setIsAdding(true)} type="button">
               + New
             </Button>
           </div>
         ) : null}
         {fleets.length === 0 && !isAdding && !error ? (
-          <PanelEmptyState>No fleets defined</PanelEmptyState>
+          <PanelEmptyState icon={<LayersIcon />}>No fleets defined</PanelEmptyState>
         ) : null}
 
         <div className="flex flex-col gap-2">
@@ -109,7 +110,7 @@ export default function Fleets({
             return (
               <div
                 key={fleet.id}
-                className="flex flex-col overflow-hidden rounded-md border border-white/5 bg-white/[0.03] transition-colors duration-fast ease-standard hover:border-white/10"
+                className="flex flex-col overflow-hidden rounded-md border border-border-soft bg-white/[0.03] transition-colors duration-fast ease-standard hover:border-border"
               >
                 <button
                   type="button"

--- a/apps/ui/src/Controls/GeofencePanel.tsx
+++ b/apps/ui/src/Controls/GeofencePanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { GeoFence, GeoFenceEvent } from "@moveet/shared-types";
 import { Switch, SquaredButton } from "@/components/Inputs";
 import { cn } from "@/lib/utils";
+import { GeofenceIcon } from "@/components/Icons";
 import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
 
 interface GeofencePanelProps {
@@ -145,7 +146,7 @@ export default function GeofencePanel({
           ) : (
             <button
               type="button"
-              className="w-full rounded-md border border-white/5 bg-white/[0.03] px-3 py-2 text-left text-sm font-medium text-muted-foreground transition-colors duration-fast ease-standard hover:border-accent/35 hover:bg-accent/10 hover:text-foreground"
+              className="w-full rounded-md surface-accent px-3 py-2 text-left text-sm font-medium text-primary-foreground shadow-raised transition-[transform,background-color,box-shadow,color] duration-fast ease-standard hover:shadow-glow-accent active:scale-[0.98]"
               onClick={onStartDrawing}
               title="Draw a geofence zone on the map"
             >
@@ -154,7 +155,7 @@ export default function GeofencePanel({
           )}
 
           {fences.length === 0 ? (
-            <PanelEmptyState>
+            <PanelEmptyState icon={<GeofenceIcon />}>
               No zones yet. Use the &ldquo;Draw Zone&rdquo; button above to create one.
             </PanelEmptyState>
           ) : (
@@ -162,7 +163,7 @@ export default function GeofencePanel({
               {fences.map((fence) => (
                 <div
                   key={fence.id}
-                  className="flex items-center gap-2 rounded-md border border-white/5 bg-white/[0.03] px-2.5 py-2 transition-colors duration-fast ease-standard hover:border-white/10 hover:bg-white/[0.06]"
+                  className="flex items-center gap-2 rounded-md border border-border-soft bg-white/[0.03] px-2.5 py-2 transition-colors duration-fast ease-standard hover:border-border hover:bg-white/[0.06]"
                 >
                   <span
                     className="h-2 w-2 flex-shrink-0 rounded-full"
@@ -206,7 +207,7 @@ export default function GeofencePanel({
       {tab === "alerts" && (
         <PanelBody className="gap-3">
           {alerts.length === 0 ? (
-            <PanelEmptyState>
+            <PanelEmptyState icon={<GeofenceIcon />}>
               No events yet. Events appear when vehicles cross zone boundaries.
             </PanelEmptyState>
           ) : (
@@ -214,7 +215,7 @@ export default function GeofencePanel({
               {alerts.map((alert, i) => (
                 <div
                   key={`${alert.fenceId}-${alert.vehicleId}-${alert.timestamp}-${i}`}
-                  className="flex items-center gap-3 rounded-md border border-white/5 bg-white/[0.03] px-2.5 py-2"
+                  className="flex items-center gap-3 rounded-md border border-border-soft bg-white/[0.03] px-2.5 py-2"
                 >
                   <span
                     data-event={alert.event}

--- a/apps/ui/src/Controls/IconRail.tsx
+++ b/apps/ui/src/Controls/IconRail.tsx
@@ -75,7 +75,8 @@ export default function IconRail({ activePanel, onPanelChange, incidentCount }: 
   return (
     <nav
       className={cn(
-        "z-[31] flex w-14 flex-shrink-0 flex-col items-center gap-2 border-r border-border surface-raised py-3",
+        "z-[31] flex w-14 flex-shrink-0 flex-col items-center gap-2 border-r border-border-soft surface-raised py-3",
+        "shadow-[4px_0_16px_-8px_rgba(0,0,0,0.5)]",
         "pointer-events-none -translate-x-4 opacity-0 transition-[opacity,transform] duration-700 ease-emphasized",
         "[[data-ready]_&]:pointer-events-auto [[data-ready]_&]:translate-x-0 [[data-ready]_&]:opacity-100"
       )}

--- a/apps/ui/src/Controls/Incidents.tsx
+++ b/apps/ui/src/Controls/Incidents.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { IncidentDTO, IncidentType } from "@/types";
 import { Switch, SquaredButton } from "@/components/Inputs";
+import { AlertIcon } from "@/components/Icons";
 import {
   PanelBadge,
   PanelBody,
@@ -90,7 +91,9 @@ export default function Incidents({ incidents, createRandom, remove, error }: In
           </label>
           <SquaredButton
             icon={<span aria-hidden="true">+</span>}
-            variant="surface"
+            variant="ghost"
+            tone="active"
+            active
             aria-label="Create incident"
             title="Create incident"
             onClick={createRandom}
@@ -98,14 +101,14 @@ export default function Incidents({ incidents, createRandom, remove, error }: In
         </div>
         {error ? <PanelErrorState>{error}</PanelErrorState> : null}
         {incidents.length === 0 && !error ? (
-          <PanelEmptyState>No active incidents</PanelEmptyState>
+          <PanelEmptyState icon={<AlertIcon />}>No active incidents</PanelEmptyState>
         ) : null}
 
         <div className="flex flex-col gap-2">
           {incidents.map((incident) => (
             <div
               key={incident.id}
-              className="flex items-center gap-3 rounded-md border border-white/5 bg-white/[0.03] px-2.5 py-2 transition-colors duration-fast ease-standard hover:bg-white/[0.06]"
+              className="flex items-center gap-3 rounded-md border border-border-soft bg-white/[0.03] px-2.5 py-2 transition-colors duration-fast ease-standard hover:bg-white/[0.06]"
             >
               <span
                 className="h-2.5 w-2.5 flex-shrink-0 rounded-full"

--- a/apps/ui/src/Controls/PanelPrimitives.tsx
+++ b/apps/ui/src/Controls/PanelPrimitives.tsx
@@ -41,7 +41,10 @@ export function PanelHeader({
   const TitleTag = titleAs;
 
   return (
-    <div {...props} className={cn("flex-shrink-0 border-b border-border px-3 py-2.5", className)}>
+    <div
+      {...props}
+      className={cn("flex-shrink-0 border-b border-border-soft px-3 py-3", className)}
+    >
       {eyebrow ? (
         <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
           {eyebrow}
@@ -118,18 +121,26 @@ export function PanelBadge({ children, tone = "active", className, ...props }: P
 
 interface PanelEmptyStateProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
+  /** Optional glyph shown above the message — give each panel its own
+   * identity instead of every empty state looking identical. */
+  icon?: ReactNode;
 }
 
-export function PanelEmptyState({ children, className, ...props }: PanelEmptyStateProps) {
+export function PanelEmptyState({ children, icon, className, ...props }: PanelEmptyStateProps) {
   return (
     <div
       {...props}
       className={cn(
-        "rounded-md border border-dashed border-border bg-muted/40 p-3 text-center text-xs leading-relaxed text-muted-foreground",
+        "flex flex-col items-center gap-2.5 rounded-lg border border-border-soft surface-raised px-4 py-6 text-center shadow-raised",
         className
       )}
     >
-      {children}
+      {icon ? (
+        <span className="flex size-9 items-center justify-center rounded-full bg-muted text-muted-foreground [&_svg]:size-4">
+          {icon}
+        </span>
+      ) : null}
+      <p className="text-xs leading-relaxed text-muted-foreground">{children}</p>
     </div>
   );
 }
@@ -148,7 +159,7 @@ export function PanelLoadingState({ children, className, ...props }: PanelLoadin
       role="status"
       aria-live="polite"
       className={cn(
-        "flex items-center justify-center gap-2 rounded-md border border-dashed border-border bg-muted/40 p-3 text-center text-xs leading-relaxed text-muted-foreground",
+        "flex items-center justify-center gap-2 rounded-lg border border-border-soft surface-raised p-3 text-center text-xs leading-relaxed text-muted-foreground shadow-raised",
         className
       )}
     >
@@ -172,7 +183,7 @@ export function PanelErrorState({ children, className, ...props }: PanelErrorSta
       {...props}
       role="alert"
       className={cn(
-        "rounded-md border border-dashed border-status-error/40 bg-status-error/10 p-3 text-center text-xs leading-relaxed text-status-error",
+        "rounded-lg border border-status-error/25 bg-status-error/10 p-3 text-center text-xs leading-relaxed text-status-error shadow-raised",
         className
       )}
     >

--- a/apps/ui/src/Controls/RecordReplay.tsx
+++ b/apps/ui/src/Controls/RecordReplay.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/Inputs";
 import { cn } from "@/lib/utils";
 import client from "@/utils/client";
+import { RecordCircleIcon } from "@/components/Icons";
 import {
   emitRecording,
   getEmitStatus,
@@ -199,7 +200,7 @@ export default function RecordReplay({
       <PanelBody className="gap-4">
         {/* ── Generate historical ── */}
         <PanelSectionLabel>Generate historical</PanelSectionLabel>
-        <div className="flex flex-col gap-3 rounded-md border border-white/5 bg-white/[0.03] p-3">
+        <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-white/[0.03] p-3">
           <label className={fieldClass}>
             <span className={fieldLabelClass}>Start</span>
             <Input
@@ -265,6 +266,7 @@ export default function RecordReplay({
             </label>
           </div>
           <Button
+            variant="default"
             size="sm"
             onClick={handleGenerate}
             isDisabled={generating}
@@ -303,7 +305,7 @@ export default function RecordReplay({
         </div>
 
         {playableRecordings.length === 0 ? (
-          <PanelEmptyState>No recordings yet</PanelEmptyState>
+          <PanelEmptyState icon={<RecordCircleIcon />}>No recordings yet</PanelEmptyState>
         ) : (
           <div className="flex flex-col gap-2">
             {playableRecordings.map((file) => {
@@ -313,7 +315,7 @@ export default function RecordReplay({
                 <div
                   key={file.fileName}
                   className={cn(
-                    "flex flex-col gap-2 rounded-md border border-white/5 bg-white/[0.03] px-2.5 py-2 transition-colors duration-fast ease-standard hover:bg-white/[0.06] hover:border-white/10",
+                    "flex flex-col gap-2 rounded-md border border-border-soft bg-white/[0.03] px-2.5 py-2 transition-colors duration-fast ease-standard hover:bg-white/[0.06] hover:border-border",
                     isActive && "border-accent/25 bg-accent/10 hover:border-accent/25"
                   )}
                 >
@@ -434,6 +436,7 @@ function EmitControl({ recording }: EmitControlProps) {
         <span>Realism</span>
       </label>
       <Button
+        variant="default"
         size="sm"
         onClick={handleEmit}
         isDisabled={emitting || !canEmit}

--- a/apps/ui/src/Controls/ScenariosPanel.tsx
+++ b/apps/ui/src/Controls/ScenariosPanel.tsx
@@ -10,7 +10,7 @@ import {
   PanelSectionLabel,
 } from "./PanelPrimitives";
 import { Button } from "@/components/Inputs";
-import { Play, Pause, Stop } from "@/components/Icons";
+import { Play, Pause, Stop, ScenarioIcon } from "@/components/Icons";
 
 interface LogEntry {
   time: number;
@@ -193,7 +193,7 @@ export default function ScenariosPanel() {
 
             <div className="flex gap-2 py-1">
               {status.state === "idle" && (
-                <Button onClick={startScenario} aria-label="Start scenario">
+                <Button variant="default" onClick={startScenario} aria-label="Start scenario">
                   <Play className={controlIconClass} />
                   Start
                 </Button>
@@ -205,7 +205,7 @@ export default function ScenariosPanel() {
                 </Button>
               )}
               {isPaused && (
-                <Button onClick={startScenario} aria-label="Resume scenario">
+                <Button variant="default" onClick={startScenario} aria-label="Resume scenario">
                   <Play className={controlIconClass} />
                   Resume
                 </Button>
@@ -297,7 +297,7 @@ export default function ScenariosPanel() {
         {/* ── Available scenarios list ── */}
         <PanelSectionLabel>Available</PanelSectionLabel>
         {scenarios.length === 0 ? (
-          <PanelEmptyState>No scenarios found</PanelEmptyState>
+          <PanelEmptyState icon={<ScenarioIcon />}>No scenarios found</PanelEmptyState>
         ) : (
           <div className="flex flex-col gap-2">
             {scenarios.map((file) => {
@@ -307,7 +307,7 @@ export default function ScenariosPanel() {
                   key={file.fileName}
                   type="button"
                   className={cn(
-                    "flex w-full flex-wrap items-center gap-3 rounded-md border border-white/5 bg-white/[0.03] px-2.5 py-2 text-left transition-colors duration-fast ease-standard hover:border-white/10 hover:bg-white/[0.06] disabled:cursor-default disabled:opacity-60",
+                    "flex w-full flex-wrap items-center gap-3 rounded-md border border-border-soft bg-white/[0.03] px-2.5 py-2 text-left transition-colors duration-fast ease-standard hover:border-border hover:bg-white/[0.06] disabled:cursor-default disabled:opacity-60",
                     isLoading && "border-accent/25 bg-accent/10"
                   )}
                   onClick={() => loadScenario(file.fileName)}

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -15,7 +15,7 @@ function SpeedBar({ speed, maxSpeed }: { speed: number; maxSpeed: number }) {
 
   return (
     <div
-      className="col-span-full h-[3px] rounded-r-full bg-gradient-to-r from-orange-500/60 via-yellow-400/65 to-status-ok/70 transition-[width] duration-normal"
+      className="col-span-full h-[3px] rounded-full bg-accent/60 transition-[width] duration-normal"
       style={{ width: `${width}%`, gridArea: "bar" }}
     />
   );
@@ -45,10 +45,10 @@ function formatRouteDistance(distance?: number) {
 }
 
 const VEHICLE_TYPE_LABELS: Record<string, string> = {
-  truck: "Truck",
-  motorcycle: "Moto",
-  ambulance: "Ambulance",
-  bus: "Bus",
+  truck: "TRK",
+  motorcycle: "MC",
+  ambulance: "AMB",
+  bus: "BUS",
 };
 
 function WaypointBadge({ assignment }: { assignment: DispatchAssignment }) {
@@ -198,7 +198,7 @@ export default function VehicleList({
               <button
                 key={vehicle.id}
                 className={cn(
-                  "grid w-full flex-shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-0.5 overflow-hidden rounded-md border border-white/5 bg-white/[0.03] px-2.5 pb-1.5 pt-2 text-left transition-colors duration-fast ease-standard hover:border-white/10 hover:bg-white/[0.06] focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+                  "grid w-full flex-shrink-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-0.5 overflow-hidden rounded-md border border-border-soft bg-white/[0.03] px-2.5 pb-1.5 pt-2 text-left transition-colors duration-fast ease-standard hover:border-border hover:bg-white/[0.06] focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
                   isSelected &&
                     "border-accent/25 bg-accent/10 shadow-[inset_2px_0_0_var(--color-accent)]",
                   isDispatchSelected &&
@@ -232,11 +232,11 @@ export default function VehicleList({
                       style={{ backgroundColor: vehicleFleet?.color ?? "transparent" }}
                     />
                   )}
-                  <span className="min-w-0 self-center truncate text-[13px] font-medium text-foreground">
+                  <span className="min-w-0 flex-1 self-center truncate text-[13px] font-medium text-foreground">
                     {vehicle.name}
                   </span>
                   {vehicle.type && vehicle.type !== "car" && (
-                    <span className="ml-2 rounded-sm bg-foreground/10 px-2 py-px text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    <span className="ml-2 flex-shrink-0 rounded-sm bg-foreground/10 px-2 py-px text-xs font-medium uppercase tracking-wide text-muted-foreground">
                       {VEHICLE_TYPE_LABELS[vehicle.type] ?? vehicle.type}
                     </span>
                   )}

--- a/apps/ui/src/Map/Breadcrumb/BreadcrumbLayer.tsx
+++ b/apps/ui/src/Map/Breadcrumb/BreadcrumbLayer.tsx
@@ -3,8 +3,7 @@ import { PathLayer } from "@deck.gl/layers";
 import type { Fleet } from "@/types";
 import { vehicleStore } from "@/hooks/vehicleStore";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
-
-const DEFAULT_TRAIL_COLOR = "#39f";
+import { resolveMapColor } from "@/lib/mapColor";
 
 interface BreadcrumbLayerProps {
   selectedId?: string;
@@ -16,19 +15,41 @@ interface BreadcrumbLayerProps {
 /** Trail data fed to deck.gl PathLayer. */
 interface TrailData {
   vehicleId: string;
-  path: [number, number][]; // [lng, lat] pairs
-  color: [number, number, number, number]; // RGBA
+  path: [number, number][]; // [lng, lat] pairs, oldest → newest
+  /** Per-vertex color (PathLayer supports Color[] for a gradient along the
+   * path) — alpha fades from oldest to newest point for a recency cue. */
+  color: [number, number, number, number][];
 }
 
-/** Convert hex color string to RGBA tuple. */
-function hexToRgba(hex: string, alpha = 180): [number, number, number, number] {
+/** Convert hex color string to an [r,g,b] triple (alpha applied separately). */
+function hexToRgb(hex: string): [number, number, number] {
   const h = hex.replace("#", "");
   const bigint =
     h.length === 3 ? parseInt(h[0] + h[0] + h[1] + h[1] + h[2] + h[2], 16) : parseInt(h, 16);
-  const r = (bigint >> 16) & 255;
-  const g = (bigint >> 8) & 255;
-  const b = bigint & 255;
-  return [r, g, b, alpha];
+  return [(bigint >> 16) & 255, (bigint >> 8) & 255, bigint & 255];
+}
+
+// Trail alpha fades linearly from the newest point (full) to the oldest
+// (dimmed, not fully transparent so a long-idle trail is still legible).
+const TRAIL_ALPHA_NEWEST = 200;
+const TRAIL_ALPHA_OLDEST = 40;
+
+// The fade ramp depends only on a trail's length (position-in-trail), not on
+// its color, so it's identical across every vehicle that currently has that
+// length — cached here instead of re-deriving it with Math.round() per point
+// per vehicle on every ~10fps trail tick.
+const alphaRampCache = new Map<number, number[]>();
+function alphaRampForLength(length: number): number[] {
+  const cached = alphaRampCache.get(length);
+  if (cached) return cached;
+  const lastIdx = length - 1;
+  const ramp = new Array<number>(length);
+  for (let i = 0; i < length; i++) {
+    const age = lastIdx === 0 ? 0 : i / lastIdx; // 0 = oldest, 1 = newest
+    ramp[i] = Math.round(TRAIL_ALPHA_OLDEST + (TRAIL_ALPHA_NEWEST - TRAIL_ALPHA_OLDEST) * age);
+  }
+  alphaRampCache.set(length, ramp);
+  return ramp;
 }
 
 /**
@@ -99,14 +120,19 @@ export default function BreadcrumbLayer({
         const fleet = fleetMap.get(vehicleId);
         if (fleet && hiddenFleets.has(fleet.id)) continue;
 
-        const colorHex = fleet?.color ?? DEFAULT_TRAIL_COLOR;
-        // Use slight transparency (alpha=180) for the whole trail
-        const color = hexToRgba(colorHex, 180);
+        const [r, g, b] = fleet?.color
+          ? hexToRgb(fleet.color)
+          : resolveMapColor("var(--color-overlay-trail)");
 
-        // Convert trail positions from [lat, lng] to [lng, lat] for deck.gl
+        // Convert trail positions from [lat, lng] to [lng, lat] for deck.gl,
+        // fading alpha from oldest (dim) to newest (full) point.
         const path: [number, number][] = [];
-        for (const pos of trail) {
+        const color: [number, number, number, number][] = [];
+        const alphaRamp = alphaRampForLength(trail.length);
+        for (let i = 0; i < trail.length; i++) {
+          const pos = trail[i];
           path.push([pos[1], pos[0]]);
+          color.push([r, g, b, alphaRamp[i]]);
         }
         if (path.length < 2) continue;
 

--- a/apps/ui/src/Map/Direction.tsx
+++ b/apps/ui/src/Map/Direction.tsx
@@ -4,6 +4,7 @@ import type { Position } from "@/types";
 import { useDirections, type DirectionState } from "@/hooks/useDirections";
 import { invertLatLng } from "@/utils/coordinates";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
+import { resolveMapColor } from "@/lib/mapColor";
 
 /** Convert a hex color string like "#39f" or "#3399ff" to [r,g,b,a]. */
 function hexToRgba(hex: string, alpha = 255): [number, number, number, number] {
@@ -31,6 +32,8 @@ interface WaypointData {
   color: string;
   label: string;
   stopsLeftLabel?: string;
+  /** 0 (origin) → 1 (destination) — drives a size/opacity progression cue. */
+  progress: number;
 }
 
 interface LabelData {
@@ -89,6 +92,7 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
       const cwi = currentWaypointIndex ?? 0;
       const remaining = waypoints.length - cwi;
 
+      const lastWaypointIdx = waypoints.length - 1;
       for (let i = 0; i < waypoints.length; i++) {
         const wp = waypoints[i];
         const [lng, lat] = invertLatLng(wp.position as Position);
@@ -104,6 +108,7 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
             i === waypoints.length - 1 && remaining > 0
               ? `${remaining} stop${remaining === 1 ? "" : "s"} left`
               : undefined,
+          progress: lastWaypointIdx === 0 ? 1 : i / lastWaypointIdx,
         });
       }
     }
@@ -147,8 +152,12 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
             id: "direction-waypoints",
             data: waypointData,
             getPosition: (d) => d.position,
-            getRadius: (d) => (d.isCurrent ? 7 : 5),
-            getFillColor: (d) => (d.isCurrent ? hexToRgba(d.color) : [0, 0, 0, 180]),
+            // Size/opacity ramp from origin (small, dim) to destination (full
+            // size, opaque) — a lightweight "progression" cue in place of an
+            // arrowhead, which PathLayer can't render natively.
+            getRadius: (d) => (d.isCurrent ? 7 : 4 + d.progress * 2),
+            getFillColor: (d) =>
+              d.isCurrent ? hexToRgba(d.color) : [0, 0, 0, Math.round(90 + d.progress * 120)],
             getLineColor: (d) => (d.isCurrent ? [255, 255, 255, 255] : hexToRgba(d.color)),
             getLineWidth: 1.5,
             stroked: true,
@@ -187,7 +196,7 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
             getAlignmentBaseline: "center",
             sizeUnits: "pixels",
             background: true,
-            getBackgroundColor: [0, 0, 0, 190],
+            getBackgroundColor: resolveMapColor("var(--color-popover)", 190),
             backgroundPadding: [4, 2],
           })
         : null;

--- a/apps/ui/src/Map/FleetLegend.tsx
+++ b/apps/ui/src/Map/FleetLegend.tsx
@@ -18,7 +18,7 @@ export default function FleetLegend({ fleets, hiddenFleetIds, onToggle }: FleetL
   if (fleets.length === 0) return null;
 
   return (
-    <div className="absolute bottom-3 right-3 z-10 flex flex-col gap-2 rounded-lg border border-border surface-glass p-3 shadow-elevated backdrop-blur-md">
+    <div className="absolute bottom-20 right-3 z-10 flex max-h-[40vh] flex-col gap-2 overflow-y-auto rounded-lg border border-border surface-glass p-3 shadow-elevated backdrop-blur-md">
       {fleets.map((fleet, i) => {
         const hidden = hiddenFleetIds.has(fleet.id);
         return (
@@ -38,7 +38,7 @@ export default function FleetLegend({ fleets, hiddenFleetIds, onToggle }: FleetL
           >
             <span
               aria-hidden="true"
-              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              className="h-2.5 w-2.5 shrink-0 rounded-full shadow-raised"
               style={{ backgroundColor: fleet.color }}
             />
             <span className="whitespace-nowrap text-sm tracking-tight text-foreground">

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
@@ -2,19 +2,25 @@ import { useMemo } from "react";
 import { PolygonLayer, TextLayer } from "@deck.gl/layers";
 import type { GeoFence, GeoFenceType } from "@moveet/shared-types";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
+import { resolveMapColor } from "@/lib/mapColor";
 
 type RGBA = [number, number, number, number];
 
+/** Fade in/out duration in milliseconds, matching SpeedLimitSigns. */
+const FADE_DURATION_MS = 500;
+
+// restricted = off-limits (danger); delivery/monitoring are both
+// permitted-access zone types, so they share the "ok" hue.
 const TYPE_FILL: Record<GeoFenceType, RGBA> = {
-  restricted: [239, 68, 68, 64],
-  delivery: [34, 197, 94, 64],
-  monitoring: [59, 130, 246, 64],
+  restricted: resolveMapColor("var(--color-overlay-danger)", 64),
+  delivery: resolveMapColor("var(--color-overlay-ok)", 64),
+  monitoring: resolveMapColor("var(--color-overlay-ok)", 64),
 };
 
 const TYPE_STROKE: Record<GeoFenceType, RGBA> = {
-  restricted: [239, 68, 68, 255],
-  delivery: [34, 197, 94, 255],
-  monitoring: [59, 130, 246, 255],
+  restricted: resolveMapColor("var(--color-overlay-danger)", 255),
+  delivery: resolveMapColor("var(--color-overlay-ok)", 255),
+  monitoring: resolveMapColor("var(--color-overlay-ok)", 255),
 };
 
 function hexToRgba(hex: string, alpha: number): RGBA {
@@ -67,6 +73,16 @@ export default function GeofenceLayer({ fences, selectedFenceId }: GeofenceLayer
         filled: true,
         stroked: true,
         pickable: false,
+        transitions: {
+          getFillColor: {
+            duration: FADE_DURATION_MS,
+            enter: (value: number[]) => [value[0], value[1], value[2], 0],
+          },
+          getLineColor: {
+            duration: FADE_DURATION_MS,
+            enter: (value: number[]) => [value[0], value[1], value[2], 0],
+          },
+        },
       }),
       new TextLayer<GeoFence>({
         id: "geofence-labels",
@@ -79,6 +95,12 @@ export default function GeofenceLayer({ fences, selectedFenceId }: GeofenceLayer
         getAlignmentBaseline: "center",
         pickable: false,
         fontFamily: "system-ui",
+        transitions: {
+          getColor: {
+            duration: FADE_DURATION_MS,
+            enter: (value: number[]) => [value[0], value[1], value[2], 0],
+          },
+        },
         outlineColor: [0, 0, 0, 153],
         outlineWidth: 3,
       }),

--- a/apps/ui/src/Map/IncidentMarkers.tsx
+++ b/apps/ui/src/Map/IncidentMarkers.tsx
@@ -1,30 +1,53 @@
+import { useState } from "react";
 import type { IncidentDTO, IncidentType } from "@/types";
+import { resolveMapColor } from "@/lib/mapColor";
 import HTMLMarker from "../components/Map/components/HTMLMarker";
 
+function rgbaToCss([r, g, b, a]: [number, number, number, number]): string {
+  return `rgba(${r}, ${g}, ${b}, ${a / 255})`;
+}
+
+// closure = danger (road impassable); accident/construction are both
+// slowdowns rather than full blockages, so they share the warning hue.
 const COLORS: Record<IncidentType, string> = {
-  closure: "#f44336",
-  accident: "#ff9800",
-  construction: "#ffeb3b",
+  closure: rgbaToCss(resolveMapColor("var(--color-overlay-danger)")),
+  accident: rgbaToCss(resolveMapColor("var(--color-overlay-warning)")),
+  construction: rgbaToCss(resolveMapColor("var(--color-overlay-warning)")),
 };
 
 interface IncidentMarkersProps {
   incidents: IncidentDTO[];
 }
 
+function IncidentMarker({ incident }: { incident: IncidentDTO }) {
+  const [hovered, setHovered] = useState(false);
+  const label = `${incident.type} — severity ${Math.round(incident.severity * 100)}%`;
+
+  return (
+    <HTMLMarker position={[incident.position[1], incident.position[0]]}>
+      <div
+        className="pointer-events-auto flex h-[22px] w-[22px] -translate-x-1/2 -translate-y-1/2 cursor-default items-center justify-center drop-shadow-[0_1px_3px_rgba(0,0,0,0.5)]"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {hovered && (
+          <div className="animate-in fade-in absolute -top-2 left-1/2 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border border-border bg-card/90 p-1.5 text-xs backdrop-blur-md">
+            {label}
+          </div>
+        )}
+        <svg viewBox="0 0 24 24" className="h-5 w-5" style={{ fill: COLORS[incident.type] }}>
+          <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+        </svg>
+      </div>
+    </HTMLMarker>
+  );
+}
+
 export default function IncidentMarkers({ incidents }: IncidentMarkersProps) {
   return (
     <>
       {incidents.map((incident) => (
-        <HTMLMarker key={incident.id} position={[incident.position[1], incident.position[0]]}>
-          <div
-            className="pointer-events-auto flex h-[22px] w-[22px] -translate-x-1/2 -translate-y-1/2 cursor-default items-center justify-center drop-shadow-[0_1px_3px_rgba(0,0,0,0.5)]"
-            title={`${incident.type} — severity ${Math.round(incident.severity * 100)}%`}
-          >
-            <svg viewBox="0 0 24 24" className="h-5 w-5" style={{ fill: COLORS[incident.type] }}>
-              <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
-            </svg>
-          </div>
-        </HTMLMarker>
+        <IncidentMarker key={incident.id} incident={incident} />
       ))}
     </>
   );

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useMemo } from "react";
+import { lazy, Suspense, useCallback, useMemo } from "react";
+import type { PickingInfo } from "@deck.gl/core";
 import type {
   DispatchAssignment,
   Fleet,
@@ -39,6 +40,16 @@ import { ViewportBboxReporter } from "./ViewportBboxReporter";
 // hand child layers a new prop identity on every render.
 const NOOP = () => {};
 
+// deck.gl's getTooltip renders raw HTML outside the React tree — escape
+// vehicle/fleet names before interpolating them into the tooltip markup.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 const Heatmap = lazy(() => import("./Heatmap"));
 const POIs = lazy(() => import("./POIs"));
 const TrafficZones = lazy(() => import("./TrafficZones"));
@@ -56,6 +67,8 @@ interface MapProps {
   onMapClick?: (event: React.MouseEvent, position: Position) => void;
   onMapContextClick: (evt: React.MouseEvent, position: Position) => void;
   onPOIClick: (poi: POI) => void;
+  onHoverVehicle?: (id: string | undefined) => void;
+  onEscape?: () => void;
   vehicleFleetMap: Map<string, Fleet>;
   hiddenFleetIds: Set<string>;
   hiddenVehicleTypes: Set<VehicleType>;
@@ -85,6 +98,8 @@ export default function Map({
   onMapClick,
   onMapContextClick,
   onPOIClick,
+  onHoverVehicle,
+  onEscape,
   vehicleFleetMap,
   hiddenFleetIds,
   hiddenVehicleTypes,
@@ -105,6 +120,27 @@ export default function Map({
 }: MapProps) {
   // Derive cursor: prefer dispatchState if provided, fall back to dispatchMode boolean
   const cursor = dispatchState ? cursorForDispatchState(dispatchState) : "grab";
+
+  // Native deck.gl tooltip for GL-picked layers (currently just vehicles —
+  // POIs/incidents render their own styled HTML markers instead). Hover is
+  // infrequent, so a linear scan over `vehicles` is fine — no need for a
+  // memoized id index.
+  const getTooltip = useCallback(
+    (info: PickingInfo) => {
+      if (info.layer?.id !== "vehicles" || !info.object) return null;
+      const vehicle = vehicles.find((v) => v.id === (info.object as { id: string }).id);
+      if (!vehicle) return null;
+      const fleet = vehicleFleetMap.get(vehicle.id);
+      return {
+        html: `<div class="rounded-md border border-border bg-card/90 px-2.5 py-1.5 text-xs shadow-elevated backdrop-blur-md">
+          <div class="font-medium text-foreground">${escapeHtml(vehicle.name)}</div>
+          <div class="text-muted-foreground">${escapeHtml(fleet?.name ?? vehicle.type)} · ${Math.round(vehicle.speed)} km/h</div>
+        </div>`,
+        style: { backgroundColor: "transparent", border: "none", padding: "0", margin: "8px" },
+      };
+    },
+    [vehicles, vehicleFleetMap]
+  );
 
   // Only rebuild the HTML marker subtree when its actual inputs change, so
   // DeckGLMap doesn't receive a new htmlMarkers element on unrelated renders.
@@ -127,8 +163,10 @@ export default function Map({
         strokeWidth={1.5}
         onClick={onMapClick}
         onContextClick={onMapContextClick}
+        onEscape={onEscape}
         cursor={cursor}
         htmlMarkers={htmlMarkers}
+        getTooltip={getTooltip}
       >
         {/* POIs & speed-limit signs — GPU-rendered via IconLayer */}
         {modifiers.showPOIs && (
@@ -174,6 +212,7 @@ export default function Map({
             selectedId={filters.selected}
             hoveredId={filters.hovered}
             onClick={onClick}
+            onHover={onHoverVehicle}
           />
         )}
         {modifiers.showHeatmap && (

--- a/apps/ui/src/Map/POI/POI.tsx
+++ b/apps/ui/src/Map/POI/POI.tsx
@@ -40,7 +40,7 @@ const POIMarker = memo(function POIMarker({ poi, showLabel, onClick }: POIMarker
   return (
     <HTMLMarker key={poi.id} position={position} onClick={onClick}>
       {showLabel && (
-        <div className="absolute -left-[60px] bottom-8 -ml-[50%] min-w-[120px] rounded-md border border-border bg-card/90 p-1.5 text-center text-base backdrop-blur-md">
+        <div className="absolute bottom-8 left-1/2 min-w-[120px] -translate-x-1/2 rounded-md border border-border bg-card/90 p-1.5 text-center text-base backdrop-blur-md">
           {poi.name}
         </div>
       )}

--- a/apps/ui/src/Map/Road.tsx
+++ b/apps/ui/src/Map/Road.tsx
@@ -60,7 +60,9 @@ export default function DirectionMap({ road }: DirectionProps) {
         widthUnits: "pixels",
         jointRounded: true,
         capRounded: true,
-        pickable: false,
+        pickable: true,
+        autoHighlight: true,
+        highlightColor: [255, 255, 255, 40],
       }),
       new TextLayer({
         id: "selected-road-label",

--- a/apps/ui/src/Map/TrafficOverlay.tsx
+++ b/apps/ui/src/Map/TrafficOverlay.tsx
@@ -3,6 +3,7 @@ import { PathLayer } from "@deck.gl/layers";
 import { useTraffic } from "@/hooks/useTraffic";
 import { useNetwork } from "@/hooks/useNetwork";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
+import { resolveMapColor } from "@/lib/mapColor";
 import type { TrafficEdge } from "@/types";
 
 const HIGHWAY_WIDTH: Record<string, number> = {
@@ -13,13 +14,16 @@ const HIGHWAY_WIDTH: Record<string, number> = {
   tertiary: 1.5,
 };
 
-// Google Maps-style: green -> yellow -> orange -> red  (RGBA)
+const CONGESTION_ALPHA = 217;
+
+// Google Maps-style: ok -> warning -> danger, resolved from the shared
+// overlay-severity tokens (tokens.css) instead of hardcoded hex.
 function congestionColorRgba(factor: number): [number, number, number, number] {
-  if (factor >= 0.85) return [34, 197, 94, 217]; // green  - free flow
-  if (factor >= 0.7) return [132, 204, 22, 217]; // lime   - light traffic
-  if (factor >= 0.55) return [234, 179, 8, 217]; // yellow - moderate
-  if (factor >= 0.4) return [249, 115, 22, 217]; // orange - heavy
-  return [239, 68, 68, 217]; // red    - jammed
+  if (factor >= 0.85) return resolveMapColor("var(--color-overlay-ok)", CONGESTION_ALPHA); // free flow
+  if (factor >= 0.7) return resolveMapColor("var(--color-overlay-ok)", CONGESTION_ALPHA); // light traffic
+  if (factor >= 0.55) return resolveMapColor("var(--color-overlay-warning)", CONGESTION_ALPHA); // moderate
+  if (factor >= 0.4) return resolveMapColor("var(--color-overlay-warning)", CONGESTION_ALPHA); // heavy
+  return resolveMapColor("var(--color-overlay-danger)", CONGESTION_ALPHA); // jammed
 }
 
 // Aggregate congestion per streetId (worst = lowest factor wins)

--- a/apps/ui/src/Map/TrafficZones.tsx
+++ b/apps/ui/src/Map/TrafficZones.tsx
@@ -2,12 +2,18 @@ import { useMemo } from "react";
 import { PolygonLayer } from "@deck.gl/layers";
 import { useHeatzones } from "@/hooks/useHeatzones";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
+import { resolveMapColor } from "@/lib/mapColor";
 import type { Heatzone } from "@/types";
+
+/** Fade in/out duration in milliseconds, matching SpeedLimitSigns. */
+const FADE_DURATION_MS = 500;
 
 interface HeatzoneDatum {
   polygon: [number, number][];
   intensity: number;
 }
+
+const DENSITY_LINE_RGBA = resolveMapColor("var(--color-overlay-density)", 153);
 
 export default function Heatzones({ visible }: { visible: boolean }) {
   const heatzones = useHeatzones();
@@ -25,13 +31,26 @@ export default function Heatzones({ visible }: { visible: boolean }) {
         id: "traffic-zones",
         data,
         getPolygon: (d) => d.polygon,
-        getFillColor: (d) => [255, 0, 0, Math.round(0.2 * d.intensity * 255)],
-        getLineColor: [255, 0, 0, 153], // #ff000099
+        getFillColor: (d) => {
+          const [r, g, b] = resolveMapColor("var(--color-overlay-density)");
+          return [r, g, b, Math.round(0.2 * d.intensity * 255)];
+        },
+        getLineColor: DENSITY_LINE_RGBA,
         getLineWidth: 1,
         lineWidthUnits: "pixels",
         filled: true,
         stroked: true,
         pickable: false,
+        transitions: {
+          getFillColor: {
+            duration: FADE_DURATION_MS,
+            enter: (value: number[]) => [value[0], value[1], value[2], 0],
+          },
+          getLineColor: {
+            duration: FADE_DURATION_MS,
+            enter: (value: number[]) => [value[0], value[1], value[2], 0],
+          },
+        },
       }),
     ];
   }, [visible, heatzones]);

--- a/apps/ui/src/Map/TypeLegend.tsx
+++ b/apps/ui/src/Map/TypeLegend.tsx
@@ -37,7 +37,7 @@ export default function TypeLegend({ hiddenVehicleTypes, onToggle }: TypeLegendP
           >
             <span
               aria-hidden="true"
-              className="h-2.5 w-2.5 shrink-0 rounded-sm"
+              className="h-2.5 w-2.5 shrink-0 rounded-sm shadow-raised"
               style={{ backgroundColor: color }}
             />
             <span className="whitespace-nowrap text-sm tracking-tight text-foreground">

--- a/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
+++ b/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
@@ -48,6 +48,13 @@ interface VehicleIconDatum {
   icon: string;
   isSelected: boolean;
   isHovered: boolean;
+  /**
+   * Icon tint [r,g,b,a] — dimmed alpha for near-idle vehicles, full for
+   * moving ones. Built once per vehicle per publish (like `position`/`icon`
+   * below) so the IconLayer's `getColor` accessor returns a stored
+   * reference instead of allocating a new array per call.
+   */
+  iconColor: [number, number, number, number];
 }
 
 /** Per-vehicle interpolation state for smooth animation between WS updates. */
@@ -147,6 +154,13 @@ const SIZE_ZOOM_EXPONENT = 0.4;
 const BASE_SIZE_PX = 24;
 const MIN_SIZE_PX = 10;
 const MAX_SIZE_PX = 72;
+
+// Idle vs. moving tint — below this speed a vehicle reads as stopped rather
+// than just moving slowly, so it's dimmed to visually separate it from
+// actively-moving traffic without a new status enum.
+const IDLE_SPEED_KMH = 1;
+const IDLE_ICON_ALPHA = 166; // 0.65 * 255
+const MOVING_ICON_ALPHA = 255;
 
 function iconSizeForZoom(zoom: number): number {
   const size = BASE_SIZE_PX * Math.pow(2, (zoom - REFERENCE_ZOOM) * SIZE_ZOOM_EXPONENT);
@@ -467,6 +481,12 @@ export default function VehiclesLayer({
           icon: atlasManager.register(vehicleType, color),
           isSelected: v.id === currentSelectedId,
           isHovered: v.id === currentHoveredId,
+          iconColor: [
+            255,
+            255,
+            255,
+            (v.speed ?? 0) < IDLE_SPEED_KMH ? IDLE_ICON_ALPHA : MOVING_ICON_ALPHA,
+          ],
         });
       }
 
@@ -535,6 +555,13 @@ export default function VehiclesLayer({
         getFillColor: selectedId ?? hoveredId ?? "",
         getLineColor: selectedId ?? hoveredId ?? "",
       },
+      // Animate hover/select transitions instead of popping instantly between
+      // colors/radius — deck.gl interpolates internally, no extra state needed.
+      transitions: {
+        getFillColor: 200,
+        getLineColor: 200,
+        getRadius: 200,
+      },
     });
 
     const vehiclesLayer = new IconLayer<VehicleIconDatum>({
@@ -545,6 +572,11 @@ export default function VehiclesLayer({
       getPosition: (d) => d.position,
       getIcon: (d) => d.icon,
       getAngle: (d) => d.angle,
+      // Icon sprites are already tinted per-vehicle-color; this tints on top
+      // to dim idle vehicles, so full white = no change from the sprite.
+      // `d.iconColor` is a stored reference built once per vehicle per
+      // publish (see the RAF loop above), not allocated here.
+      getColor: (d) => d.iconColor,
       getSize: iconSize,
       sizeUnits: "pixels",
       billboard: false,

--- a/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
+++ b/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
@@ -34,6 +34,8 @@ interface VehiclesLayerProps {
   selectedId?: string;
   hoveredId?: string;
   onClick: (id: string) => void;
+  /** Canvas hover — mirrors the sidebar list's hover state (undefined = none). */
+  onHover?: (id: string | undefined) => void;
 }
 
 /** Interpolated vehicle data for the deck.gl IconLayer. */
@@ -171,6 +173,7 @@ export default function VehiclesLayer({
   selectedId,
   hoveredId,
   onClick,
+  onHover,
 }: VehiclesLayerProps) {
   const { getZoom, getBoundingBox } = useMapContext();
   const [vehicleData, setVehicleData] = useState<VehicleIconDatum[]>([]);
@@ -212,6 +215,8 @@ export default function VehiclesLayer({
   hiddenTypesRef.current = hiddenVehicleTypes;
   const onClickRef = useRef(onClick);
   onClickRef.current = onClick;
+  const onHoverRef = useRef(onHover);
+  onHoverRef.current = onHover;
   const getZoomRef = useRef(getZoom);
   getZoomRef.current = getZoom;
   const getBoundingBoxRef = useRef(getBoundingBox);
@@ -497,6 +502,12 @@ export default function VehiclesLayer({
     }
   }, []);
 
+  // Stable hover handler — mirrors sidebar list hover so mousing over a
+  // vehicle on the canvas highlights it the same way as in the list.
+  const handleHover = useCallback((info: { object?: VehicleIconDatum }) => {
+    onHoverRef.current?.(info.object?.id);
+  }, []);
+
   // Highlight rings under the selected and hovered vehicles
   const ringData = useMemo(
     () => vehicleData.filter((v) => v.isSelected || v.isHovered),
@@ -539,6 +550,7 @@ export default function VehiclesLayer({
       billboard: false,
       pickable: true,
       onClick: handleClick,
+      onHover: handleHover,
       autoHighlight: true,
       highlightColor: [251, 201, 1, 80],
       updateTriggers: {
@@ -548,7 +560,7 @@ export default function VehiclesLayer({
     });
 
     return [ringLayer, vehiclesLayer];
-  }, [vehicleData, ringData, atlas, iconSize, handleClick, selectedId, hoveredId]);
+  }, [vehicleData, ringData, atlas, iconSize, handleClick, handleHover, selectedId, hoveredId]);
 
   // Register layers with the DeckGLMap parent
   useRegisterLayers("vehicles", layers);

--- a/apps/ui/src/components/Map/components/DeckGLMap.tsx
+++ b/apps/ui/src/components/Map/components/DeckGLMap.tsx
@@ -1,7 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import DeckGL from "@deck.gl/react";
 import { MapView, WebMercatorViewport } from "@deck.gl/core";
-import type { Layer, MapViewState } from "@deck.gl/core";
+import type { Layer, MapViewState, PickingInfo } from "@deck.gl/core";
+
+// `TooltipContent` isn't re-exported from the @deck.gl/core package root
+// (only from its internal tooltip-widget module) — mirror deck's own type.
+type TooltipContent =
+  | null
+  | string
+  | { text?: string; html?: string; className?: string; style?: Partial<CSSStyleDeclaration> };
 import { SectionErrorFallback } from "@/components/ErrorBoundary";
 import { webgl2Adapter } from "@luma.gl/webgl";
 import { PathLayer } from "@deck.gl/layers";
@@ -31,7 +38,10 @@ interface DeckGLMapProps {
   htmlMarkers?: React.ReactNode;
   onClick?: (event: React.MouseEvent, position: Position) => void;
   onContextClick?: (event: React.MouseEvent, position: Position) => void;
+  /** Escape key — typically wired to clear the current selection. */
+  onEscape?: () => void;
   cursor?: string;
+  getTooltip?: (info: PickingInfo) => TooltipContent;
 }
 
 // Separate road features into regular roads and highways for distinct styling,
@@ -171,8 +181,10 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
   children,
   onClick,
   onContextClick,
+  onEscape,
   htmlMarkers,
   cursor = "grab",
+  getTooltip,
 }) => {
   const [containerRef, size] = useResizeObserver();
   const deckContainerRef = useRef<HTMLDivElement>(null);
@@ -277,9 +289,40 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
     [onContextClick, viewport]
   );
 
-  // Stable cursor accessor — an inline closure would be a new prop for DeckGL
-  // on every render.
-  const getCursor = useCallback(() => cursor, [cursor]);
+  // Cursor feedback: `cursor` is an explicit mode override (dispatch-flow
+  // crosshairs, geofence-draw crosshair, etc.) and always wins when set to
+  // anything but the idle default. Otherwise reflect deck.gl's own
+  // hover/drag state so pickable objects (vehicles, POIs, …) show a pointer
+  // and panning shows a grabbing hand.
+  const getCursor = useCallback(
+    ({ isDragging, isHovering }: { isDragging: boolean; isHovering: boolean }) => {
+      if (cursor !== "grab") return cursor;
+      if (isDragging) return "grabbing";
+      if (isHovering) return "pointer";
+      return cursor;
+    },
+    [cursor]
+  );
+
+  // Keyboard shortcuts, active while the pointer is over the map: Escape
+  // clears the current selection; +/- mirror the on-screen zoom buttons.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onKeyDown = (evt: KeyboardEvent) => {
+      if (evt.key === "Escape") {
+        onEscape?.();
+      } else if (evt.key === "+" || evt.key === "=") {
+        controls.zoomIn();
+      } else if (evt.key === "-" || evt.key === "_") {
+        controls.zoomOut();
+      }
+    };
+
+    container.addEventListener("keydown", onKeyDown);
+    return () => container.removeEventListener("keydown", onKeyDown);
+  }, [containerRef, controls, onEscape]);
 
   const MAP_VIEW = useMemo(
     () =>
@@ -311,8 +354,9 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
           <DeckLayersContext.Provider value={layerContextValue}>
             <div
               ref={containerRef}
-              style={{ width: "100%", height: "100%", position: "relative" }}
+              style={{ width: "100%", height: "100%", position: "relative", outline: "none" }}
               onContextMenu={handleContextMenu}
+              tabIndex={0}
             >
               <div ref={deckContainerRef} style={{ width: "100%", height: "100%" }}>
                 {size.width > 0 && size.height > 0 && (
@@ -328,6 +372,7 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
                     controller={true}
                     style={{ position: "relative" }}
                     getCursor={getCursor}
+                    getTooltip={getTooltip}
                     deviceProps={{ adapters: [webgl2Adapter] }}
                   >
                     {/* HTML overlay — children rendered as absolute-positioned elements */}

--- a/apps/ui/src/components/Map/components/DeckGLMap.tsx
+++ b/apps/ui/src/components/Map/components/DeckGLMap.tsx
@@ -304,8 +304,10 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
     [cursor]
   );
 
-  // Keyboard shortcuts, active while the pointer is over the map: Escape
-  // clears the current selection; +/- mirror the on-screen zoom buttons.
+  // Keyboard shortcuts, active while the map container has focus (click it
+  // first, or Tab to it): Escape clears the current selection; +/- mirror
+  // the on-screen zoom buttons. `onEscape` is expected to no-op for modes
+  // that already own Escape (dispatch flow, geofence drawing) — see App.tsx.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -355,6 +357,7 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
             <div
               ref={containerRef}
               style={{ width: "100%", height: "100%", position: "relative", outline: "none" }}
+              className="focus-visible:ring-inset focus-visible:ring-[3px] focus-visible:ring-ring/50"
               onContextMenu={handleContextMenu}
               tabIndex={0}
             >

--- a/apps/ui/src/components/Map/hooks/useDeckViewState.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckViewState.ts
@@ -72,13 +72,25 @@ export function useDeckViewState({ data, width, height }: UseDeckViewStateOption
     []
   );
 
-  // Control methods
+  // Control methods. Zoom buttons/keyboard shortcuts ease with the same
+  // FlyToInterpolator as panTo/focusOn (200ms — short enough to feel like a
+  // direct response, long enough not to snap) instead of jumping instantly.
   const zoomIn = useCallback(() => {
-    setViewState((prev) => ({ ...prev, zoom: Math.min((prev.zoom ?? 1) + 0.5, 20) }));
+    setViewState((prev) => ({
+      ...prev,
+      zoom: Math.min((prev.zoom ?? 1) + 0.5, 20),
+      transitionDuration: 200,
+      transitionInterpolator: new FlyToInterpolator(),
+    }));
   }, []);
 
   const zoomOut = useCallback(() => {
-    setViewState((prev) => ({ ...prev, zoom: Math.max((prev.zoom ?? 1) - 0.5, 1) }));
+    setViewState((prev) => ({
+      ...prev,
+      zoom: Math.max((prev.zoom ?? 1) - 0.5, 1),
+      transitionDuration: 200,
+      transitionInterpolator: new FlyToInterpolator(),
+    }));
   }, []);
 
   const panTo = useCallback((lng: number, lat: number, options: PanToOptions) => {

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -30,7 +30,12 @@
   --color-accent-foreground: oklch(0.99 0 0);
   --color-destructive: oklch(0.62 0.2 22);
   --color-destructive-foreground: oklch(0.99 0 0);
-  --color-border: oklch(1 0 0 / 13%);
+  --color-border: oklch(1 0 0 / 10%);
+  /* Hairline variant for internal dividers (list rows, header rules) where
+     the full-strength border would compete with content instead of quietly
+     separating it. Panel/card outer edges keep --color-border for enough
+     definition against the near-black map/background. */
+  --color-border-soft: oklch(1 0 0 / 6%);
   --color-input: oklch(1 0 0 / 16%);
   --color-ring: oklch(0.62 0.15 250);
 

--- a/apps/ui/src/lib/mapColor.ts
+++ b/apps/ui/src/lib/mapColor.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve a CSS color — including `var(--token)` references and modern
+ * syntaxes like oklch() — to a concrete [r, g, b, a] byte array for deck.gl
+ * layer props, which only accept numeric color arrays (see tokens.css).
+ *
+ * Uses an offscreen 1x1 canvas so the browser does the color-space
+ * conversion, avoiding hand-rolled oklch math and staying correct for any
+ * valid CSS color string regardless of how getComputedStyle serializes it.
+ *
+ * Results are cached per (color, alpha) pair. Safe to call from useMemo, not
+ * from a per-frame hot loop — see VehiclesLayer's own resolveCSSColor for
+ * that case (it resolves to a color *string* for the icon atlas, not bytes).
+ */
+const cache = new Map<string, [number, number, number, number]>();
+let sharedCtx: CanvasRenderingContext2D | null | undefined;
+
+function getSharedCtx(): CanvasRenderingContext2D | null {
+  if (sharedCtx !== undefined) return sharedCtx;
+  if (typeof document === "undefined") {
+    sharedCtx = null;
+    return sharedCtx;
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = 1;
+  canvas.height = 1;
+  sharedCtx = canvas.getContext("2d", { willReadFrequently: true });
+  return sharedCtx;
+}
+
+/** Fallback used when the color can't be resolved (e.g. jsdom in tests). */
+const FALLBACK: [number, number, number, number] = [128, 128, 128, 255];
+
+export function resolveMapColor(color: string, alpha = 255): [number, number, number, number] {
+  const key = `${color}:${alpha}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  let cssColor = color;
+  if (color.startsWith("var(")) {
+    const match = color.match(/^var\(([^)]+)\)$/);
+    const varName = match?.[1];
+    cssColor = varName
+      ? getComputedStyle(document.documentElement).getPropertyValue(varName).trim() || color
+      : color;
+  }
+
+  const ctx = getSharedCtx();
+  let rgba = FALLBACK;
+  if (ctx) {
+    ctx.clearRect(0, 0, 1, 1);
+    ctx.fillStyle = cssColor;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    rgba = [r, g, b, alpha];
+  }
+  cache.set(key, rgba);
+  return rgba;
+}

--- a/apps/ui/src/styles/tokens.css
+++ b/apps/ui/src/styles/tokens.css
@@ -10,21 +10,40 @@
  * system is the oklch `@theme` block in index.css plus Tailwind utilities.
  */
 :root {
-  /* POI category fills — consumed by Map/POI/helpers.ts getFillByType() */
-  --color-poi-shop: #993300;
-  --color-poi-leisure: #339900;
-  --color-poi-craft: #333399;
-  --color-poi-office: #cc6633;
-  --color-poi-bus: #bbf;
-  --color-poi-default: #666;
+  /* POI category fills — consumed by Map/POI/helpers.ts getFillByType().
+     oklch siblings of the theme palette (index.css) instead of raw legacy
+     hex, so POI colors sit coherently next to --color-primary/--color-status-*. */
+  --color-poi-shop: oklch(0.7 0.15 55);
+  --color-poi-leisure: oklch(0.72 0.14 152);
+  --color-poi-craft: oklch(0.64 0.12 285);
+  --color-poi-office: oklch(0.7 0.12 75);
+  --color-poi-bus: oklch(0.78 0.07 250);
+  --color-poi-default: oklch(0.65 0.015 255);
 
   /* Vehicle rendering — resolved at runtime by VehiclesLayer.resolveCSSColor()
      and mirrored in the TypeLegend swatches. Per-type defaults used when a
-     vehicle has no fleet color. */
-  --color-vehicle-fill: #dcdcdc;
-  --color-vehicle-car: #dcdcdc;
-  --color-vehicle-truck: #f59e0b;
-  --color-vehicle-motorcycle: #8b5cf6;
-  --color-vehicle-ambulance: #ef4444;
-  --color-vehicle-bus: #3b82f6;
+     vehicle has no fleet color. oklch siblings of the theme's status/accent
+     hues instead of raw Tailwind-palette hex. */
+  --color-vehicle-fill: oklch(0.86 0.005 255);
+  --color-vehicle-car: oklch(0.86 0.005 255);
+  --color-vehicle-truck: oklch(0.78 0.13 80);
+  --color-vehicle-motorcycle: oklch(0.66 0.15 300);
+  --color-vehicle-ambulance: oklch(0.63 0.19 25);
+  --color-vehicle-bus: oklch(0.62 0.15 250);
+
+  /* Overlay severity — shared "road danger" family for traffic congestion +
+     incidents, resolved at runtime via src/lib/mapColor.ts (deck.gl layers
+     need numeric [r,g,b,a], not CSS strings). Kept separate from
+     --color-status-* (chrome/UI state) so map-overlay colors can be tuned
+     independently even though they start aligned. */
+  --color-overlay-danger: oklch(0.65 0.2 22);
+  --color-overlay-warning: oklch(0.8 0.14 80);
+  --color-overlay-ok: oklch(0.74 0.15 152);
+
+  /* Heatzones — vehicle-density metric, deliberately a different hue family
+     from --color-overlay-danger so stacked overlays stay visually distinct. */
+  --color-overlay-density: oklch(0.62 0.19 300);
+
+  /* Route/breadcrumb trail tint — distinct from all of the above. */
+  --color-overlay-trail: oklch(0.68 0.16 235);
 }


### PR DESCRIPTION
## Summary

Cross-cutting deck.gl map UX pass driven by 4 parallel audit agents (interactions, overlays, theming, vehicle layer) covering:

**Foundation**
- oklch color tokens for POI/vehicle categories and a shared overlay-severity triad (danger/warning/ok/density), replacing five independent hardcoded palettes
- `resolveMapColor()` — canvas-based CSS-color → `[r,g,b,a]` resolver for deck.gl layers
- Dynamic cursor feedback (pointer on hover, grabbing while dragging), a native deck.gl vehicle tooltip, Escape-to-deselect, and `+`/`-` keyboard zoom eased consistently with existing pans

**Vehicle & route polish**
- Animated selection ring transitions, speed-derived idle/moving icon tint, breadcrumb recency fade, a route-progress visual cue, token-based label colors

**Overlays**
- Traffic/heatzone/incident/geofence colors now derive from the shared oklch tokens instead of five separate hardcoded systems, with consistent fade-in transitions and a styled incident hover tooltip (replacing the native `title` attribute)

**Chrome**
- Fixed the FleetLegend/Zoom control collision, elevation treatment on legend swatches, pickable hover highlight on the selected-road overlay, more robust POI label anchoring

**Review fixes** (found via an 8-angle adversarial code review + verification pass)
- Removed a per-frame array allocation and a no-op update trigger from the vehicle icon tint that was undermining `VehiclesLayer.tsx`'s tuned RAF hot path
- Cached the breadcrumb fade ramp by trail length instead of recomputing it per vehicle per tick
- Fixed an Escape-key double-fire against the existing dispatch-mode/geofence-draw shortcuts
- Added a focus-visible ring now that the map container is keyboard-focusable

Several review candidates (a11y regression on incident markers, per-datum color-resolution cost, module-scope color caching, leftover local hex-to-rgba helpers) were investigated and refuted with evidence — see commit messages for detail.

## Test plan
- [x] `npm run type-check`, `npm run lint` (0 errors), `npm run test` (794/794) all pass
- [x] Manually verified in a running dev server against the simulator: map renders with new colors and recency-faded trails, zoom-in/out eases consistently, map container is keyboard-focusable, click-to-select renders the animated ring, hover-triggered tooltip populates correctly per vehicle (verified against two different vehicles), no new console errors
- [ ] Not covered: true pixel-level automated hover/click testing (deck.gl canvas picking isn't exposed to accessibility-tree-based browser automation) — verified manually instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: chrome polish pass

Addressed feedback that the surrounding UI (panels, buttons, borders) wasn't yet professional/modern:

- New `--color-border-soft` token for internal dividers; softened `--color-border` for outer edges
- Redesigned `PanelPrimitives`' empty/loading/error states (icon slot, proper surface instead of dashed wireframe box)
- Fixed a real layout bug: vehicle-list type badges ("AMBULANCE") were forcing premature name truncation — badges are now fixed-width codes and the name gets flex priority
- Replaced the vehicle list's 3-color traffic-light speed bar with a single accent-toned fill
- Promoted each panel's primary action (Fleets "+ New", Incidents "+", Geofences "+ Draw Zone", Scenarios "Start", RecordReplay "Generate"/"Emit") to a filled/accent button so it reads as primary
- Wired relevant icons into empty states across all panels
- Softened the sidebar/map seam with a hairline border + shadow feather instead of a hard line

Verified visually in a running dev server (all panels reviewed) plus type-check/lint/794 tests passing throughout. One bug caught and fixed during manual review: the Incidents "+" button's accent tint was being silently overridden by a same-specificity `dark:bg-input/30` class from its base button variant — fixed by switching to the `ghost` variant, matching the pattern already proven in `IconRail`.