### PR TITLE
feat(ui): salvage #197 Phase-2 interaction quality onto the dock

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import client from "./utils/client";
 import Dock from "./Dock/Dock";
+import Inspector from "./Inspector/Inspector";
 import useTracking from "./Controls/useTracking";
 import MapView from "./Map/Map";
 import FleetLegend from "./Map/FleetLegend";
@@ -11,6 +12,7 @@ import CreateZoneDialog from "./Map/Geofence/CreateZoneDialog";
 import type { Fleet, Modifiers } from "./types";
 import type { BoundingBox } from "@moveet/shared-types";
 import type { POI } from "./types";
+import { isRoad } from "./utils/typeGuards";
 import { useVehicles } from "./hooks/useVehicles";
 import { useFleets } from "./hooks/useFleets";
 import { useVehicleTypeFilter } from "./hooks/useVehicleTypeFilter";
@@ -155,6 +157,19 @@ export default function App() {
     [setModifiers]
   );
 
+  // ─── Inspector selection ────────────────────────────────────────
+  // Resolve the selected vehicle / POI objects from the existing selection
+  // state (no new selection source) to feed the on-demand Inspector panel.
+  const selectedVehicle = useMemo(
+    () => (filters.selected ? vehicles.find((v) => v.id === filters.selected) : undefined),
+    [filters.selected, vehicles]
+  );
+  const selectedPoi = selectedItem && !isRoad(selectedItem) ? selectedItem : undefined;
+  const closeInspector = useCallback(() => {
+    onUnselectVehicle();
+    setSelectedItem(null);
+  }, [onUnselectVehicle, setSelectedItem]);
+
   const maxSpeedRef = useRef(60);
   useTracking(vehicles, filters.selected, status.interval);
 
@@ -193,6 +208,8 @@ export default function App() {
               onRemoveWaypointGroup={dispatch.removeWaypointGroup}
               incidents={incidents.incidents}
               fences={geofences.fences}
+              selectedFenceId={geofences.selectedFenceId}
+              onSelectFence={geofences.onSelectFence}
               drawingActive={geofences.drawingActive}
               onDrawComplete={geofences.onDrawComplete}
               onDrawCancel={geofences.onDrawCancel}
@@ -273,6 +290,12 @@ export default function App() {
                 onRefreshRecordings: recording.refreshRecordings,
               }}
               advanced={{ maxSpeedRef }}
+            />
+            <Inspector
+              vehicle={selectedVehicle}
+              poi={selectedPoi ?? undefined}
+              fleet={selectedVehicle ? vehicleFleetMap.get(selectedVehicle.id) : undefined}
+              onClose={closeInspector}
             />
             <CreateZoneDialog
               polygon={geofences.pendingPolygon}

--- a/apps/ui/src/Controls/useTracking.test.ts
+++ b/apps/ui/src/Controls/useTracking.test.ts
@@ -1,35 +1,110 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
-import useTracking from "./useTracking";
+import useTracking, { MIN_FOCUS_ZOOM } from "./useTracking";
 import { useMapControls } from "@/components/Map/hooks";
 import { createVehicle } from "@/test/mocks/types";
+import type { Vehicle } from "@/types";
 
 vi.mock("@/components/Map/hooks", () => ({
-  useMapControls: vi.fn().mockReturnValue({
-    focusOn: vi.fn(),
-  }),
+  useMapControls: vi.fn(),
 }));
+
+const focusOn = vi.fn();
+const getZoom = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  getZoom.mockReturnValue(12);
+  vi.mocked(useMapControls).mockReturnValue({
+    zoomIn: vi.fn(),
+    zoomOut: vi.fn(),
+    panTo: vi.fn(),
+    setZoom: vi.fn(),
+    getZoom,
+    setBounds: vi.fn(),
+    focusOn,
+  });
 });
 
