### PR TITLE
fix(ui): snappier map zoom controls + zoom-out limit

### DIFF
--- a/apps/ui/src/components/Map/components/DeckGLMap.tsx
+++ b/apps/ui/src/components/Map/components/DeckGLMap.tsx
@@ -328,8 +328,9 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
 
   // Controller config lives on the view (single source of truth — do not also
   // pass `controller` to <DeckGL>): the map is strictly 2D so rotation is
-  // disabled, smooth scroll-zoom and a short inertia make pan/zoom feel less
-  // stepped.
+  // disabled. Scroll-zoom tracks the wheel directly (no `smooth` interpolation)
+  // and inertia is off, so pan/zoom respond immediately instead of gliding —
+  // the smoothed variant read as laggy/floaty.
   const MAP_VIEW = useMemo(
     () =>
       new MapView({
@@ -337,8 +338,8 @@ export const DeckGLMap: React.FC<DeckGLMapProps> = ({
         controller: {
           dragRotate: false,
           touchRotate: false,
-          scrollZoom: { smooth: true },
-          inertia: 250,
+          scrollZoom: { smooth: false },
+          inertia: 0,
         },
       }),
     []

--- a/apps/ui/src/components/Map/hooks/useDeckViewState.test.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckViewState.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDeckViewState } from "./useDeckViewState";
+
+// Default zoom when no network data is supplied (see DEFAULT_VIEW_STATE).
+const DEFAULT_ZOOM = 12;
+
+function setup() {
+  return renderHook(() => useDeckViewState({ data: null, width: 800, height: 600 }));
+}
+
+describe("useDeckViewState zoom controls", () => {
+  it("zooms in by a full level per press and eases the transition", () => {
+    const { result } = setup();
+    act(() => result.current.controls.zoomIn());
+    expect(result.current.viewState.zoom).toBe(DEFAULT_ZOOM + 1);
+    expect(result.current.viewState.transitionDuration).toBe(200);
+    expect(result.current.viewState.transitionInterpolator).toBeTruthy();
+  });
+
+  it("zooms out by a full level per press", () => {
+    const { result } = setup();
+    act(() => result.current.controls.zoomOut());
+    expect(result.current.viewState.zoom).toBe(DEFAULT_ZOOM - 1);
+  });
+
+  it("accumulates across successive presses", () => {
+    const { result } = setup();
+    act(() => result.current.controls.zoomIn());
+    act(() => result.current.controls.zoomIn());
+    act(() => result.current.controls.zoomIn());
+    expect(result.current.viewState.zoom).toBe(DEFAULT_ZOOM + 3);
+  });
+
+  it("clamps to the view's min/max zoom", () => {
+    const { result } = setup();
+    // maxZoom is 20 → 8 presses from 12 would reach 20 and stop there.
+    act(() => {
+      for (let i = 0; i < 12; i++) result.current.controls.zoomIn();
+    });
+    expect(result.current.viewState.zoom).toBe(20);
+
+    act(() => {
+      for (let i = 0; i < 40; i++) result.current.controls.zoomOut();
+    });
+    expect(result.current.viewState.zoom).toBe(1);
+  });
+});

--- a/apps/ui/src/components/Map/hooks/useDeckViewState.test.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckViewState.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import type { RoadNetwork } from "@/types";
 import { useDeckViewState } from "./useDeckViewState";
 
 // Default zoom when no network data is supplied (see DEFAULT_VIEW_STATE).
@@ -8,6 +9,24 @@ const DEFAULT_ZOOM = 12;
 function setup() {
   return renderHook(() => useDeckViewState({ data: null, width: 800, height: 600 }));
 }
+
+/** A minimal road network spanning a small bbox so fitBounds has real extent. */
+const NETWORK: RoadNetwork = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [36.6, -1.4],
+          [37.0, -1.1],
+        ],
+      },
+      properties: {},
+    },
+  ],
+};
 
 describe("useDeckViewState zoom controls", () => {
   it("zooms in by a full level per press and eases the transition", () => {
@@ -32,17 +51,31 @@ describe("useDeckViewState zoom controls", () => {
     expect(result.current.viewState.zoom).toBe(DEFAULT_ZOOM + 3);
   });
 
-  it("clamps to the view's min/max zoom", () => {
+  it("clamps zoom-in to the view's max zoom", () => {
     const { result } = setup();
     // maxZoom is 20 → 8 presses from 12 would reach 20 and stop there.
     act(() => {
       for (let i = 0; i < 12; i++) result.current.controls.zoomIn();
     });
     expect(result.current.viewState.zoom).toBe(20);
+  });
 
+  it("floors the zoom-out at the fitted network extent so you can't zoom out into empty space", () => {
+    const { result } = renderHook(() =>
+      useDeckViewState({ data: NETWORK, width: 800, height: 600 })
+    );
+
+    // The fit-to-bounds effect sets zoom to the fitted level and minZoom one
+    // level below it.
+    const fittedZoom = result.current.viewState.zoom!;
+    expect(result.current.viewState.minZoom).toBeCloseTo(fittedZoom - 1, 5);
+    // The world-scale floor (1) is gone — the floor now sits near the city fit.
+    expect(result.current.viewState.minZoom!).toBeGreaterThan(5);
+
+    // Hammering zoom-out cannot go below that floor.
     act(() => {
-      for (let i = 0; i < 40; i++) result.current.controls.zoomOut();
+      for (let i = 0; i < 30; i++) result.current.controls.zoomOut();
     });
-    expect(result.current.viewState.zoom).toBe(1);
+    expect(result.current.viewState.zoom).toBeCloseTo(fittedZoom - 1, 5);
   });
 });

--- a/apps/ui/src/components/Map/hooks/useDeckViewState.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckViewState.ts
@@ -15,13 +15,23 @@ const DEFAULT_ZOOM = 12;
  */
 const ZOOM_STEP = 1;
 
+/**
+ * How far past the full-network fit the user may zoom out (levels). The floor is
+ * derived from the fitted zoom on load so it tracks the actual network + the
+ * current viewport; this margin just grants a little breathing room around it.
+ * Prevents zooming out to empty ocean/continent around a single city.
+ */
+const MIN_ZOOM_MARGIN = 1;
+
 const DEFAULT_VIEW_STATE: MapViewState = {
   longitude: 36.82,
   latitude: -1.29,
   zoom: DEFAULT_ZOOM,
   pitch: 0,
   bearing: 0,
-  minZoom: 1,
+  // Conservative floor until the network loads and we derive a tighter one from
+  // its fitted bounds (see the fit-to-bounds effect).
+  minZoom: 8,
   maxZoom: 20,
 };
 
@@ -77,6 +87,9 @@ export function useDeckViewState({ data, width, height }: UseDeckViewStateOption
       longitude: fitted.longitude,
       latitude: fitted.latitude,
       zoom: fitted.zoom,
+      // Floor the zoom-out at (fit − margin) so the network always roughly
+      // fills the viewport and you can't zoom out into empty space around it.
+      minZoom: fitted.zoom - MIN_ZOOM_MARGIN,
     }));
     initializedRef.current = true;
   }, [data, width, height]);

