### PR TITLE
feat(ui): improve POI visibility (prominent markers + name labels)

### DIFF
--- a/apps/ui/src/Map/POI/iconAtlas.ts
+++ b/apps/ui/src/Map/POI/iconAtlas.ts
@@ -3,7 +3,10 @@
  * canvas so deck.gl's IconLayer can instance them on the GPU.
  */
 
-const ICON_SIZE = 44;
+// Cell size includes an internal margin (PAD) so each marker's drop shadow and
+// white halo ring stay within their own atlas cell and don't bleed into the neighbour.
+const ICON_SIZE = 48;
+const ICON_PAD = 5;
 
 // ─── POI type → background colour ──────────────────────────────────
 const POI_COLORS: Record<string, string> = {
@@ -58,22 +61,34 @@ function renderSVGToCanvas(
   iconColor: string,
   viewBox: string
 ) {
-  // Draw background circle
-  const r = size / 2;
+  const cx = x + size / 2;
+  const cy = y + size / 2;
+  const r = size / 2 - ICON_PAD;
+
+  // Filled circle with a soft drop shadow so the marker separates from the map.
+  ctx.save();
+  ctx.shadowColor = "rgba(0,0,0,0.55)";
+  ctx.shadowBlur = 3;
+  ctx.shadowOffsetY = 1;
   ctx.beginPath();
-  ctx.arc(x + r, y + r, r - 1, 0, Math.PI * 2);
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
   ctx.fillStyle = bgColor;
   ctx.fill();
-  ctx.strokeStyle = "rgba(255,255,255,0.4)";
-  ctx.lineWidth = 1;
+  ctx.restore();
+
+  // Crisp white halo ring (no shadow) — the main contrast boost.
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.strokeStyle = "rgba(255,255,255,0.95)";
+  ctx.lineWidth = 2.5;
   ctx.stroke();
 
-  // Draw SVG icon using Path2D
+  // Draw SVG icon using Path2D, sized relative to the circle (not the padded cell).
   const [, , vw, vh] = viewBox.split(" ").map(Number);
-  const iconSize = size * 0.6;
+  const iconSize = r * 2 * 0.58;
   const scale = iconSize / Math.max(vw, vh);
-  const offsetX = x + (size - vw * scale) / 2;
-  const offsetY = y + (size - vh * scale) / 2;
+  const offsetX = cx - (vw * scale) / 2;
+  const offsetY = cy - (vh * scale) / 2;
 
   ctx.save();
   ctx.translate(offsetX, offsetY);
@@ -104,7 +119,7 @@ export function createPOIIconAtlas(): {
     const x = i * ICON_SIZE;
     const bgColor = POI_COLORS[type] ?? POI_COLORS.unknown;
     // Bus stops use dark icon on light bg; others use white icon
-    const iconColor = type === "bus_stop" ? "rgba(51,51,51,0.87)" : "rgba(255,255,255,0.87)";
+    const iconColor = type === "bus_stop" ? "rgba(40,40,40,0.95)" : "rgba(255,255,255,0.98)";
     const { d, viewBox } = POI_PATHS[type];
     renderSVGToCanvas(ctx, d, x, 0, ICON_SIZE, bgColor, iconColor, viewBox);
     iconMapping[type] = { x, y: 0, width: ICON_SIZE, height: ICON_SIZE, mask: false };

--- a/apps/ui/src/Map/POIs.tsx
+++ b/apps/ui/src/Map/POIs.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { IconLayer } from "@deck.gl/layers";
+import { IconLayer, TextLayer } from "@deck.gl/layers";
 import { CollisionFilterExtension, type CollisionFilterExtensionProps } from "@deck.gl/extensions";
 import { useMapContext } from "@/components/Map/hooks";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
@@ -27,6 +27,9 @@ const ZOOM_TIERS: Record<string, number> = {
   bus_stop: 9,
 };
 const MIN_ZOOM = 7;
+
+/** Zoom at which persistent name labels appear beneath the markers. */
+const LABEL_ZOOM = 15;
 
 /** POI collision priority — higher values win when icons overlap. */
 const TYPE_PRIORITY: Record<string, number> = {
@@ -65,6 +68,7 @@ export default function POIs({ visible, onClick }: POIMarkerProps) {
 
   const { settledZoom, isZooming } = useSettledZoom(zoom);
   const showData = visible && settledZoom >= MIN_ZOOM - 1;
+  const showLabels = showData && !isZooming && settledZoom >= LABEL_ZOOM;
 
   // Data is emptied while zooming so items disappear instantly.
   // When isZooming flips false the array repopulates and deck.gl's
@@ -87,7 +91,7 @@ export default function POIs({ visible, onClick }: POIMarkerProps) {
         },
         getPosition: (d) => [d.coordinates[1], d.coordinates[0]],
         getIcon: (d) => (d.type && d.type in iconMapping ? d.type : "unknown"),
-        getSize: (d) => (isBusStop(d) ? 14 : 22),
+        getSize: (d) => (isBusStop(d) ? 16 : 26),
         getColor: (d) => {
           const tier = ZOOM_TIERS[d.type ?? "unknown"] ?? MIN_ZOOM;
           const alpha = settledZoom >= tier ? 255 : 0;
@@ -106,8 +110,8 @@ export default function POIs({ visible, onClick }: POIMarkerProps) {
           return false;
         },
         sizeUnits: "pixels",
-        sizeMinPixels: 8,
-        sizeMaxPixels: 36,
+        sizeMinPixels: 10,
+        sizeMaxPixels: 40,
         transitions: {
           getColor: {
             duration: FADE_DURATION_MS,
@@ -125,8 +129,28 @@ export default function POIs({ visible, onClick }: POIMarkerProps) {
           },
         } as Record<string, unknown>),
       }),
+      // Persistent name labels below each marker. Decluttered purely by the
+      // LABEL_ZOOM gate: they only appear once you've zoomed into a
+      // neighbourhood, so overlap stays manageable. (CollisionFilterExtension
+      // is deliberately NOT used here — on TextLayer it culls every label.)
+      new TextLayer<POI>({
+        id: "poi-labels",
+        data: showLabels ? visiblePois : [],
+        getPosition: (d) => [d.coordinates[1], d.coordinates[0]],
+        getText: (d) => d.name ?? "",
+        getColor: [236, 239, 241, 255],
+        getSize: 12,
+        getTextAnchor: "middle",
+        getAlignmentBaseline: "top",
+        getPixelOffset: [0, 17],
+        fontFamily: "inherit",
+        fontWeight: "600",
+        outlineWidth: 2,
+        outlineColor: [8, 10, 12, 235],
+        pickable: false,
+      }),
     ],
-    [visiblePois, onClick, settledZoom]
+    [visiblePois, showLabels, onClick, settledZoom]
   );
 
   useRegisterLayers("pois", layers, 45);


### PR DESCRIPTION
## Summary

POI markers blended into the dark map — flat circles with a barely-visible 1px/40% white ring and no separation from the background. You also couldn't tell *what* a POI was without clicking it.

- **`iconAtlas.ts`**: each marker now has a soft **drop shadow** + a crisp **white halo ring** (2.5px, 95%) so it lifts off the map. The atlas cell grew (48px + 5px padding) so the shadow/halo stay inside their own sprite, and the glyph is brighter.
- **`POIs.tsx`**: larger markers (26px, 16px for bus stops; clamped 10–40px) and **persistent name labels** below each marker (a `TextLayer`) once you zoom past `LABEL_ZOOM` (15).

### Note on decluttering
`CollisionFilterExtension` is deliberately **not** applied to the label `TextLayer` — in this deck.gl setup it culls *every* label (icons collision-filter fine). Label overlap is instead managed by the zoom gate, so labels only appear once zoomed into a neighbourhood.

## Test plan
- [x] `apps/ui`: `npm run type-check` passes
- [x] `apps/ui`: `npm test` passes (792/792)
- [x] `apps/ui`: `npm run format:check` / eslint pass
- [x] Verified live on the dev server: markers render with halo+shadow across all POI types; name labels appear at zoom ≥15 (e.g. "Pangani Girls Secondary School", "Lakumi Motors Ltd")

🤖 Generated with [Claude Code](https://claude.com/claude-code)