+function renderTracking(vehicles: Vehicle[], selected: string | undefined) {
+  return renderHook(
+    ({ vehicles, selected }: { vehicles: Vehicle[]; selected: string | undefined }) =>
+      useTracking(vehicles, selected),
+    { initialProps: { vehicles, selected } }
+  );
+}
+
 describe("useTracking", () => {
-  it("calls focusOn with vehicle position and zoom 15 when a vehicle is selected", () => {
+  it("flies once on selection, flooring the current zoom to MIN_FOCUS_ZOOM", () => {
     const vehicle = createVehicle({ id: "v1", position: [36.82, -1.29] });
-    const { focusOn } = vi.mocked(useMapControls)();
+    getZoom.mockReturnValue(10);
 
-    renderHook(() => useTracking([vehicle], "v1"));
+    renderTracking([vehicle], "v1");
 
-    expect(focusOn).toHaveBeenCalledWith(36.82, -1.29, 15, { duration: 0 });
+    expect(focusOn).toHaveBeenCalledTimes(1);
+    expect(focusOn).toHaveBeenCalledWith(36.82, -1.29, MIN_FOCUS_ZOOM, { duration: 0 });
+  });
+
+  it("keeps the user's zoom when already zoomed in past the floor", () => {
+    const vehicle = createVehicle({ id: "v1", position: [36.82, -1.29] });
+    getZoom.mockReturnValue(16.5);
+
+    renderTracking([vehicle], "v1");
+
+    expect(focusOn).toHaveBeenCalledWith(36.82, -1.29, 16.5, { duration: 0 });
   });
 
   it("does NOT call focusOn when no vehicle is selected", () => {
     const vehicle = createVehicle({ id: "v1" });
-    const { focusOn } = vi.mocked(useMapControls)();
 
-    renderHook(() => useTracking([vehicle], undefined));
+    renderTracking([vehicle], undefined);
 
     expect(focusOn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT re-fly on position ticks while the same vehicle stays selected", () => {
+    const vehicle = createVehicle({ id: "v1", position: [36.82, -1.29] });
+    const { rerender } = renderTracking([vehicle], "v1");
+    expect(focusOn).toHaveBeenCalledTimes(1);
+
+    const moved = createVehicle({ id: "v1", position: [36.83, -1.3] });
+    rerender({ vehicles: [moved], selected: "v1" });
+    rerender({ vehicles: [createVehicle({ id: "v1", position: [36.84, -1.31] })], selected: "v1" });
+
+    expect(focusOn).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-flies when a different vehicle is selected", () => {
+    const v1 = createVehicle({ id: "v1", position: [36.82, -1.29] });
+    const v2 = createVehicle({ id: "v2", position: [36.9, -1.35] });
+    const { rerender } = renderTracking([v1, v2], "v1");
+    expect(focusOn).toHaveBeenCalledTimes(1);
+
+    rerender({ vehicles: [v1, v2], selected: "v2" });
+
+    expect(focusOn).toHaveBeenCalledTimes(2);
+    expect(focusOn).toHaveBeenLastCalledWith(36.9, -1.35, MIN_FOCUS_ZOOM, { duration: 0 });
+  });
+
+  it("re-flies when the same vehicle is re-selected after deselection", () => {
+    const vehicle = createVehicle({ id: "v1", position: [36.82, -1.29] });
+    const { rerender } = renderTracking([vehicle], "v1");
+    expect(focusOn).toHaveBeenCalledTimes(1);
+
+    rerender({ vehicles: [vehicle], selected: undefined });
+    rerender({ vehicles: [vehicle], selected: "v1" });
+
+    expect(focusOn).toHaveBeenCalledTimes(2);
+  });
+
+  it("flies once the selected vehicle's position becomes available", () => {
+    const { rerender } = renderTracking([], "v1");
+    expect(focusOn).not.toHaveBeenCalled();
+
+    const vehicle = createVehicle({ id: "v1", position: [36.82, -1.29] });
+    rerender({ vehicles: [vehicle], selected: "v1" });
+
+    expect(focusOn).toHaveBeenCalledTimes(1);
+    expect(focusOn).toHaveBeenCalledWith(36.82, -1.29, MIN_FOCUS_ZOOM, { duration: 0 });
   });
 });

--- a/apps/ui/src/Controls/useTracking.ts
+++ b/apps/ui/src/Controls/useTracking.ts
@@ -1,19 +1,41 @@
 import { useMapControls } from "@/components/Map/hooks";
 import type { Vehicle } from "@/types";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
+/**
+ * Minimum zoom the camera flies to when a vehicle is selected from a far
+ * overview. When already zoomed in past this, the user's zoom is kept.
+ */
+export const MIN_FOCUS_ZOOM = 14;
+
+/**
+ * Fly to the selected vehicle ONCE per selection, at the user's current zoom
+ * floored to MIN_FOCUS_ZOOM. Position ticks never re-center the viewport, so
+ * the user can pan/zoom freely while a vehicle stays selected. The camera
+ * moves again only when the selection changes (or the vehicle is re-selected
+ * after being deselected).
+ */
 export default function useTracking(
   vehicles: Vehicle[],
   selected: string | undefined,
   duration: number = 0
 ) {
-  const { focusOn } = useMapControls();
+  const { focusOn, getZoom } = useMapControls();
   const vehicle = vehicles.find((v) => v.id === selected);
   const [lng, lat] = vehicle?.position || [null, null];
 
+  // Selection id we already flew to — guards against per-tick re-centering
+  // (lng/lat update ~every second and must not fight the user's viewport).
+  const flownToRef = useRef<string | undefined>(undefined);
+
   useEffect(() => {
-    if (selected && lng != null && lat != null) {
-      focusOn(lng, lat, 15, { duration });
+    if (!selected) {
+      flownToRef.current = undefined;
+      return;
     }
-  }, [selected, lng, lat, duration, focusOn]);
+    if (flownToRef.current === selected) return;
+    if (lng == null || lat == null) return;
+    flownToRef.current = selected;
+    focusOn(lng, lat, Math.max(getZoom(), MIN_FOCUS_ZOOM), { duration });
+  }, [selected, lng, lat, duration, focusOn, getZoom]);
 }

--- a/apps/ui/src/Inspector/Inspector.test.tsx
+++ b/apps/ui/src/Inspector/Inspector.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Inspector from "./Inspector";
+import { createVehicle, createPOI } from "@/test/mocks/types";
+import type { Fleet, Route } from "@/types";
+
+describe("Inspector", () => {
+  it("renders nothing when neither a vehicle nor a POI is selected", () => {
+    const { container } = render(<Inspector onClose={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders vehicle details when a vehicle is selected", () => {
+    render(
+      <Inspector
+        vehicle={createVehicle({ id: "v1", name: "Test Vehicle 1", speed: 42, heading: 90 })}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Test Vehicle 1")).toBeInTheDocument();
+    expect(screen.getByText("v1")).toBeInTheDocument();
+    expect(screen.getByText(/42 km\/h/)).toBeInTheDocument();
+    expect(screen.getByText(/90°/)).toBeInTheDocument();
+    expect(screen.getByText("En route")).toBeInTheDocument();
+  });
+
+  it("shows Idle status for a stopped vehicle", () => {
+    render(<Inspector vehicle={createVehicle({ speed: 0 })} onClose={vi.fn()} />);
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+
+  it("prefers the resolved fleet name and shows the route distance when provided", () => {
+    const fleet: Fleet = {
+      id: "f1",
+      name: "North Fleet",
+      color: "#fff",
+      source: "local",
+      vehicleIds: ["v1"],
+    };
+    const route: Route = { edges: [], distance: 3.4 };
+    render(
+      <Inspector
+        vehicle={createVehicle({ id: "v1" })}
+        fleet={fleet}
+        route={route}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText("North Fleet")).toBeInTheDocument();
+    expect(screen.getByText("3.4 km")).toBeInTheDocument();
+  });
+
+  it("renders POI details, falling back gracefully when the name is null", () => {
+    render(
+      <Inspector
+        poi={createPOI({ id: "poi1", name: null, type: "restaurant" })}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Point of interest")).toBeInTheDocument();
+    expect(screen.getByText("restaurant")).toBeInTheDocument();
+    expect(screen.getByText("poi1")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(<Inspector vehicle={createVehicle()} onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    render(<Inspector vehicle={createVehicle()} onClose={onClose} />);
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/src/Inspector/Inspector.tsx
+++ b/apps/ui/src/Inspector/Inspector.tsx
@@ -1,0 +1,137 @@
+import { useEffect } from "react";
+import { cn } from "@/lib/utils";
+import type { Fleet, POI, Position, Route, Vehicle } from "@/types";
+import { CloseIcon } from "@/components/Icons";
+import { Eyebrow, Hairline, PanelHead, StatusDot, Tag, mono } from "@/Dock/DockPanelKit";
+
+/**
+ * On-demand right-side detail panel for the currently selected vehicle or POI.
+ * Selection is passed in via props (App owns the selection state) — this panel
+ * is a pure presenter that renders nothing when neither target is set. It
+ * borrows the dock family's glass surface and tight-technical density
+ * (monospace numerics, hairline rows, micro uppercase eyebrows) so it reads as
+ * the same instrument as the dock panels.
+ */
+export interface InspectorProps {
+  /** The selected vehicle, if any. */
+  vehicle?: Vehicle;
+  /** The selected POI, if any. Ignored when a vehicle is set. */
+  poi?: POI;
+  /** Resolved fleet for the selected vehicle (App resolves it from `fleetId`). */
+  fleet?: Fleet;
+  /** Active route for the selected vehicle (App reads it from the directions map). */
+  route?: Route;
+  /** Close the inspector (clears selection upstream). */
+  onClose: () => void;
+}
+
+/** One key/value detail line: muted uppercase label left, mono-ish value right. */
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3 border-t border-border-soft px-[15px] py-[9px] first:border-t-0">
+      <Eyebrow className="shrink-0">{label}</Eyebrow>
+      <div className="min-w-0 truncate text-right text-[12px] text-foreground">{children}</div>
+    </div>
+  );
+}
+
+/** Format a [lng, lat] position as a monospace `lat, lng` pair. */
+function formatCoords([lng, lat]: Position): string {
+  return `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+}
+
+export default function Inspector({ vehicle, poi, fleet, route, onClose }: InspectorProps) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  if (!vehicle && !poi) return null;
+
+  const moving = vehicle ? vehicle.speed > 0 : false;
+  const eyebrow = vehicle ? "Vehicle" : "Location";
+  const title = vehicle ? vehicle.name : (poi?.name ?? "Point of interest");
+
+  return (
+    <aside
+      role="region"
+      aria-label="Inspector"
+      className={cn(
+        "absolute right-4 top-4 z-40 w-80 max-w-[calc(100vw-2rem)] origin-top-right",
+        "overflow-hidden rounded-[10px] border border-border surface-glass-strong shadow-floating backdrop-blur-2xl backdrop-saturate-150",
+        "animate-scale-in"
+      )}
+    >
+      <PanelHead
+        eyebrow={eyebrow}
+        title={title}
+        right={
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close inspector"
+            title="Close"
+            className={cn(
+              "flex size-6 shrink-0 items-center justify-center rounded-md border border-transparent",
+              "text-muted-foreground transition-colors duration-fast ease-standard",
+              "hover:border-border hover:bg-accent hover:text-foreground",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+            )}
+          >
+            <CloseIcon className="size-4" />
+          </button>
+        }
+      />
+      <Hairline />
+
+      {vehicle && (
+        <div className="flex flex-col pb-1">
+          <Field label="ID">
+            <span className={mono}>{vehicle.id}</span>
+          </Field>
+          <Field label="Status">
+            <span className="inline-flex items-center gap-1.5">
+              <StatusDot tone={moving ? "ok" : "idle"} />
+              {moving ? "En route" : "Idle"}
+            </span>
+          </Field>
+          <Field label="Type">
+            <Tag tone="accent">{vehicle.type}</Tag>
+          </Field>
+          <Field label="Speed">
+            <span className={mono}>{Math.round(vehicle.speed)} km/h</span>
+          </Field>
+          <Field label="Heading">
+            <span className={mono}>{Math.round(vehicle.heading)}°</span>
+          </Field>
+          <Field label="Fleet">{fleet?.name ?? vehicle.fleetId ?? "—"}</Field>
+          {route && (
+            <Field label="Route">
+              <span className={mono}>{route.distance.toFixed(1)} km</span>
+            </Field>
+          )}
+          <Field label="Coordinates">
+            <span className={mono}>{formatCoords(vehicle.position)}</span>
+          </Field>
+        </div>
+      )}
+
+      {poi && !vehicle && (
+        <div className="flex flex-col pb-1">
+          <Field label="ID">
+            <span className={mono}>{poi.id}</span>
+          </Field>
+          <Field label="Type">
+            <Tag tone="accent">{poi.type}</Tag>
+          </Field>
+          <Field label="Coordinates">
+            <span className={mono}>{formatCoords(poi.coordinates)}</span>
+          </Field>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceDrawTool.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { PolygonLayer, ScatterplotLayer, PathLayer } from "@deck.gl/layers";
 import { useMapContext, useOverlay } from "@/components/Map/hooks";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
+import { drawProgressHint } from "@/lib/geofenceHints";
 
 interface GeofenceDrawToolProps {
   active: boolean;
@@ -476,12 +477,11 @@ export default function GeofenceDrawTool({
   // Hint overlay rendered over the map, outside the side panel.
   if (!active || !mapHTMLElement) return null;
 
+  // Vertex-count phase copy comes from the shared helper; once the polygon has
+  // enough vertices (helper returns null) show the ready-state instructions.
   const hint =
-    vertices.length === 0
-      ? "Click the map to place points — at least 3 — Esc to cancel"
-      : vertices.length < 3
-        ? `${vertices.length} point${vertices.length === 1 ? "" : "s"} — add ${3 - vertices.length} more`
-        : "Click the first point or press Enter to finish • drag to move • click an edge to insert • right-click to delete";
+    drawProgressHint(vertices.length) ??
+    "Click the first point or press Enter to finish • drag to move • click an edge to insert • right-click to delete";
 
   return createPortal(
     <div

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.test.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { GeoFence } from "@moveet/shared-types";
+
+// ---------------------------------------------------------------------------
+// Capture registered layers via useRegisterLayers mock (jsdom has no WebGL —
+// assert on constructed layer props, not pixels).
+// ---------------------------------------------------------------------------
+const { registeredLayers } = vi.hoisted(() => {
+  const registeredLayers = new Map<string, unknown[]>();
+  return { registeredLayers };
+});
+
+vi.mock("@/components/Map/hooks/useDeckLayers", () => ({
+  useRegisterLayers: (id: string, layers: unknown[]) => {
+    registeredLayers.set(id, layers);
+  },
+  useDeckLayersContext: () => ({
+    registerLayers: () => {},
+    unregisterLayers: () => {},
+  }),
+}));
+
+import GeofenceLayer from "./GeofenceLayer";
+
+function makeFence(overrides: Partial<GeoFence> = {}): GeoFence {
+  return {
+    id: "fence-1",
+    name: "Depot Zone",
+    type: "delivery",
+    active: true,
+    polygon: [
+      [36.8, -1.28],
+      [36.82, -1.28],
+      [36.82, -1.3],
+      [36.8, -1.3],
+    ],
+    ...overrides,
+  } as GeoFence;
+}
+
+interface LayerLike {
+  props: {
+    id: string;
+    pickable: boolean;
+    onClick?: (info: { object?: GeoFence }) => boolean;
+    updateTriggers?: Record<string, unknown>;
+    getLineWidth: (d: GeoFence) => number;
+  };
+}
+
+function getLayer(id: string): LayerLike {
+  const layers = (registeredLayers.get("geofences") ?? []) as LayerLike[];
+  const layer = layers.find((l) => l.props.id === id);
+  if (!layer) throw new Error(`layer ${id} not registered`);
+  return layer;
+}
+
+beforeEach(() => {
+  registeredLayers.clear();
+});
+
+describe("GeofenceLayer", () => {
+  it("registers no layers when there are no fences", () => {
+    render(<GeofenceLayer fences={[]} />);
+    expect(registeredLayers.get("geofences")).toEqual([]);
+  });
+
+  it("fence polygons are pickable; labels are not", () => {
+    render(<GeofenceLayer fences={[makeFence()]} />);
+    expect(getLayer("geofences").props.pickable).toBe(true);
+    expect(getLayer("geofence-labels").props.pickable).toBe(false);
+  });
+
+  it("onClick selects the clicked fence and returns true (marks the event handled)", () => {
+    const onSelectFence = vi.fn();
+    const fence = makeFence();
+    render(<GeofenceLayer fences={[fence]} onSelectFence={onSelectFence} />);
+
+    const handled = getLayer("geofences").props.onClick!({ object: fence });
+
+    expect(onSelectFence).toHaveBeenCalledWith("fence-1");
+    expect(handled).toBe(true);
+  });
+
+  it("onClick without a picked object does not fire the callback and lets the event bubble", () => {
+    const onSelectFence = vi.fn();
+    render(<GeofenceLayer fences={[makeFence()]} onSelectFence={onSelectFence} />);
+
+    const handled = getLayer("geofences").props.onClick!({});
+
+    expect(onSelectFence).not.toHaveBeenCalled();
+    expect(handled).toBe(false);
+  });
+
+  it("still marks a fence click handled when no onSelectFence is wired", () => {
+    const fence = makeFence();
+    render(<GeofenceLayer fences={[fence]} />);
+    expect(getLayer("geofences").props.onClick!({ object: fence })).toBe(true);
+  });
+
+  it("is not pickable and lets clicks fall through when selectable is false", () => {
+    // While another interaction owns the map click, a fence must not pick
+    // (returning true) and swallow DeckGL's map-level onClick.
+    const onSelectFence = vi.fn();
+    const fence = makeFence();
+    render(<GeofenceLayer fences={[fence]} onSelectFence={onSelectFence} selectable={false} />);
+
+    const layer = getLayer("geofences");
+    expect(layer.props.pickable).toBe(false);
+    expect(layer.props.onClick!({ object: fence })).toBe(false);
+    expect(onSelectFence).not.toHaveBeenCalled();
+  });
+
+  it("draws the selected fence with a thicker outline and pins it via updateTriggers", () => {
+    const fence = makeFence();
+    const other = makeFence({ id: "fence-2", name: "Other" });
+    render(<GeofenceLayer fences={[fence, other]} selectedFenceId="fence-1" />);
+
+    const layer = getLayer("geofences");
+    expect(layer.props.getLineWidth(fence)).toBe(2);
+    expect(layer.props.getLineWidth(other)).toBe(1);
+    expect(layer.props.updateTriggers?.getLineWidth).toBe("fence-1");
+  });
+});

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
@@ -52,12 +52,31 @@ function centroid(points: [number, number][]): [number, number] {
   return [x, y];
 }
 
+// INTEGRATION: Map.tsx must pass `selectedFenceId` + `onSelectFence` from
+// useGeofenceManager() so a fence click selects/deselects it. Optionally pass
+// `selectable={false}` while another map interaction owns the click (e.g.
+// dispatch/geofence-draw), otherwise a fence pick returns true and swallows
+// DeckGL's map-level onClick. The pointer-on-hover cursor is automatic:
+// DeckGL's getCursor already returns "pointer" for any hovered pickable layer.
 interface GeofenceLayerProps {
   fences: GeoFence[];
   selectedFenceId?: string;
+  /** Map click on a fence polygon selects it (panel-local selection). */
+  onSelectFence?: (id: string) => void;
+  /**
+   * Whether fence polygons respond to map clicks. Defaults to true. Set false
+   * when another interaction owns map clicks so a fence must NOT pick (which
+   * would return true from onClick and suppress DeckGL's map-level onClick).
+   */
+  selectable?: boolean;
 }
 
-export default function GeofenceLayer({ fences, selectedFenceId }: GeofenceLayerProps) {
+export default function GeofenceLayer({
+  fences,
+  selectedFenceId,
+  onSelectFence,
+  selectable = true,
+}: GeofenceLayerProps) {
   const layers = useMemo(() => {
     if (fences.length === 0) return [];
 
@@ -72,7 +91,21 @@ export default function GeofenceLayer({ fences, selectedFenceId }: GeofenceLayer
         lineWidthUnits: "pixels",
         filled: true,
         stroked: true,
-        pickable: false,
+        // Only pickable in browse mode: while another interaction owns map
+        // clicks, a fence pick would return true and swallow the map-level
+        // click. When pickable, DeckGL's getCursor shows a pointer on hover.
+        pickable: selectable,
+        onClick: (info: { object?: GeoFence }) => {
+          if (!selectable || !info.object) return false;
+          onSelectFence?.(info.object.id);
+          // Mark handled so DeckGL.onClick (map-empty-click clear) doesn't fire.
+          return true;
+        },
+        updateTriggers: {
+          // Accessor identity changes don't re-evaluate attributes in deck.gl;
+          // the selected fence's thicker outline needs an explicit trigger.
+          getLineWidth: selectedFenceId,
+        },
         transitions: {
           getFillColor: {
             duration: FADE_DURATION_MS,
@@ -105,7 +138,7 @@ export default function GeofenceLayer({ fences, selectedFenceId }: GeofenceLayer
         outlineWidth: 3,
       }),
     ];
-  }, [fences, selectedFenceId]);
+  }, [fences, selectedFenceId, onSelectFence, selectable]);
 
   useRegisterLayers("geofences", layers);
 

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -80,6 +80,7 @@ interface MapProps {
   incidents?: IncidentDTO[];
   fences?: GeoFence[];
   selectedFenceId?: string;
+  onSelectFence?: (id: string) => void;
   drawingActive?: boolean;
   onDrawComplete?: (polygon: [number, number][]) => void;
   onDrawCancel?: () => void;
@@ -111,6 +112,7 @@ export default function Map({
   incidents,
   fences = [],
   selectedFenceId,
+  onSelectFence,
   drawingActive = false,
   onDrawComplete,
   onDrawCancel,
@@ -179,8 +181,19 @@ export default function Map({
             <SpeedLimitSigns visible={modifiers.showSpeedLimits} />
           </Suspense>
         )}
-        {/* Geofence zones — rendered between roads and vehicles */}
-        {fences.length > 0 && <GeofenceLayer fences={fences} selectedFenceId={selectedFenceId} />}
+        {/* Geofence zones — rendered between roads and vehicles. Fence clicks
+            select/deselect; disabled while drawing or dispatching so those
+            interactions own the map click. */}
+        {fences.length > 0 && (
+          <GeofenceLayer
+            fences={fences}
+            selectedFenceId={selectedFenceId}
+            onSelectFence={onSelectFence}
+            selectable={
+              !drawingActive && (!dispatchState || dispatchState === DispatchState.BROWSE)
+            }
+          />
+        )}
         <Direction selected={filters.selected} hovered={filters.hovered} />
         {modifiers.showBreadcrumbs && (
           <Suspense fallback={null}>

--- a/apps/ui/src/Map/Road.tsx
+++ b/apps/ui/src/Map/Road.tsx
@@ -60,9 +60,10 @@ export default function DirectionMap({ road }: DirectionProps) {
         widthUnits: "pixels",
         jointRounded: true,
         capRounded: true,
-        pickable: true,
-        autoHighlight: true,
-        highlightColor: [255, 255, 255, 40],
+        // Not pickable: the path has no click handler, so a hover highlight
+        // would imply interactivity it doesn't have (a click falls through
+        // to the map and clears the selection).
+        pickable: false,
       }),
       new TextLayer({
         id: "selected-road-label",

--- a/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
+++ b/apps/ui/src/Map/Vehicle/VehiclesLayer.tsx
@@ -582,9 +582,9 @@ export default function VehiclesLayer({
       billboard: false,
       pickable: true,
       onClick: handleClick,
+      // Hover feedback is the React-driven ring above (via onHover →
+      // hoveredId) — no autoHighlight, which would stack a second treatment.
       onHover: handleHover,
-      autoHighlight: true,
-      highlightColor: [251, 201, 1, 80],
       updateTriggers: {
         // Icons only change when the atlas rebuilds (new type/color combo).
         getIcon: atlas,

--- a/apps/ui/src/__tests__/VehiclesLayer.test.tsx
+++ b/apps/ui/src/__tests__/VehiclesLayer.test.tsx
@@ -538,10 +538,19 @@ describe("VehiclesLayer hit testing (deck.gl)", () => {
     const layers = registeredLayers.get("vehicles")!;
     const vehiclesLayer = layers.find(
       (l) => (l as { props: { id: string } }).props.id === "vehicles"
-    ) as { props: { pickable: boolean; onClick: (info: { object?: unknown }) => void } };
+    ) as {
+      props: {
+        pickable: boolean;
+        autoHighlight: boolean;
+        onClick: (info: { object?: unknown }) => void;
+      };
+    };
 
     expect(vehiclesLayer.props.pickable).toBe(true);
     expect(typeof vehiclesLayer.props.onClick).toBe("function");
+    // Hover feedback is the React-driven ring only — autoHighlight would
+    // stack a second, GL-side hover treatment on top of it.
+    expect(vehiclesLayer.props.autoHighlight).toBe(false);
   });
 });
 

--- a/apps/ui/src/components/Icons.tsx
+++ b/apps/ui/src/components/Icons.tsx
@@ -34,6 +34,7 @@ import {
   Hexagon as HexagonBase,
   ClipboardList as ClipboardListBase,
   Clock as ClockBase,
+  X as XBase,
   type LucideIcon,
   type LucideProps,
 } from "lucide-react";
@@ -88,3 +89,4 @@ export const ChartIcon = aliasIcon(ChartLineBase);
 export const GeofenceIcon = aliasIcon(HexagonBase);
 export const ScenarioIcon = aliasIcon(ClipboardListBase);
 export const ClockIcon = aliasIcon(ClockBase);
+export const CloseIcon = aliasIcon(XBase);

--- a/apps/ui/src/components/Map/components/DeckGLMap.tsx
+++ b/apps/ui/src/components/Map/components/DeckGLMap.tsx
@@ -326,11 +326,20 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
     return () => container.removeEventListener("keydown", onKeyDown);
   }, [containerRef, controls, onEscape]);
 
+  // Controller config lives on the view (single source of truth — do not also
+  // pass `controller` to <DeckGL>): the map is strictly 2D so rotation is
+  // disabled, smooth scroll-zoom and a short inertia make pan/zoom feel less
+  // stepped.
   const MAP_VIEW = useMemo(
     () =>
       new MapView({
         id: "main",
-        controller: true,
+        controller: {
+          dragRotate: false,
+          touchRotate: false,
+          scrollZoom: { smooth: true },
+          inertia: 250,
+        },
       }),
     []
   );
@@ -372,7 +381,7 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
                     layers={allLayers}
                     onClick={handleClick}
                     onError={handleDeckError}
-                    controller={true}
+                    pickingRadius={5}
                     style={{ position: "relative" }}
                     getCursor={getCursor}
                     getTooltip={getTooltip}

--- a/apps/ui/src/components/Map/hooks/useDeckLayers.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckLayers.ts
@@ -38,7 +38,6 @@ const LAYER_ORDER: Record<string, number> = {
   "selected-road": 55,
   "pending-dispatch": 60,
   vehicles: 70,
-  "vehicle-selection-ring": 65,
   "geofence-draw": 80,
 };
 

--- a/apps/ui/src/components/Map/hooks/useDeckViewState.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckViewState.ts
@@ -6,10 +6,12 @@ import type { PanToOptions, DeckViewStateControls } from "../providers/types";
 
 export type { DeckViewStateControls };
 
+const DEFAULT_ZOOM = 12;
+
 const DEFAULT_VIEW_STATE: MapViewState = {
   longitude: 36.82,
   latitude: -1.29,
-  zoom: 12,
+  zoom: DEFAULT_ZOOM,
   pitch: 0,
   bearing: 0,
   minZoom: 1,
@@ -25,6 +27,13 @@ interface UseDeckViewStateOptions {
 export function useDeckViewState({ data, width, height }: UseDeckViewStateOptions) {
   const [viewState, setViewState] = useState<MapViewState>(DEFAULT_VIEW_STATE);
   const initializedRef = useRef(false);
+
+  // Live view-state ref so stable callbacks (getZoom) can read the current
+  // value without re-creating on every pan/zoom.
+  const viewStateRef = useRef(viewState);
+  useEffect(() => {
+    viewStateRef.current = viewState;
+  }, [viewState]);
 
   // Fit to data bounds on first load
   useEffect(() => {
@@ -107,6 +116,8 @@ export function useDeckViewState({ data, width, height }: UseDeckViewStateOption
     setViewState((prev) => ({ ...prev, zoom }));
   }, []);
 
+  const getZoom = useCallback(() => viewStateRef.current.zoom ?? DEFAULT_ZOOM, []);
+
   const setBounds = useCallback(
     (bounds: [Position, Position]) => {
       if (!width || !height) return;
@@ -145,6 +156,7 @@ export function useDeckViewState({ data, width, height }: UseDeckViewStateOption
     zoomOut,
     panTo,
     setZoom,
+    getZoom,
     setBounds,
     focusOn,
   };

--- a/apps/ui/src/components/Map/providers/contexts.ts
+++ b/apps/ui/src/components/Map/providers/contexts.ts
@@ -26,6 +26,7 @@ export const MapControlsContext = createContext<MapControlsContextValue>({
   zoomOut: () => {},
   panTo: () => {},
   setZoom: () => {},
+  getZoom: () => 0,
   setBounds: () => {},
   focusOn: () => {},
 });

--- a/apps/ui/src/components/Map/providers/controls.ts
+++ b/apps/ui/src/components/Map/providers/controls.ts
@@ -5,6 +5,7 @@ export let controlsRef: MapControlsContextValue = {
   zoomOut: () => {},
   panTo: () => {},
   setZoom: () => {},
+  getZoom: () => 0,
   setBounds: () => {},
   focusOn: () => {},
 };

--- a/apps/ui/src/components/Map/providers/types.ts
+++ b/apps/ui/src/components/Map/providers/types.ts
@@ -20,6 +20,8 @@ export interface MapControlsContextValue {
   zoomOut: () => void;
   panTo: (lng: number, lat: number, options: PanToOptions) => void;
   setZoom: (zoom: number) => void;
+  /** Current map zoom — for callers outside the map providers (e.g. useTracking). */
+  getZoom: () => number;
   setBounds: (bounds: [Position, Position]) => void;
   focusOn: (lng: number, lat: number, zoom: number, options: PanToOptions) => void;
 }

--- a/apps/ui/src/hooks/useDispatchState.test.ts
+++ b/apps/ui/src/hooks/useDispatchState.test.ts
@@ -95,16 +95,18 @@ describe("cursorForDispatchState", () => {
     expect(cursorForDispatchState(DispatchState.DISPATCH)).toBe("wait");
   });
 
-  it('returns "default" for BROWSE', () => {
-    expect(cursorForDispatchState(DispatchState.BROWSE)).toBe("default");
+  // Non-override states must return "grab": DeckGLMap's getCursor only falls
+  // through to hover/drag feedback (pointer/grabbing) when the cursor is "grab".
+  it('returns "grab" for BROWSE', () => {
+    expect(cursorForDispatchState(DispatchState.BROWSE)).toBe("grab");
   });
 
-  it('returns "default" for SELECT', () => {
-    expect(cursorForDispatchState(DispatchState.SELECT)).toBe("default");
+  it('returns "grab" for SELECT', () => {
+    expect(cursorForDispatchState(DispatchState.SELECT)).toBe("grab");
   });
 
-  it('returns "default" for RESULTS', () => {
-    expect(cursorForDispatchState(DispatchState.RESULTS)).toBe("default");
+  it('returns "grab" for RESULTS', () => {
+    expect(cursorForDispatchState(DispatchState.RESULTS)).toBe("grab");
   });
 
   it('returns "grab" for undefined', () => {

--- a/apps/ui/src/hooks/useDispatchState.ts
+++ b/apps/ui/src/hooks/useDispatchState.ts
@@ -28,12 +28,15 @@ export function useDispatchState(signals: DispatchSignals): DispatchState {
   return deriveDispatchState(signals);
 }
 
+// "grab" is the idle map cursor — DeckGLMap's getCursor only applies its
+// hover/drag feedback (pointer/grabbing) when the explicit cursor is "grab",
+// so non-override states must map to "grab", not "default".
 const CURSOR_BY_STATE: Record<DispatchState, string> = {
-  [DispatchState.BROWSE]: "default",
-  [DispatchState.SELECT]: "default",
+  [DispatchState.BROWSE]: "grab",
+  [DispatchState.SELECT]: "grab",
   [DispatchState.ROUTE]: "crosshair",
   [DispatchState.DISPATCH]: "wait",
-  [DispatchState.RESULTS]: "default",
+  [DispatchState.RESULTS]: "grab",
 };
 
 export function cursorForDispatchState(state: DispatchState | undefined): string {

--- a/apps/ui/src/hooks/useGeofenceManager.ts
+++ b/apps/ui/src/hooks/useGeofenceManager.ts
@@ -15,6 +15,9 @@ const MAX_ALERTS = 200;
 export function useGeofenceManager() {
   const [fences, setFences] = useState<GeoFence[]>([]);
   const [alerts, setAlerts] = useState<GeoFenceEvent[]>([]);
+  // Fence selection is deliberately panel-local (NOT part of vehicle/POI
+  // selection): it only drives the map outline emphasis.
+  const [selectedFenceId, setSelectedFenceId] = useState<string | undefined>(undefined);
   const [drawingActive, setDrawingActive] = useState(false);
   const [drawingVertexCount, setDrawingVertexCount] = useState(0);
   const [drawConfirmId, setDrawConfirmId] = useState(0);
@@ -68,6 +71,7 @@ export function useGeofenceManager() {
     async (id: string) => {
       const prev = fences;
       setFences((f) => f.filter((x) => x.id !== id));
+      setSelectedFenceId((sel) => (sel === id ? undefined : sel));
       try {
         const res = await client.deleteGeofence(id);
         if (res.error) throw new Error(res.error);
@@ -79,6 +83,12 @@ export function useGeofenceManager() {
     },
     [fences]
   );
+
+  // ─── Selection ────────────────────────────────────────────────────
+  /** Toggle map-side fence selection (click the same fence again to clear). */
+  const onSelectFence = useCallback((id: string) => {
+    setSelectedFenceId((prev) => (prev === id ? undefined : id));
+  }, []);
 
   // ─── Drawing ──────────────────────────────────────────────────────
   const startDrawing = useCallback(() => setDrawingActive(true), []);
@@ -116,6 +126,8 @@ export function useGeofenceManager() {
   return {
     fences,
     alerts,
+    selectedFenceId,
+    onSelectFence,
     drawingActive,
     drawingVertexCount,
     setDrawingVertexCount,

--- a/apps/ui/src/lib/geofenceHints.test.ts
+++ b/apps/ui/src/lib/geofenceHints.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { drawProgressHint, MIN_GEOFENCE_VERTICES } from "./geofenceHints";
+
+describe("drawProgressHint", () => {
+  it("prompts for the first points when the polygon is empty", () => {
+    expect(drawProgressHint(0)).toBe(
+      `Click the map to add points (at least ${MIN_GEOFENCE_VERTICES})`
+    );
+  });
+
+  it("counts down remaining points while still short of the minimum", () => {
+    expect(drawProgressHint(1)).toBe("1 point placed, add 2 more");
+    expect(drawProgressHint(2)).toBe("2 points placed, add 1 more");
+  });
+
+  it("returns null once the polygon has enough vertices to confirm", () => {
+    expect(drawProgressHint(MIN_GEOFENCE_VERTICES)).toBeNull();
+    expect(drawProgressHint(MIN_GEOFENCE_VERTICES + 5)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/geofenceHints.ts
+++ b/apps/ui/src/lib/geofenceHints.ts
@@ -1,0 +1,20 @@
+/** Minimum vertices a geofence polygon needs before it can be confirmed. */
+export const MIN_GEOFENCE_VERTICES = 3;
+
+/**
+ * Progress copy for an in-progress geofence polygon, shared by the map's draw
+ * hint (GeofenceDrawTool) and any side-panel affordance so the vertex-count
+ * wording and the min-vertex rule live in exactly one place.
+ *
+ * Returns the "keep adding points" phase while the polygon is still short of
+ * MIN_GEOFENCE_VERTICES, or `null` once it has enough, so each surface can
+ * render its own ready-state affordance (finish instructions / Confirm button).
+ */
+export function drawProgressHint(vertexCount: number): string | null {
+  if (vertexCount >= MIN_GEOFENCE_VERTICES) return null;
+  if (vertexCount === 0) {
+    return `Click the map to add points (at least ${MIN_GEOFENCE_VERTICES})`;
+  }
+  const remaining = MIN_GEOFENCE_VERTICES - vertexCount;
+  return `${vertexCount} point${vertexCount === 1 ? "" : "s"} placed, add ${remaining} more`;
+}


### PR DESCRIPTION
Stacked on #210 (the dock redesign). Salvages the genuinely-independent Phase-2 improvements from the now-superseded **#197**, re-applied onto the dock architecture. #197's Phase-1 nav/IA is intentionally dropped — the dock replaced it.

## Included
- **Vehicle follow no longer fights the user** — flies to a selected vehicle *once* at the current zoom (floor 14); manual pan/zoom breaks follow instead of being re-centered every tick. (cherry-picked `6e9947a`)
- **Map interaction quality** — reachable grab/grabbing/pointer cursor states (was dead code), `pickingRadius=5` so small/moving targets are hittable, the 2D controller declared once (rotate off, smooth wheel zoom, pan inertia), misleading road hover-highlight removed, vehicle hover dedup (drop deck.gl `autoHighlight`, keep the React selection ring).
- **Inspector** — a new on-demand right-side panel for the selected vehicle/POI, styled in the dock's glass + tight-technical language (mono numerics, hairline fields), wired to the existing selection state. Escape/close clears selection.
- **Clickable geofences** — hover pointer + click-to-select on the map via `selectedFenceId`, disabled while drawing or dispatching so those interactions own the click.

## Deferred (still available in #197)
The **interaction-mode engine** (`useInteractionMode` mutual exclusion + single Escape/Enter dispatcher + `ModeBanner`). It reparents the *approved* dispatch flow (`useDispatchFlow`) and replaces the dispatch/geofence-draw banners — worth doing, but as a focused, browser-verified pass rather than a blind change to the dispatch UX. Its source stays on the `feat/ui-redesign-workspace` branch.

## Verification
Type-check clean · 0 lint errors · 788 tests pass · production build ok. Built without a browser — reviewer should exercise vehicle-follow, cursors, the Inspector, and geofence clicks in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)