--- a/apps/ui/src/components/Map/hooks/useDeckViewState.ts
+++ b/apps/ui/src/components/Map/hooks/useDeckViewState.ts
@@ -8,6 +8,13 @@ export type { DeckViewStateControls };
 
 const DEFAULT_ZOOM = 12;
 
+/**
+ * How many zoom levels one button press / keyboard shortcut moves. A full level
+ * per press (matching Google Maps / Mapbox) — the previous 0.5 barely changed
+ * the view and read as an unresponsive control.
+ */
+const ZOOM_STEP = 1;
+
 const DEFAULT_VIEW_STATE: MapViewState = {
   longitude: 36.82,
   latitude: -1.29,
@@ -87,7 +94,7 @@ export function useDeckViewState({ data, width, height }: UseDeckViewStateOption
   const zoomIn = useCallback(() => {
     setViewState((prev) => ({
       ...prev,
-      zoom: Math.min((prev.zoom ?? 1) + 0.5, 20),
+      zoom: Math.min((prev.zoom ?? 1) + ZOOM_STEP, prev.maxZoom ?? 20),
       transitionDuration: 200,
       transitionInterpolator: new FlyToInterpolator(),
     }));
@@ -96,7 +103,7 @@ export function useDeckViewState({ data, width, height }: UseDeckViewStateOption
   const zoomOut = useCallback(() => {
     setViewState((prev) => ({
       ...prev,
-      zoom: Math.max((prev.zoom ?? 1) - 0.5, 1),
+      zoom: Math.max((prev.zoom ?? 1) - ZOOM_STEP, prev.minZoom ?? 1),
       transitionDuration: 200,
       transitionInterpolator: new FlyToInterpolator(),
     }));


### PR DESCRIPTION
## Problem

The map zoom controls felt bad:
- **Buttons** stepped by only 0.5 zoom levels — a click barely changed the view.
- **Scroll-wheel zoom** used smoothed interpolation + 250ms inertia, so it felt laggy/floaty.
- **No zoom-out limit** — `minZoom` was 1 (whole world), so you could zoom out far past the city into empty space.

## Fix

- Zoom buttons / keyboard shortcuts step a **full level** per press (`ZOOM_STEP = 1`), keep the 200ms ease, clamp to the view's own min/max.
- Scroll-wheel zoom tracks the wheel directly (`smooth: false`) with inertia off, so pan/zoom respond immediately.
- **Floor the zoom-out** at the fitted network extent (fit − 1 level), derived on load from the network bounds + viewport; pre-load default raised from 1 to 8. The network now always roughly fills the viewport.

## Testing

- `useDeckViewState.test.ts`: full-level step, accumulation, ease, max-zoom clamp, and the zoom-out floor (minZoom = fit − 1, hammering zoom-out clamps there).
- `type-check` + full `vitest` green.
- **Verified in a running build** via deck viewState introspection: button click `10.147 → 11.147` (full level); wheel tick zooms immediately (`transitionDuration: 0`); `minZoom` is `9.147` and 25 wheel-out events bottom out at ~9.17 instead of world-scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
