### PR TITLE
feat(ui): turn-by-turn directions in the vehicle inspector + map highlight

### DIFF
--- a/apps/ui/src/Inspector/Inspector.test.tsx
+++ b/apps/ui/src/Inspector/Inspector.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Inspector from "./Inspector";
 import { createVehicle, createPOI } from "@/test/mocks/types";
-import type { Fleet, Route } from "@/types";
+import type { Fleet } from "@/types";
 
 describe("Inspector", () => {
   it("renders nothing when neither a vehicle nor a POI is selected", () => {
@@ -30,7 +30,7 @@ describe("Inspector", () => {
     expect(screen.getByText("Idle")).toBeInTheDocument();
   });
 
-  it("prefers the resolved fleet name and shows the route distance when provided", () => {
+  it("prefers the resolved fleet name over the raw fleet id", () => {
     const fleet: Fleet = {
       id: "f1",
       name: "North Fleet",
@@ -38,17 +38,8 @@ describe("Inspector", () => {
       source: "local",
       vehicleIds: ["v1"],
     };
-    const route: Route = { edges: [], distance: 3.4 };
-    render(
-      <Inspector
-        vehicle={createVehicle({ id: "v1" })}
-        fleet={fleet}
-        route={route}
-        onClose={vi.fn()}
-      />
-    );
+    render(<Inspector vehicle={createVehicle({ id: "v1" })} fleet={fleet} onClose={vi.fn()} />);
     expect(screen.getByText("North Fleet")).toBeInTheDocument();
-    expect(screen.getByText("3.4 km")).toBeInTheDocument();
   });
 
   it("renders POI details, falling back gracefully when the name is null", () => {

--- a/apps/ui/src/Inspector/Inspector.tsx
+++ b/apps/ui/src/Inspector/Inspector.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
 import { cn } from "@/lib/utils";
-import type { Fleet, POI, Position, Route, Vehicle } from "@/types";
+import type { Fleet, POI, Position, Vehicle } from "@/types";
 import { CloseIcon } from "@/components/Icons";
+import { invertLatLng } from "@/utils/coordinates";
 import { Eyebrow, Hairline, PanelHead, StatusDot, Tag, mono } from "@/Dock/DockPanelKit";
+import VehicleDirections from "./VehicleDirections";
 
 /**
  * On-demand right-side detail panel for the currently selected vehicle or POI.
@@ -19,8 +21,6 @@ export interface InspectorProps {
   poi?: POI;
   /** Resolved fleet for the selected vehicle (App resolves it from `fleetId`). */
   fleet?: Fleet;
-  /** Active route for the selected vehicle (App reads it from the directions map). */
-  route?: Route;
   /** Close the inspector (clears selection upstream). */
   onClose: () => void;
 }
@@ -40,7 +40,7 @@ function formatCoords([lng, lat]: Position): string {
   return `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
 }
 
-export default function Inspector({ vehicle, poi, fleet, route, onClose }: InspectorProps) {
+export default function Inspector({ vehicle, poi, fleet, onClose }: InspectorProps) {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -60,7 +60,7 @@ export default function Inspector({ vehicle, poi, fleet, route, onClose }: Inspe
       role="region"
       aria-label="Inspector"
       className={cn(
-        "absolute right-4 top-4 z-40 w-80 max-w-[calc(100vw-2rem)] origin-top-right",
+        "absolute right-4 top-4 z-40 flex max-h-[calc(100vh-2rem)] w-80 max-w-[calc(100vw-2rem)] flex-col origin-top-right",
         "overflow-hidden rounded-[10px] border border-border surface-glass-strong shadow-floating backdrop-blur-2xl backdrop-saturate-150",
         "animate-scale-in"
       )}
@@ -88,7 +88,7 @@ export default function Inspector({ vehicle, poi, fleet, route, onClose }: Inspe
       <Hairline />
 
       {vehicle && (
-        <div className="flex flex-col pb-1">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-1">
           <Field label="ID">
             <span className={mono}>{vehicle.id}</span>
           </Field>
@@ -108,14 +108,12 @@ export default function Inspector({ vehicle, poi, fleet, route, onClose }: Inspe
             <span className={mono}>{Math.round(vehicle.heading)}°</span>
           </Field>
           <Field label="Fleet">{fleet?.name ?? vehicle.fleetId ?? "—"}</Field>
-          {route && (
-            <Field label="Route">
-              <span className={mono}>{route.distance.toFixed(1)} km</span>
-            </Field>
-          )}
           <Field label="Coordinates">
             <span className={mono}>{formatCoords(vehicle.position)}</span>
           </Field>
+          {/* Vehicle positions are [lng, lat] here; edge coords are [lat, lng].
+              Invert so the active-step lookup compares matching axes. */}
+          <VehicleDirections vehicleId={vehicle.id} position={invertLatLng(vehicle.position)} />
         </div>
       )}
 

--- a/apps/ui/src/Inspector/Inspector.tsx
+++ b/apps/ui/src/Inspector/Inspector.tsx
@@ -88,29 +88,32 @@ export default function Inspector({ vehicle, poi, fleet, onClose }: InspectorPro
       <Hairline />
 
       {vehicle && (
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain pb-1">
-          <Field label="ID">
-            <span className={mono}>{vehicle.id}</span>
-          </Field>
-          <Field label="Status">
-            <span className="inline-flex items-center gap-1.5">
-              <StatusDot tone={moving ? "ok" : "idle"} />
-              {moving ? "En route" : "Idle"}
-            </span>
-          </Field>
-          <Field label="Type">
-            <Tag tone="accent">{vehicle.type}</Tag>
-          </Field>
-          <Field label="Speed">
-            <span className={mono}>{Math.round(vehicle.speed)} km/h</span>
-          </Field>
-          <Field label="Heading">
-            <span className={mono}>{Math.round(vehicle.heading)}°</span>
-          </Field>
-          <Field label="Fleet">{fleet?.name ?? vehicle.fleetId ?? "—"}</Field>
-          <Field label="Coordinates">
-            <span className={mono}>{formatCoords(vehicle.position)}</span>
-          </Field>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {/* Vehicle stats stay pinned; only the directions list scrolls. */}
+          <div className="shrink-0">
+            <Field label="ID">
+              <span className={mono}>{vehicle.id}</span>
+            </Field>
+            <Field label="Status">
+              <span className="inline-flex items-center gap-1.5">
+                <StatusDot tone={moving ? "ok" : "idle"} />
+                {moving ? "En route" : "Idle"}
+              </span>
+            </Field>
+            <Field label="Type">
+              <Tag tone="accent">{vehicle.type}</Tag>
+            </Field>
+            <Field label="Speed">
+              <span className={mono}>{Math.round(vehicle.speed)} km/h</span>
+            </Field>
+            <Field label="Heading">
+              <span className={mono}>{Math.round(vehicle.heading)}°</span>
+            </Field>
+            <Field label="Fleet">{fleet?.name ?? vehicle.fleetId ?? "—"}</Field>
+            <Field label="Coordinates">
+              <span className={mono}>{formatCoords(vehicle.position)}</span>
+            </Field>
+          </div>
           {/* Vehicle positions are [lng, lat] here; edge coords are [lat, lng].
               Invert so the active-step lookup compares matching axes. */}
           <VehicleDirections vehicleId={vehicle.id} position={invertLatLng(vehicle.position)} />

--- a/apps/ui/src/Inspector/VehicleDirections.test.tsx
+++ b/apps/ui/src/Inspector/VehicleDirections.test.tsx
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import VehicleDirections from "./VehicleDirections";
 import { DirectionContext, type DirectionMap } from "@/data/context";
 import type { DirectionState } from "@/hooks/useDirections";
+import { clearDirectionHighlight } from "@/hooks/directionHighlightStore";
 import type { Edge, Node, Position } from "@/types";
+
+beforeEach(() => clearDirectionHighlight());
 
 function node(coordinates: Position): Node {
   return { id: `n${coordinates.join(",")}`, coordinates, connections: [] };
@@ -95,5 +99,32 @@ describe("VehicleDirections", () => {
     const current = document.querySelector('[aria-current="step"]');
     expect(current).not.toBeNull();
     expect(current).toHaveTextContent("Turn right onto Second St");
+  });
+
+  it("pins a step on click and toggles it off on a second click", async () => {
+    renderWithDirection("v1", {
+      route: {
+        edges: [
+          edge({ name: "First St", bearing: 0, distance: 1 }),
+          edge({ name: "Second St", bearing: 90, distance: 1 }),
+        ],
+        distance: 2,
+      },
+    });
+
+    const turn = screen.getByRole("button", { name: /Turn right onto Second St/ });
+    expect(turn).toHaveAttribute("aria-pressed", "false");
+    await userEvent.click(turn);
+    expect(turn).toHaveAttribute("aria-pressed", "true");
+    await userEvent.click(turn);
+    expect(turn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("makes the terminal arrival step non-interactive", () => {
+    renderWithDirection("v1", {
+      route: { edges: [edge({ name: "Only St", bearing: 0, distance: 1 })], distance: 1 },
+    });
+    const arrive = screen.getByRole("button", { name: /Arrive at your destination/ });
+    expect(arrive).toBeDisabled();
   });
 });

--- a/apps/ui/src/Inspector/VehicleDirections.test.tsx
+++ b/apps/ui/src/Inspector/VehicleDirections.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import VehicleDirections from "./VehicleDirections";
+import { DirectionContext, type DirectionMap } from "@/data/context";
+import type { DirectionState } from "@/hooks/useDirections";
+import type { Edge, Node, Position } from "@/types";
+
+function node(coordinates: Position): Node {
+  return { id: `n${coordinates.join(",")}`, coordinates, connections: [] };
+}
+
+let edgeSeq = 0;
+function edge(opts: {
+  name?: string;
+  bearing: number;
+  distance: number;
+  start?: Position;
+  end?: Position;
+}): Edge {
+  edgeSeq += 1;
+  return {
+    id: `e${edgeSeq}`,
+    streetId: `s${edgeSeq}`,
+    name: opts.name,
+    start: node(opts.start ?? [0, 0]),
+    end: node(opts.end ?? [0, 0]),
+    distance: opts.distance,
+    bearing: opts.bearing,
+    highway: "residential",
+    maxSpeed: 50,
+    surface: "asphalt",
+    oneway: false,
+  };
+}
+
+function renderWithDirection(
+  vehicleId: string,
+  state: DirectionState | undefined,
+  position?: Position
+) {
+  const directions: DirectionMap = new Map();
+  if (state) directions.set(vehicleId, state);
+  return render(
+    <DirectionContext.Provider value={{ directions, setDirections: vi.fn() }}>
+      <VehicleDirections vehicleId={vehicleId} position={position} />
+    </DirectionContext.Provider>
+  );
+}
+
+describe("VehicleDirections", () => {
+  it("renders nothing when the vehicle has no active route", () => {
+    const { container } = renderWithDirection("v1", undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the route has no edges", () => {
+    const { container } = renderWithDirection("v1", { route: { edges: [], distance: 0 } });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("lists each turn with its road name and the arrival step", () => {
+    renderWithDirection("v1", {
+      route: {
+        edges: [
+          edge({ name: "Uhuru Highway", bearing: 90, distance: 1.2 }),
+          edge({ name: "Moi Avenue", bearing: 0, distance: 0.3 }),
+        ],
+        distance: 1.5,
+      },
+      eta: 300,
+    });
+
+    expect(screen.getByText(/Head east on Uhuru Highway/)).toBeInTheDocument();
+    expect(screen.getByText("Turn left onto Moi Avenue")).toBeInTheDocument();
+    expect(screen.getByText("Arrive at your destination")).toBeInTheDocument();
+    // ETA (300 s → 5 min) surfaces in the summary.
+    expect(screen.getByText("5 min")).toBeInTheDocument();
+  });
+
+  it("marks the step nearest the vehicle position as the current step", () => {
+    renderWithDirection(
+      "v1",
+      {
+        route: {
+          edges: [
+            edge({ name: "First St", bearing: 0, distance: 1, start: [0, 0], end: [0, 2] }),
+            edge({ name: "Second St", bearing: 90, distance: 1, start: [0, 10], end: [0, 12] }),
+          ],
+          distance: 2,
+        },
+      },
+      [0, 10.5] // nearest Second St's midpoint [0, 11]
+    );
+
+    const current = document.querySelector('[aria-current="step"]');
+    expect(current).not.toBeNull();
+    expect(current).toHaveTextContent("Turn right onto Second St");
+  });
+});

--- a/apps/ui/src/Inspector/VehicleDirections.tsx
+++ b/apps/ui/src/Inspector/VehicleDirections.tsx
@@ -1,0 +1,164 @@
+import { useMemo } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  ArrowUp,
+  ArrowUpLeft,
+  ArrowUpRight,
+  CornerUpLeft,
+  CornerUpRight,
+  MapPin,
+  Navigation,
+  RotateCcw,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Position } from "@/types";
+import { useDirectionContext } from "@/data/useData";
+import {
+  buildDirectionSteps,
+  findActiveEdgeIndex,
+  remainingDistanceKm,
+  stepIndexForEdge,
+  totalDistanceKm,
+  type Maneuver,
+} from "@/utils/directionSteps";
+import { Eyebrow, Hairline, mono } from "@/Dock/DockPanelKit";
+
+/**
+ * Turn-by-turn directions for the selected vehicle, rendered inside the
+ * Inspector. Reads the shared direction context directly (rather than calling
+ * `useDirections`) so it never registers a second set of WS listeners — the
+ * always-mounted map `Direction` layer owns that subscription and this panel
+ * just consumes the resulting map. The heavy step derivation is memoized on the
+ * route object, so live position ticks only recompute the cheap active-step
+ * lookup, not the whole list.
+ */
+export interface VehicleDirectionsProps {
+  vehicleId: string;
+  /** Current vehicle position ([lat, lng]) — drives progress highlighting. */
+  position?: Position;
+}
+
+const MANEUVER_ICON: Record<Maneuver, LucideIcon> = {
+  depart: Navigation,
+  straight: ArrowUp,
+  "slight-left": ArrowUpLeft,
+  left: CornerUpLeft,
+  "sharp-left": CornerUpLeft,
+  "slight-right": ArrowUpRight,
+  right: CornerUpRight,
+  "sharp-right": CornerUpRight,
+  uturn: RotateCcw,
+  arrive: MapPin,
+};
+
+/** Compact distance: metres under 1 km, one-decimal km above. */
+function formatDistance(km: number): string {
+  if (km <= 0) return "";
+  if (km < 1) return `${Math.round(km * 1000)} m`;
+  return `${km.toFixed(1)} km`;
+}
+
+/** ETA seconds → "45 s" / "12 min" / "1 h 5 min". */
+function formatEta(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "";
+  if (seconds < 60) return `${Math.round(seconds)} s`;
+  const totalMinutes = Math.round(seconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes} min`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes ? `${hours} h ${minutes} min` : `${hours} h`;
+}
+
+export default function VehicleDirections({ vehicleId, position }: VehicleDirectionsProps) {
+  const { directions } = useDirectionContext();
+  const direction = directions.get(vehicleId);
+
+  const steps = useMemo(
+    () => (direction ? buildDirectionSteps(direction.route.edges) : []),
+    [direction]
+  );
+
+  const activeStep = useMemo(() => {
+    if (!direction) return -1;
+    const edgeIndex = findActiveEdgeIndex(direction.route.edges, position);
+    return stepIndexForEdge(steps, edgeIndex);
+  }, [direction, steps, position]);
+
+  if (!direction || steps.length === 0) return null;
+
+  const total = totalDistanceKm(direction.route);
+  const remaining = activeStep >= 0 ? remainingDistanceKm(steps, activeStep) : total;
+  // Steps minus the terminal "arrive" pseudo-step, for a "turns left" readout.
+  const turnCount = Math.max(0, steps.length - 1);
+  const eta = formatEta(direction.eta ?? 0);
+
+  return (
+    <>
+      <Hairline />
+      <div className="flex items-baseline justify-between gap-3 px-[15px] pb-[6px] pt-[10px]">
+        <Eyebrow>Directions</Eyebrow>
+        <div className={cn(mono, "flex items-center gap-1.5 text-[10.5px] text-muted-foreground")}>
+          <span className="text-foreground">{formatDistance(remaining)}</span>
+          {eta && (
+            <>
+              <span className="text-muted-foreground/40">·</span>
+              <span>{eta}</span>
+            </>
+          )}
+          <span className="text-muted-foreground/40">·</span>
+          <span>
+            {turnCount} step{turnCount === 1 ? "" : "s"}
+          </span>
+        </div>
+      </div>
+
+      <ol className="px-[15px] pb-2" aria-label="Turn-by-turn directions">
+        {steps.map((step, i) => {
+          const Icon = MANEUVER_ICON[step.maneuver];
+          const isActive = i === activeStep;
+          const isDone = activeStep >= 0 && i < activeStep;
+          const isTerminal = step.maneuver === "arrive";
+          const dist = formatDistance(step.distanceKm);
+          return (
+            <li
+              key={`${step.edgeStart}-${step.maneuver}-${i}`}
+              className={cn(
+                "flex items-start gap-2.5 border-t border-border-soft py-2 first:border-t-0",
+                isDone && "opacity-45"
+              )}
+              aria-current={isActive ? "step" : undefined}
+            >
+              <span
+                className={cn(
+                  "mt-px flex size-[22px] shrink-0 items-center justify-center rounded-full border",
+                  isActive
+                    ? "border-primary/50 bg-primary/15 text-primary"
+                    : isTerminal
+                      ? "border-status-ok/40 bg-status-ok/10 text-status-ok"
+                      : "border-border bg-muted text-muted-foreground"
+                )}
+              >
+                <Icon className="size-3.5" strokeWidth={2.25} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div
+                  className={cn(
+                    "text-[12px] leading-snug",
+                    isActive ? "font-medium text-foreground" : "text-foreground/90"
+                  )}
+                >
+                  {step.instruction}
+                </div>
+                {dist && (
+                  <div className={cn(mono, "mt-0.5 text-[10px] text-muted-foreground/70")}>
+                    {dist}
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </>
+  );
+}

--- a/apps/ui/src/Inspector/VehicleDirections.tsx
+++ b/apps/ui/src/Inspector/VehicleDirections.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   ArrowUp,
@@ -21,6 +21,13 @@ import {
   totalDistanceKm,
   type Maneuver,
 } from "@/utils/directionSteps";
+import {
+  clearDirectionHighlight,
+  sameStep,
+  setHoveredStep,
+  togglePinnedStep,
+  useDirectionHighlight,
+} from "@/hooks/directionHighlightStore";
 import { Eyebrow, Hairline, mono } from "@/Dock/DockPanelKit";
 
 /**
@@ -84,6 +91,12 @@ export default function VehicleDirections({ vehicleId, position }: VehicleDirect
     return stepIndexForEdge(steps, edgeIndex);
   }, [direction, steps, position]);
 
+  const { hovered, pinned } = useDirectionHighlight();
+
+  // Clear the map highlight when the panel unmounts or the vehicle changes, so
+  // a stale segment never lingers after switching / closing the inspector.
+  useEffect(() => clearDirectionHighlight, [vehicleId]);
+
   if (!direction || steps.length === 0) return null;
 
   const total = totalDistanceKm(direction.route);
@@ -112,49 +125,75 @@ export default function VehicleDirections({ vehicleId, position }: VehicleDirect
         </div>
       </div>
 
-      <ol className="px-[15px] pb-2" aria-label="Turn-by-turn directions">
+      <ol className="pb-2" aria-label="Turn-by-turn directions">
         {steps.map((step, i) => {
           const Icon = MANEUVER_ICON[step.maneuver];
           const isActive = i === activeStep;
           const isDone = activeStep >= 0 && i < activeStep;
           const isTerminal = step.maneuver === "arrive";
           const dist = formatDistance(step.distanceKm);
+          // Only steps with a real edge span can be drawn on the map.
+          const ref = { vehicleId, start: step.edgeStart, end: step.edgeEnd };
+          const canHighlight = step.edgeEnd > step.edgeStart;
+          const isPinned = canHighlight && sameStep(pinned, ref);
+          const isHovered = canHighlight && sameStep(hovered, ref);
           return (
             <li
               key={`${step.edgeStart}-${step.maneuver}-${i}`}
-              className={cn(
-                "flex items-start gap-2.5 border-t border-border-soft py-2 first:border-t-0",
-                isDone && "opacity-45"
-              )}
               aria-current={isActive ? "step" : undefined}
             >
-              <span
+              <button
+                type="button"
+                disabled={!canHighlight}
+                aria-pressed={canHighlight ? isPinned : undefined}
+                onMouseEnter={canHighlight ? () => setHoveredStep(ref) : undefined}
+                onMouseLeave={canHighlight ? () => setHoveredStep(null) : undefined}
+                onFocus={canHighlight ? () => setHoveredStep(ref) : undefined}
+                onBlur={canHighlight ? () => setHoveredStep(null) : undefined}
+                onClick={canHighlight ? () => togglePinnedStep(ref) : undefined}
                 className={cn(
-                  "mt-px flex size-[22px] shrink-0 items-center justify-center rounded-full border",
-                  isActive
-                    ? "border-primary/50 bg-primary/15 text-primary"
-                    : isTerminal
-                      ? "border-status-ok/40 bg-status-ok/10 text-status-ok"
-                      : "border-border bg-muted text-muted-foreground"
+                  "relative flex w-full items-start gap-2.5 border-t border-border-soft px-[15px] py-2 text-left transition-colors duration-fast",
+                  "first:border-t-0 disabled:cursor-default",
+                  canHighlight &&
+                    "hover:bg-accent/60 focus-visible:outline-none focus-visible:bg-accent/60",
+                  (isPinned || isHovered) && "bg-primary/10",
+                  isDone && !isPinned && !isHovered && "opacity-45"
                 )}
               >
-                <Icon className="size-3.5" strokeWidth={2.25} />
-              </span>
-              <div className="min-w-0 flex-1">
-                <div
+                {isPinned && (
+                  <span
+                    className="absolute inset-y-1 left-0 w-[2px] rounded-r bg-primary"
+                    aria-hidden
+                  />
+                )}
+                <span
                   className={cn(
-                    "text-[12px] leading-snug",
-                    isActive ? "font-medium text-foreground" : "text-foreground/90"
+                    "mt-px flex size-[22px] shrink-0 items-center justify-center rounded-full border",
+                    isActive
+                      ? "border-primary/50 bg-primary/15 text-primary"
+                      : isTerminal
+                        ? "border-status-ok/40 bg-status-ok/10 text-status-ok"
+                        : "border-border bg-muted text-muted-foreground"
                   )}
                 >
-                  {step.instruction}
-                </div>
-                {dist && (
-                  <div className={cn(mono, "mt-0.5 text-[10px] text-muted-foreground/70")}>
-                    {dist}
-                  </div>
-                )}
-              </div>
+                  <Icon className="size-3.5" strokeWidth={2.25} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span
+                    className={cn(
+                      "block text-[12px] leading-snug",
+                      isActive || isPinned ? "font-medium text-foreground" : "text-foreground/90"
+                    )}
+                  >
+                    {step.instruction}
+                  </span>
+                  {dist && (
+                    <span className={cn(mono, "mt-0.5 block text-[10px] text-muted-foreground/70")}>
+                      {dist}
+                    </span>
+                  )}
+                </span>
+              </button>
             </li>
           );
         })}

--- a/apps/ui/src/Inspector/VehicleDirections.tsx
+++ b/apps/ui/src/Inspector/VehicleDirections.tsx
@@ -106,9 +106,9 @@ export default function VehicleDirections({ vehicleId, position }: VehicleDirect
   const eta = formatEta(direction.eta ?? 0);
 
   return (
-    <>
+    <div className="flex min-h-0 flex-1 flex-col">
       <Hairline />
-      <div className="flex items-baseline justify-between gap-3 px-[15px] pb-[6px] pt-[10px]">
+      <div className="flex shrink-0 items-baseline justify-between gap-3 px-[15px] pb-[6px] pt-[10px]">
         <Eyebrow>Directions</Eyebrow>
         <div className={cn(mono, "flex items-center gap-1.5 text-[10.5px] text-muted-foreground")}>
           <span className="text-foreground">{formatDistance(remaining)}</span>
@@ -125,7 +125,10 @@ export default function VehicleDirections({ vehicleId, position }: VehicleDirect
         </div>
       </div>
 
-      <ol className="pb-2" aria-label="Turn-by-turn directions">
+      <ol
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-2"
+        aria-label="Turn-by-turn directions"
+      >
         {steps.map((step, i) => {
           const Icon = MANEUVER_ICON[step.maneuver];
           const isActive = i === activeStep;
@@ -198,6 +201,6 @@ export default function VehicleDirections({ vehicleId, position }: VehicleDirect
           );
         })}
       </ol>
-    </>
+    </div>
   );
 }

--- a/apps/ui/src/Map/Direction.test.tsx
+++ b/apps/ui/src/Map/Direction.test.tsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
-import type { Route } from "@/types";
+import type { Edge, Node, Position, Route } from "@/types";
 import type * as UseDirectionsModule from "@/hooks/useDirections";
 import type { DirectionState } from "@/hooks/useDirections";
+import {
+  clearDirectionHighlight,
+  setHoveredStep,
+  togglePinnedStep,
+} from "@/hooks/directionHighlightStore";
 
 // ---------------------------------------------------------------------------
 // Capture registered layers via useRegisterLayers mock
@@ -48,6 +53,34 @@ function createDirection(distance: number): DirectionState {
   return { route: createRoute(distance) };
 }
 
+function node(coordinates: Position): Node {
+  return { id: `n${coordinates.join(",")}`, coordinates, connections: [] };
+}
+
+let edgeSeq = 0;
+function edge(start: Position, end: Position): Edge {
+  edgeSeq += 1;
+  return {
+    id: `e${edgeSeq}`,
+    streetId: `s${edgeSeq}`,
+    start: node(start),
+    end: node(end),
+    distance: 1,
+    bearing: 0,
+    highway: "residential",
+    maxSpeed: 50,
+    surface: "asphalt",
+    oneway: false,
+  };
+}
+
+/** A direction whose route has `n` unit edges laid along the lat axis. */
+function createDirectionWithEdges(n: number): DirectionState {
+  const edges: Edge[] = [];
+  for (let i = 0; i < n; i++) edges.push(edge([i, 0], [i + 1, 0]));
+  return { route: { edges, distance: n } };
+}
+
 function getLayers(): { props: Record<string, unknown> }[] {
   return (registeredLayers.get("directions") ?? []) as { props: Record<string, unknown> }[];
 }
@@ -56,10 +89,17 @@ function getLayer(id: string) {
   return getLayers().find((l) => l.props.id === id);
 }
 
+function getHighlightLayers(): { props: Record<string, unknown> }[] {
+  return (registeredLayers.get("direction-highlight") ?? []) as {
+    props: Record<string, unknown>;
+  }[];
+}
+
 describe("DirectionMap", () => {
   beforeEach(() => {
     registeredLayers.clear();
     directionsRef.current = new Map();
+    clearDirectionHighlight();
   });
 
   it("registers no layers when neither selected nor hovered is set", () => {
@@ -135,5 +175,52 @@ describe("DirectionMap", () => {
     expect(pathLayer).toBeTruthy();
     const data = pathLayer!.props.data as { id: string }[];
     expect(data.map((d) => d.id).sort()).toEqual(["v1--selected", "v2--hovered"]);
+  });
+
+  describe("step highlight", () => {
+    it("registers no highlight layers when no step is highlighted", () => {
+      directionsRef.current = new Map([["v1", createDirectionWithEdges(5)]]);
+      render(<DirectionMap selected="v1" />);
+      expect(getHighlightLayers().length).toBe(0);
+    });
+
+    it("overlays the hovered step's sub-path for the selected vehicle", () => {
+      directionsRef.current = new Map([["v1", createDirectionWithEdges(5)]]);
+      setHoveredStep({ vehicleId: "v1", start: 1, end: 3 });
+      render(<DirectionMap selected="v1" />);
+
+      const highlight = getHighlightLayers().find(
+        (l) => l.props.id === "direction-step-highlight-path"
+      );
+      expect(highlight).toBeTruthy();
+      // 2 edges (indices 1,2) → 3 points, and edge coords [lat,lng] are
+      // inverted to [lng,lat] for the map.
+      const data = highlight!.props.data as { path: [number, number][] }[];
+      expect(data[0].path).toEqual([
+        [0, 1],
+        [0, 2],
+        [0, 3],
+      ]);
+    });
+
+    it("draws a start marker at the step's maneuver point", () => {
+      directionsRef.current = new Map([["v1", createDirectionWithEdges(5)]]);
+      togglePinnedStep({ vehicleId: "v1", start: 2, end: 4 });
+      render(<DirectionMap selected="v1" />);
+
+      const marker = getHighlightLayers().find(
+        (l) => l.props.id === "direction-step-highlight-start"
+      );
+      expect(marker).toBeTruthy();
+      const data = marker!.props.data as { position: [number, number] }[];
+      expect(data[0].position).toEqual([0, 2]);
+    });
+
+    it("ignores a highlight that targets a different vehicle", () => {
+      directionsRef.current = new Map([["v1", createDirectionWithEdges(5)]]);
+      setHoveredStep({ vehicleId: "v2", start: 0, end: 2 });
+      render(<DirectionMap selected="v1" />);
+      expect(getHighlightLayers().length).toBe(0);
+    });
   });
 });

--- a/apps/ui/src/Map/Direction.tsx
+++ b/apps/ui/src/Map/Direction.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { PathLayer, ScatterplotLayer, TextLayer } from "@deck.gl/layers";
 import type { Position } from "@/types";
 import { useDirections, type DirectionState } from "@/hooks/useDirections";
+import { useDirectionHighlight } from "@/hooks/directionHighlightStore";
 import { invertLatLng } from "@/utils/coordinates";
 import { useRegisterLayers } from "@/components/Map/hooks/useDeckLayers";
 import { resolveMapColor } from "@/lib/mapColor";
@@ -207,6 +208,80 @@ export default function DirectionMap({ selected, hovered }: DirectionProps) {
   }, [hovered, hoveredDirection, selected, selectedDirection]);
 
   useRegisterLayers("directions", layers);
+
+  // ─── Step highlight ────────────────────────────────────────────────
+  // When a turn-by-turn step is hovered/pinned in the inspector, overlay the
+  // matching sub-path (and a dot at the maneuver point) for the SELECTED
+  // vehicle. Kept in its own memo + layer group so hovering a row only rebuilds
+  // this cheap slice, not the base route path (which can span 800+ edges).
+  const { hovered: hoveredStep, pinned: pinnedStep } = useDirectionHighlight();
+  const step = hoveredStep ?? pinnedStep;
+
+  const highlightLayers = useMemo(() => {
+    if (!step || step.vehicleId !== selected || !selectedDirection) return [];
+    const edges = selectedDirection.route.edges;
+    const start = Math.max(0, step.start);
+    const end = Math.min(edges.length, step.end);
+    if (end <= start) return [];
+
+    const path: [number, number][] = [];
+    for (let i = start; i < end; i++) {
+      path.push(invertLatLng(edges[i].start.coordinates as Position) as [number, number]);
+    }
+    path.push(invertLatLng(edges[end - 1].end.coordinates as Position) as [number, number]);
+
+    const core: [number, number, number, number] = [255, 255, 255, 255];
+    const halo: [number, number, number, number] = [255, 255, 255, 70];
+    // depth test always passes so the overlay paints over the coincident base
+    // route path (same z-plane) instead of z-fighting with it. (luma.gl v9 uses
+    // `depthCompare`, not the old `depthTest` flag.)
+    const noDepth = { depthCompare: "always" as const };
+    return [
+      // Soft glow beneath the core so the highlight reads over both the blue
+      // route line and warm traffic colouring.
+      new PathLayer<{ path: [number, number][] }>({
+        id: "direction-step-highlight-halo",
+        data: [{ path }],
+        getPath: (d) => d.path,
+        getColor: halo,
+        getWidth: 12,
+        widthUnits: "pixels",
+        widthMinPixels: 9,
+        jointRounded: true,
+        capRounded: true,
+        parameters: noDepth,
+      }),
+      new PathLayer<{ path: [number, number][] }>({
+        id: "direction-step-highlight-path",
+        data: [{ path }],
+        getPath: (d) => d.path,
+        getColor: core,
+        getWidth: 6,
+        widthUnits: "pixels",
+        widthMinPixels: 4,
+        jointRounded: true,
+        capRounded: true,
+        parameters: noDepth,
+      }),
+      new ScatterplotLayer<{ position: [number, number] }>({
+        id: "direction-step-highlight-start",
+        data: [{ position: path[0] }],
+        getPosition: (d) => d.position,
+        getRadius: 6,
+        radiusUnits: "pixels",
+        radiusMinPixels: 5,
+        getFillColor: hexToRgba("#39f"),
+        getLineColor: core,
+        getLineWidth: 2,
+        stroked: true,
+        lineWidthUnits: "pixels",
+        parameters: noDepth,
+      }),
+    ];
+  }, [step, selected, selectedDirection]);
+
+  // Sits just above the base "directions" group (50) but below vehicles (70).
+  useRegisterLayers("direction-highlight", highlightLayers, 52);
 
   return null;
 }

--- a/apps/ui/src/hooks/directionHighlightStore.test.ts
+++ b/apps/ui/src/hooks/directionHighlightStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  clearDirectionHighlight,
+  sameStep,
+  setHoveredStep,
+  togglePinnedStep,
+  useDirectionHighlight,
+} from "./directionHighlightStore";
+import { renderHook, act } from "@testing-library/react";
+
+beforeEach(() => clearDirectionHighlight());
+
+describe("sameStep", () => {
+  it("matches on vehicleId + start, ignoring end, and rejects nulls", () => {
+    expect(
+      sameStep({ vehicleId: "v", start: 2, end: 5 }, { vehicleId: "v", start: 2, end: 9 })
+    ).toBe(true);
+    expect(
+      sameStep({ vehicleId: "v", start: 2, end: 5 }, { vehicleId: "w", start: 2, end: 5 })
+    ).toBe(false);
+    expect(sameStep(null, { vehicleId: "v", start: 0, end: 1 })).toBe(false);
+    expect(sameStep(null, null)).toBe(false);
+  });
+});
+
+describe("directionHighlightStore", () => {
+  it("tracks hovered and pinned independently and notifies subscribers", () => {
+    const { result } = renderHook(() => useDirectionHighlight());
+    expect(result.current).toEqual({ hovered: null, pinned: null });
+
+    act(() => setHoveredStep({ vehicleId: "v1", start: 0, end: 3 }));
+    expect(result.current.hovered).toEqual({ vehicleId: "v1", start: 0, end: 3 });
+    expect(result.current.pinned).toBeNull();
+
+    act(() => togglePinnedStep({ vehicleId: "v1", start: 5, end: 8 }));
+    expect(result.current.pinned).toEqual({ vehicleId: "v1", start: 5, end: 8 });
+    // Hover survives pinning.
+    expect(result.current.hovered).toEqual({ vehicleId: "v1", start: 0, end: 3 });
+
+    act(() => setHoveredStep(null));
+    expect(result.current.hovered).toBeNull();
+  });
+
+  it("toggles the pinned step off when the same step is clicked again", () => {
+    const { result } = renderHook(() => useDirectionHighlight());
+    const step = { vehicleId: "v1", start: 2, end: 4 };
+
+    act(() => togglePinnedStep(step));
+    expect(result.current.pinned).toEqual(step);
+    act(() => togglePinnedStep({ ...step, end: 99 })); // same step (start matches)
+    expect(result.current.pinned).toBeNull();
+  });
+
+  it("clears both hovered and pinned", () => {
+    const { result } = renderHook(() => useDirectionHighlight());
+    act(() => {
+      setHoveredStep({ vehicleId: "v1", start: 0, end: 1 });
+      togglePinnedStep({ vehicleId: "v1", start: 2, end: 3 });
+    });
+    act(() => clearDirectionHighlight());
+    expect(result.current).toEqual({ hovered: null, pinned: null });
+  });
+});

--- a/apps/ui/src/hooks/directionHighlightStore.ts
+++ b/apps/ui/src/hooks/directionHighlightStore.ts
@@ -1,0 +1,67 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * A reference to one turn-by-turn step: the vehicle it belongs to and the
+ * half-open edge range `[start, end)` within that vehicle's `route.edges`.
+ */
+export interface StepRef {
+  vehicleId: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Tiny external store for "which direction step is highlighted on the map".
+ * Lives outside React (like `vehicleStore`) so hovering rows in the inspector
+ * doesn't re-render App — only the two subscribers (the map `Direction` layer
+ * and the inspector step list) update. `hovered` is transient (row hover);
+ * `pinned` survives until toggled off or the selection changes. The map draws
+ * `hovered ?? pinned`.
+ */
+interface HighlightState {
+  hovered: StepRef | null;
+  pinned: StepRef | null;
+}
+
+let state: HighlightState = { hovered: null, pinned: null };
+const listeners = new Set<() => void>();
+
+function emit(next: HighlightState) {
+  state = next;
+  for (const listener of listeners) listener();
+}
+
+/** Two step refs point at the same step (ignores `end`, `start` is unique). */
+export function sameStep(a: StepRef | null, b: StepRef | null): boolean {
+  return !!a && !!b && a.vehicleId === b.vehicleId && a.start === b.start;
+}
+
+export function setHoveredStep(step: StepRef | null) {
+  if (sameStep(state.hovered, step) && !!state.hovered === !!step) return;
+  emit({ ...state, hovered: step });
+}
+
+/** Toggle the pinned step: clicking the already-pinned step clears it. */
+export function togglePinnedStep(step: StepRef) {
+  emit({ ...state, pinned: sameStep(state.pinned, step) ? null : step });
+}
+
+export function clearDirectionHighlight() {
+  if (!state.hovered && !state.pinned) return;
+  emit({ hovered: null, pinned: null });
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function getSnapshot(): HighlightState {
+  return state;
+}
+
+export function useDirectionHighlight(): HighlightState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/ui/src/hooks/useDirections.ts
+++ b/apps/ui/src/hooks/useDirections.ts
@@ -5,18 +5,25 @@ import { useCallback, useEffect } from "react";
 
 export interface DirectionState {
   route: Route;
+  /** Estimated time of arrival in seconds, when the simulator provides it. */
+  eta?: number;
   waypoints?: VehicleDirection["waypoints"];
   currentWaypointIndex?: number;
+}
+
+function toState(direction: VehicleDirection): DirectionState {
+  return {
+    route: direction.route,
+    eta: direction.eta,
+    waypoints: direction.waypoints,
+    currentWaypointIndex: direction.currentWaypointIndex,
+  };
 }
 
 function buildDirectionMap(directions: VehicleDirection[]): Map<string, DirectionState> {
   const directionMap = new Map<string, DirectionState>();
   for (const direction of directions) {
-    directionMap.set(direction.vehicleId, {
-      route: direction.route,
-      waypoints: direction.waypoints,
-      currentWaypointIndex: direction.currentWaypointIndex,
-    });
+    directionMap.set(direction.vehicleId, toState(direction));
   }
   return directionMap;
 }
@@ -41,11 +48,7 @@ export function useDirections() {
     const directionHandler = (direction: VehicleDirection) => {
       setDirections((prev) => {
         const updated = new Map(prev);
-        updated.set(direction.vehicleId, {
-          route: direction.route,
-          waypoints: direction.waypoints,
-          currentWaypointIndex: direction.currentWaypointIndex,
-        });
+        updated.set(direction.vehicleId, toState(direction));
         return updated;
       });
     };

--- a/apps/ui/src/utils/directionSteps.test.ts
+++ b/apps/ui/src/utils/directionSteps.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import type { Edge, Node, Position } from "@/types";
+import {
+  bearingToCompass,
+  buildDirectionSteps,
+  classifyManeuver,
+  findActiveEdgeIndex,
+  remainingDistanceKm,
+  stepIndexForEdge,
+  totalDistanceKm,
+} from "./directionSteps";
+
+function node(id: string, coordinates: Position): Node {
+  return { id, coordinates, connections: [] };
+}
+
+let edgeSeq = 0;
+function edge(overrides: Partial<Edge> & { bearing: number; distance: number }): Edge {
+  edgeSeq += 1;
+  const start: Position = [0, 0];
+  const end: Position = [0, 0];
+  return {
+    id: `e${edgeSeq}`,
+    streetId: `s${edgeSeq}`,
+    start: node(`n${edgeSeq}a`, start),
+    end: node(`n${edgeSeq}b`, end),
+    highway: "residential",
+    maxSpeed: 50,
+    surface: "asphalt",
+    oneway: false,
+    ...overrides,
+  } as Edge;
+}
+
+describe("bearingToCompass", () => {
+  it("maps cardinal and intercardinal bearings", () => {
+    expect(bearingToCompass(0)).toBe("north");
+    expect(bearingToCompass(45)).toBe("northeast");
+    expect(bearingToCompass(90)).toBe("east");
+    expect(bearingToCompass(180)).toBe("south");
+    expect(bearingToCompass(270)).toBe("west");
+  });
+
+  it("normalizes out-of-range and negative bearings", () => {
+    expect(bearingToCompass(360)).toBe("north");
+    expect(bearingToCompass(-90)).toBe("west");
+  });
+});
+
+describe("classifyManeuver", () => {
+  it("treats near-collinear bearings as straight", () => {
+    expect(classifyManeuver(90, 95)).toBe("straight");
+    expect(classifyManeuver(90, 80)).toBe("straight");
+  });
+
+  it("distinguishes slight / full / sharp turns by magnitude", () => {
+    expect(classifyManeuver(0, 30)).toBe("slight-right");
+    expect(classifyManeuver(0, 90)).toBe("right");
+    expect(classifyManeuver(0, 150)).toBe("sharp-right");
+    expect(classifyManeuver(0, -30)).toBe("slight-left");
+    expect(classifyManeuver(0, -90)).toBe("left");
+    expect(classifyManeuver(0, -150)).toBe("sharp-left");
+  });
+
+  it("detects U-turns near ±180", () => {
+    expect(classifyManeuver(0, 180)).toBe("uturn");
+    expect(classifyManeuver(10, 190)).toBe("uturn");
+  });
+
+  it("handles the wraparound at 360/0", () => {
+    // 350° → 10° is a 20° right nudge, not a near-U-turn.
+    expect(classifyManeuver(350, 10)).toBe("slight-right");
+  });
+});
+
+describe("buildDirectionSteps", () => {
+  it("returns an empty list for a route with no edges", () => {
+    expect(buildDirectionSteps([])).toEqual([]);
+  });
+
+  it("groups contiguous same-road edges into one step and appends arrival", () => {
+    const steps = buildDirectionSteps([
+      edge({ name: "Uhuru Highway", bearing: 90, distance: 0.5 }),
+      edge({ name: "Uhuru Highway", bearing: 92, distance: 0.7 }),
+      edge({ name: "Moi Avenue", bearing: 0, distance: 0.3 }),
+    ]);
+
+    expect(steps).toHaveLength(3); // depart + turn + arrive
+    expect(steps[0].maneuver).toBe("depart");
+    expect(steps[0].road).toBe("Uhuru Highway");
+    expect(steps[0].distanceKm).toBeCloseTo(1.2);
+    expect(steps[0].instruction).toMatch(/Head east on Uhuru Highway/);
+
+    expect(steps[1].maneuver).toBe("left"); // 92° → 0° is a left turn
+    expect(steps[1].road).toBe("Moi Avenue");
+    expect(steps[1].instruction).toBe("Turn left onto Moi Avenue");
+    expect(steps[1].distanceKm).toBeCloseTo(0.3);
+
+    expect(steps[2].maneuver).toBe("arrive");
+  });
+
+  it("labels unnamed edges and splits distinct unnamed ways by streetId", () => {
+    const steps = buildDirectionSteps([
+      edge({ streetId: "wayA", bearing: 0, distance: 0.4 }),
+      edge({ streetId: "wayA", bearing: 5, distance: 0.2 }),
+      edge({ streetId: "wayB", bearing: 90, distance: 0.6 }),
+    ]);
+
+    expect(steps).toHaveLength(3);
+    expect(steps[0].road).toBe("Unnamed road");
+    expect(steps[0].distanceKm).toBeCloseTo(0.6);
+    expect(steps[1].road).toBe("Unnamed road");
+    expect(steps[1].maneuver).toBe("right");
+  });
+
+  it("maps each step to a contiguous, non-overlapping edge range", () => {
+    const steps = buildDirectionSteps([
+      edge({ name: "A", bearing: 0, distance: 1 }),
+      edge({ name: "A", bearing: 0, distance: 1 }),
+      edge({ name: "B", bearing: 90, distance: 1 }),
+    ]);
+    expect(steps[0].edgeStart).toBe(0);
+    expect(steps[0].edgeEnd).toBe(2);
+    expect(steps[1].edgeStart).toBe(2);
+    expect(steps[1].edgeEnd).toBe(3);
+  });
+});
+
+describe("findActiveEdgeIndex / stepIndexForEdge", () => {
+  const edges = [
+    edge({ name: "A", bearing: 0, distance: 1 }),
+    edge({ name: "B", bearing: 90, distance: 1 }),
+  ];
+  // Position edge midpoints deterministically.
+  edges[0].start.coordinates = [0, 0];
+  edges[0].end.coordinates = [0, 2]; // mid [0,1]
+  edges[1].start.coordinates = [0, 10];
+  edges[1].end.coordinates = [0, 12]; // mid [0,11]
+
+  it("returns -1 when position is missing or there are no edges", () => {
+    expect(findActiveEdgeIndex(edges, undefined)).toBe(-1);
+    expect(findActiveEdgeIndex([], [0, 0])).toBe(-1);
+  });
+
+  it("finds the nearest edge by midpoint", () => {
+    expect(findActiveEdgeIndex(edges, [0, 1.2])).toBe(0);
+    expect(findActiveEdgeIndex(edges, [0, 10.5])).toBe(1);
+  });
+
+  it("maps an edge index back to the step that contains it", () => {
+    const steps = buildDirectionSteps(edges);
+    expect(stepIndexForEdge(steps, 0)).toBe(0);
+    expect(stepIndexForEdge(steps, 1)).toBe(1);
+    expect(stepIndexForEdge(steps, -1)).toBe(-1);
+  });
+});
+
+describe("remainingDistanceKm / totalDistanceKm", () => {
+  const steps = buildDirectionSteps([
+    edge({ name: "A", bearing: 0, distance: 2 }),
+    edge({ name: "B", bearing: 90, distance: 3 }),
+  ]);
+
+  it("sums distances from the given step onward", () => {
+    expect(remainingDistanceKm(steps, 0)).toBeCloseTo(5);
+    expect(remainingDistanceKm(steps, 1)).toBeCloseTo(3);
+    expect(remainingDistanceKm(steps, -1)).toBeCloseTo(5); // treated as 0
+  });
+
+  it("prefers the route's own distance, falling back to summed edges", () => {
+    expect(totalDistanceKm({ edges: [], distance: 4.2 })).toBeCloseTo(4.2);
+    expect(
+      totalDistanceKm({
+        edges: [edge({ bearing: 0, distance: 1.5 }), edge({ bearing: 0, distance: 2.5 })],
+        distance: 0,
+      })
+    ).toBeCloseTo(4);
+  });
+});

--- a/apps/ui/src/utils/directionSteps.ts
+++ b/apps/ui/src/utils/directionSteps.ts
@@ -1,0 +1,216 @@
+import type { Edge, Position, Route } from "@/types";
+
+/**
+ * Turn-by-turn derivation for the vehicle inspector.
+ *
+ * The simulator already ships everything we need on `route.edges`: each edge
+ * carries its road `name`, its compass `bearing`, and its `distance` (km). This
+ * module folds that per-edge stream into Google-Maps-style *steps* — one per
+ * contiguous run of edges on the same road — and classifies the maneuver at
+ * each step boundary from the bearing delta between the two roads. No extra
+ * network round-trip; it's a pure transform over data the UI already holds.
+ */
+
+export type Maneuver =
+  | "depart"
+  | "straight"
+  | "slight-left"
+  | "left"
+  | "sharp-left"
+  | "slight-right"
+  | "right"
+  | "sharp-right"
+  | "uturn"
+  | "arrive";
+
+export interface DirectionStep {
+  /** The maneuver to perform to *begin* this step. */
+  maneuver: Maneuver;
+  /** Road name for this step (or a synthetic label for unnamed ways). */
+  road: string;
+  /** Human-readable instruction, Google-Maps style. */
+  instruction: string;
+  /** Length of this step in km (sum of its edges). */
+  distanceKm: number;
+  /** Index of this step's first edge within `route.edges`. */
+  edgeStart: number;
+  /** One past this step's last edge within `route.edges` (exclusive). */
+  edgeEnd: number;
+}
+
+const UNNAMED_ROAD = "Unnamed road";
+
+const COMPASS_8 = [
+  "north",
+  "northeast",
+  "east",
+  "southeast",
+  "south",
+  "southwest",
+  "west",
+  "northwest",
+] as const;
+
+/** Bearing (deg, 0 = north, clockwise) → coarse 8-point compass word. */
+export function bearingToCompass(bearing: number): string {
+  const normalized = ((bearing % 360) + 360) % 360;
+  return COMPASS_8[Math.round(normalized / 45) % 8];
+}
+
+/** Signed bearing delta in (-180, 180]; positive = turning right (clockwise). */
+function bearingDelta(from: number, to: number): number {
+  return ((((to - from) % 360) + 540) % 360) - 180;
+}
+
+/**
+ * Classify the maneuver between two consecutive road bearings. `right` is the
+ * clockwise direction; thresholds mirror what a driver would call a slight vs.
+ * full vs. sharp turn.
+ */
+export function classifyManeuver(fromBearing: number, toBearing: number): Maneuver {
+  const delta = bearingDelta(fromBearing, toBearing);
+  const magnitude = Math.abs(delta);
+  if (magnitude <= 18) return "straight";
+  if (magnitude >= 160) return "uturn";
+  const right = delta > 0;
+  if (magnitude <= 45) return right ? "slight-right" : "slight-left";
+  if (magnitude <= 130) return right ? "right" : "left";
+  return right ? "sharp-right" : "sharp-left";
+}
+
+function instructionFor(maneuver: Maneuver, road: string, compass?: string): string {
+  switch (maneuver) {
+    case "depart":
+      return `Head ${compass ?? "out"} on ${road}`;
+    case "straight":
+      return `Continue onto ${road}`;
+    case "slight-left":
+      return `Slight left onto ${road}`;
+    case "left":
+      return `Turn left onto ${road}`;
+    case "sharp-left":
+      return `Sharp left onto ${road}`;
+    case "slight-right":
+      return `Slight right onto ${road}`;
+    case "right":
+      return `Turn right onto ${road}`;
+    case "sharp-right":
+      return `Sharp right onto ${road}`;
+    case "uturn":
+      return `Make a U-turn onto ${road}`;
+    case "arrive":
+      return "Arrive at your destination";
+  }
+}
+
+/**
+ * Group key that decides where one step ends and the next begins. Named roads
+ * group by name (so a single road spanning several OSM ways stays one step);
+ * unnamed edges fall back to their `streetId` so distinct unnamed ways — and
+ * the turn between them — are still surfaced as separate steps.
+ */
+function groupKey(edge: Edge): string {
+  const name = edge.name?.trim();
+  return name ? `name:${name}` : `street:${edge.streetId}`;
+}
+
+function roadLabel(edge: Edge): string {
+  return edge.name?.trim() || UNNAMED_ROAD;
+}
+
+/**
+ * Fold a route's edges into ordered turn-by-turn steps. Returns an empty array
+ * for a route with no edges. A terminal "arrive" step is appended so the list
+ * always ends at the destination, mirroring turn-by-turn nav apps.
+ */
+export function buildDirectionSteps(edges: Edge[]): DirectionStep[] {
+  if (edges.length === 0) return [];
+
+  const steps: DirectionStep[] = [];
+  let i = 0;
+  while (i < edges.length) {
+    const key = groupKey(edges[i]);
+    let j = i;
+    let distanceKm = 0;
+    while (j < edges.length && groupKey(edges[j]) === key) {
+      distanceKm += edges[j].distance;
+      j++;
+    }
+
+    const first = edges[i];
+    const road = roadLabel(first);
+    let maneuver: Maneuver;
+    let instruction: string;
+    if (i === 0) {
+      maneuver = "depart";
+      instruction = instructionFor("depart", road, bearingToCompass(first.bearing));
+    } else {
+      maneuver = classifyManeuver(edges[i - 1].bearing, first.bearing);
+      instruction = instructionFor(maneuver, road);
+    }
+
+    steps.push({ maneuver, road, instruction, distanceKm, edgeStart: i, edgeEnd: j });
+    i = j;
+  }
+
+  const lastRoad = steps[steps.length - 1]?.road ?? UNNAMED_ROAD;
+  steps.push({
+    maneuver: "arrive",
+    road: lastRoad,
+    instruction: instructionFor("arrive", lastRoad),
+    distanceKm: 0,
+    edgeStart: edges.length,
+    edgeEnd: edges.length,
+  });
+
+  return steps;
+}
+
+/** Squared planar distance between two [lat, lng] points (ranking only). */
+function distanceSquared(a: Position, b: Position): number {
+  const dLat = a[0] - b[0];
+  const dLng = a[1] - b[1];
+  return dLat * dLat + dLng * dLng;
+}
+
+/**
+ * Index of the edge whose midpoint is closest to `position` ([lat, lng], the
+ * same order edge coordinates use). Returns -1 when there are no edges. Used to
+ * mark how far along the route the vehicle has progressed.
+ */
+export function findActiveEdgeIndex(edges: Edge[], position: Position | undefined): number {
+  if (!position || edges.length === 0) return -1;
+  let best = -1;
+  let bestDist = Infinity;
+  for (let i = 0; i < edges.length; i++) {
+    const start = edges[i].start.coordinates;
+    const end = edges[i].end.coordinates;
+    const mid: Position = [(start[0] + end[0]) / 2, (start[1] + end[1]) / 2];
+    const d = distanceSquared(mid, position);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/** Step index containing `edgeIndex`, or -1 if none does. */
+export function stepIndexForEdge(steps: DirectionStep[], edgeIndex: number): number {
+  if (edgeIndex < 0) return -1;
+  return steps.findIndex((s) => edgeIndex >= s.edgeStart && edgeIndex < s.edgeEnd);
+}
+
+/** Sum of the distances of steps at or after `fromStep` (km). */
+export function remainingDistanceKm(steps: DirectionStep[], fromStep: number): number {
+  const start = fromStep < 0 ? 0 : fromStep;
+  let total = 0;
+  for (let i = start; i < steps.length; i++) total += steps[i].distanceKm;
+  return total;
+}
+
+/** Total route distance (km). Prefers the route's own figure when present. */
+export function totalDistanceKm(route: Route): number {
+  if (typeof route.distance === "number" && route.distance > 0) return route.distance;
+  return route.edges.reduce((sum, e) => sum + e.distance, 0);
+}


### PR DESCRIPTION
## What

Adds **Google-Maps-style turn-by-turn directions** to the vehicle inspection panel, and lets you **highlight any step on the map** by hovering or clicking it.

**In the inspector** (below the vehicle stats):
- Summary line: **remaining distance · ETA · step count**
- Ordered step list: **maneuver icon + road name + per-step distance** (e.g. `Turn left onto Kangundo Road — 20.7 km`), ending in **Arrive at your destination**. The step the vehicle is currently on is highlighted.

**On the map:**
- Hovering a step (or focusing it via keyboard) highlights that road segment with a white core + soft glow and a dot at the maneuver point.
- Clicking a step **pins** the highlight (click again to unpin); the row shows an accent bar + `aria-pressed`.

## How

No new data was needed — the simulator already ships `name`, `bearing`, and `distance` on every `route.edge`.

- **`utils/directionSteps.ts`** (pure, unit-tested): folds the per-edge stream into steps — one per contiguous run on the same road (named roads group by name; unnamed ways fall back to `streetId`) — classifying each maneuver from the signed bearing delta at the junction. Also `findActiveEdgeIndex`, `remainingDistanceKm`, `totalDistanceKm`.
- **`Inspector/VehicleDirections.tsx`**: reads the **shared direction context directly** (no second WS listener — the always-mounted map `Direction` layer owns that subscription). Step build is memoized on the route, so live position ticks only recompute the cheap active-step lookup. Rows are toggle buttons.
- **`hooks/directionHighlightStore.ts`**: a tiny external store (like `vehicleStore`) so hovering rows never re-renders App — only the map layer and the step list subscribe. `hovered` transient, `pinned` sticky.
- **`Map/Direction.tsx`**: registers a second `direction-highlight` layer group (order 52 — above the route, below vehicles) that slices the step's edge range into a white core + glow path + start marker. `depthCompare: "always"` so it paints over the coincident base route. Memoized separately so hovering only rebuilds this cheap slice, not the 800-edge base path.
- Threads `eta` through `DirectionState`; removes the previously **dead** `route` prop from `Inspector` (`App` never passed it).

### Coordinate notes
- The UI's `vehicle.position` is `[lng, lat]` while edge coords are `[lat, lng]`; the active-step lookup inverts the vehicle position so the nearest-edge match compares matching axes.

## Testing

- `directionSteps.test.ts` (15) · `directionHighlightStore.test.ts` · `VehicleDirections.test.tsx` (incl. pin/toggle + inert arrival) · `Direction.test.tsx` (incl. 4 highlight-layer cases asserting the inverted sub-path + start marker + vehicle scoping)
- `npm run type-check`, `npm run lint`, full `vitest` (817) all green
- **Verified end-to-end** in a running dev build against the live simulator: full turn-by-turn list renders; hovering/pinning a step highlights the matching segment on the map. Confirmed via deck-layer introspection that the white highlight path reaches DeckGL with the correct inverted coordinates and z-order.

Closes fleetsim-all-39mo, fleetsim-all-rq4q

🤖 Generated with [Claude Code](https://claude.com/claude-code)
