### PR TITLE
feat: stale-bundle reload prompt, time-of-day heat zones, adapter config validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,12 @@ jobs:
           context: .
           file: Dockerfile
           target: ${{ matrix.target }}
+          # Only the ui target reads BUILD_ID; it stamps dist/version.json so an
+          # open tab can detect it is running a superseded bundle. Pinning it to
+          # the release tag means the prompt fires on real releases rather than
+          # on every rebuild (the default is a build timestamp).
+          build-args: |
+            BUILD_ID=${{ needs.release-please.outputs.tag_name }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,16 @@ CMD ["node", "dist/index.js"]
 # ── ui: static SPA built by vite, served by Caddy ───────────────────────────
 # VITE_* vars are baked at build with localhost defaults; the browser reaches
 # the simulator/adapter via their published host ports, so no build args needed.
+#
+# BUILD_ID is the exception. The UI bakes it in and also emits it to
+# dist/version.json, which an open tab polls to detect that a new build is
+# being served (see apps/ui/src/lib/versionCheck.ts). Left unset it defaults to
+# a build timestamp, so every rebuild — including a no-op one — looks like a new
+# version and nags open tabs. Pass the git sha so the prompt tracks real code
+# changes: `docker build --build-arg BUILD_ID=$(git rev-parse --short HEAD)`.
 FROM source AS ui-build
+ARG BUILD_ID
+ENV BUILD_ID=${BUILD_ID}
 RUN npm run build -w @moveet/ui
 
 FROM caddy:2-alpine AS ui

--- a/apps/adapter/.env.example
+++ b/apps/adapter/.env.example
@@ -18,6 +18,17 @@ SINK_CONSOLE_CONFIG={"verbose":false}
 # Telemetry realism (off by default). Applies degraded GPS / dropouts / cadence jitter to ALL sinks.
 # REALISM_CONFIG='{"enabled":true,"reportingPeriodMs":5000,"jitterMs":800}'
 
+# Optional: supply the same source/sink/realism config as a readable JSON file:
+#   { "source": { "type": ..., "config": {...} },
+#     "sinks":  [ { "type": ..., "config": {...} } ],
+#     "realism": {...} }
+# Environment variables take precedence over the file: SOURCE_TYPE / SINK_TYPES
+# override the file's type and sink list, and SOURCE_CONFIG / SINK_<TYPE>_CONFIG /
+# REALISM_CONFIG are shallow-merged over the file's objects key by key.
+# Malformed config (bad JSON, unknown plugin type, missing required field) aborts
+# startup; dry-run it first with: curl -XPOST localhost:5011/config/validate -d '{}'
+# ADAPTER_CONFIG_FILE=/etc/moveet/adapter.json
+
 # Example: GraphQL source + Redpanda sink
 # SOURCE_TYPE=graphql
 # SOURCE_CONFIG={"url":"http://localhost:4001/graphql","token":"your-token","query":"{ vehicles { id callsign latitude longitude } }","vehiclePath":"vehicles"}

--- a/apps/adapter/README.md
+++ b/apps/adapter/README.md
@@ -89,6 +89,7 @@ cp .env.example .env
 | `REDPANDA_BROKERS`    | `localhost:19092`               | Comma-separated Redpanda/Kafka broker addresses                                                                                                               |
 | `REDPANDA_TOPIC`      | `dispatch.vehicle.positions`    | Kafka topic for vehicle position updates                                                                                                                      |
 | `REALISM_CONFIG`      | `` (off)                        | JSON config for the telemetry realism engine (GPS noise / dropouts / cadence jitter). Off unless `enabled:true`. See [Telemetry realism](#telemetry-realism). |
+| `ADAPTER_CONFIG_FILE` | --                              | Path to a JSON file holding `{ source, sinks, realism }` — a readable alternative to the JSON-in-env-var form. **Environment variables take precedence**: `SOURCE_TYPE` / `SINK_TYPES` override the file's type and sink list, and `SOURCE_CONFIG` / `SINK_<TYPE>_CONFIG` / `REALISM_CONFIG` are shallow-merged over the file's objects key by key. A broken file aborts startup. |
 
 ## API Endpoints
 
@@ -121,6 +122,23 @@ cp .env.example .env
 ```json
 { "config": { "enabled": true, "reportingPeriodMs": 5000, "jitterMs": 800 } }
 ```
+
+**`POST /config/validate`** -- Dry run. Reports what the configuration *would* activate, with a precise per-plugin reason for anything malformed. It never mutates the running plugin set and never connects to a backend.
+
+```bash
+# Validate the current env + ADAPTER_CONFIG_FILE (re-resolved from scratch)
+curl -XPOST localhost:5011/config/validate -H 'content-type: application/json' -d '{}'
+
+# Validate a candidate before applying it
+curl -XPOST localhost:5011/config/validate -H 'content-type: application/json' \
+  -d '{"source":{"type":"rest","config":{"url":"http://x"}},"sinks":[{"type":"redpanda","config":{"brokers":"b:9092"}}]}'
+```
+
+Returns `{ valid, checked, configFile, source, sinks, wouldActivate, active, errors, warnings, backendConnectivity }`.
+`200` with `valid:false` means the configuration is invalid (fix it); `400` means the
+*request body* was malformed. `backendConnectivity.checked` is always `false` — a plugin
+reported valid here can still be skipped at startup if its backend is unreachable, which
+is intentional fail-soft behaviour visible in `GET /health`.
 
 **`GET /health`** -- Returns health check status for the active source and all sinks (plus a `realism` status block when the engine is active).
 

--- a/apps/adapter/src/__tests__/config-validate.test.ts
+++ b/apps/adapter/src/__tests__/config-validate.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { PluginManager } from "../plugins/manager";
+import { createConfigValidateHandler } from "../routes/configValidate";
+import type { ConfigField, DataSink, DataSource } from "../plugins/types";
+import type { StartupConfig } from "../utils/config";
+
+/**
+ * Route test for the dry-run endpoint, driving the REAL handler and a REAL
+ * PluginManager. Plugins are fakes so the test needs no broker, no network and
+ * no external module mocks — and so "did we connect?" is directly observable.
+ */
+
+const SOURCE_SCHEMA: ConfigField[] = [
+  { name: "url", label: "URL", type: "string", required: true },
+  { name: "token", label: "Token", type: "password" },
+];
+
+const SINK_SCHEMA: ConfigField[] = [
+  { name: "brokers", label: "Brokers", type: "string", required: true },
+  { name: "topic", label: "Topic", type: "string" },
+];
+
+const connects = { source: 0, sink: 0, console: 0 };
+
+function makeSource(): DataSource {
+  return {
+    type: "rest",
+    name: "REST source",
+    configSchema: SOURCE_SCHEMA,
+    connect: async () => {
+      connects.source++;
+    },
+    disconnect: async () => {},
+    getVehicles: async () => [],
+    healthCheck: async () => ({ healthy: true }),
+  };
+}
+
+function makeSink(): DataSink {
+  return {
+    type: "redpanda",
+    name: "Redpanda sink",
+    configSchema: SINK_SCHEMA,
+    connect: async () => {
+      connects.sink++;
+    },
+    disconnect: async () => {},
+    publishUpdates: async () => {},
+    healthCheck: async () => ({ healthy: true }),
+  };
+}
+
+function makeConsoleSink(): DataSink {
+  return {
+    type: "console",
+    name: "Console sink",
+    configSchema: [],
+    connect: async () => {
+      connects.console++;
+    },
+    disconnect: async () => {},
+    publishUpdates: async () => {},
+    healthCheck: async () => ({ healthy: true }),
+  };
+}
+
+function startupConfig(overrides: Partial<StartupConfig> = {}): StartupConfig {
+  return {
+    port: 5011,
+    corsOrigins: "*",
+    source: { type: "rest", config: { url: "http://roster" } },
+    sinks: [{ type: "redpanda", config: { brokers: "b:9092" } }],
+    realism: {},
+    simulatorUrl: "http://localhost:5010",
+    origins: {
+      configFile: "/etc/moveet/adapter.json",
+      source: "file",
+      sinkList: "file",
+      sinks: { redpanda: "env+file" },
+      realism: "default",
+    },
+    ...overrides,
+  };
+}
+
+async function buildApp(resolve: () => StartupConfig) {
+  const manager = new PluginManager();
+  manager.registerSource("rest", makeSource);
+  manager.registerSink("redpanda", makeSink);
+  manager.registerSink("console", makeConsoleSink);
+
+  // Give the manager a real active plugin set so mutation is detectable.
+  await manager.setSource("rest", { url: "http://active" });
+  await manager.addSink("console", {});
+
+  const app = express();
+  app.use(express.json());
+  app.post(
+    "/config/validate",
+    createConfigValidateHandler({ manager, resolveStartupConfig: resolve })
+  );
+  return { app, manager };
+}
+
+describe("POST /config/validate", () => {
+  beforeEach(() => {
+    connects.source = 0;
+    connects.sink = 0;
+    connects.console = 0;
+  });
+
+  it("reports the resolved startup config and what it would activate", async () => {
+    const { app } = await buildApp(() => startupConfig());
+    const connectsAfterSetup = { ...connects };
+
+    const res = await request(app).post("/config/validate").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+    expect(res.body.checked).toBe("startup-config");
+    expect(res.body.configFile).toBe("/etc/moveet/adapter.json");
+    expect(res.body.wouldActivate).toEqual({ source: "rest", sinks: ["redpanda"] });
+    expect(res.body.source.origin).toBe("file");
+    expect(res.body.sinks[0].origin).toBe("env+file");
+    // Reachability is explicitly not checked — no backend was contacted.
+    expect(res.body.backendConnectivity.checked).toBe(false);
+    expect(connects).toEqual(connectsAfterSetup);
+  });
+
+  it("does not mutate the active plugin set and does not connect anything", async () => {
+    const { app, manager } = await buildApp(() => startupConfig());
+    const before = manager.getConfig();
+    const connectsBefore = { ...connects };
+
+    const res = await request(app)
+      .post("/config/validate")
+      .send({
+        source: { type: "rest", config: { url: "http://candidate" } },
+        sinks: [{ type: "redpanda", config: { brokers: "candidate:9092" } }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.checked).toBe("request-body");
+    expect(res.body.wouldActivate).toEqual({ source: "rest", sinks: ["redpanda"] });
+
+    // Active set untouched: still the source/sinks wired during setup.
+    const after = manager.getConfig();
+    expect(after.activeSource).toBe(before.activeSource);
+    expect(after.activeSinks).toEqual(before.activeSinks);
+    expect(after.sinkConfig).toEqual(before.sinkConfig);
+    expect(after.sourceConfig).toEqual(before.sourceConfig);
+    expect(res.body.active).toEqual({ source: "rest", sinks: ["console"] });
+
+    // Nothing was connected by the dry run.
+    expect(connects).toEqual(connectsBefore);
+  });
+
+  it("returns a precise per-plugin rejection reason for malformed config", async () => {
+    const { app } = await buildApp(() => startupConfig());
+
+    const res = await request(app)
+      .post("/config/validate")
+      .send({
+        source: { type: "rest", config: {} },
+        sinks: [
+          { type: "redpandaa", config: {} },
+          { type: "redpanda", config: { brokers: 9092 } },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.errors).toEqual([
+      'source(rest).url: required field "url" is missing or empty',
+      'sink(redpandaa): unknown sink type "redpandaa" (registered types: redpanda, console); did you mean "redpanda"?',
+      "sink(redpanda).brokers: must be a string (got number 9092)",
+    ]);
+    expect(res.body.wouldActivate).toEqual({ source: null, sinks: [] });
+  });
+
+  it("reports a config-resolution failure as an invalid config, not a server error", async () => {
+    const { app } = await buildApp(() => {
+      throw new Error("Invalid JSON in environment variable SINK_REDPANDA_CONFIG: bad");
+    });
+
+    const res = await request(app).post("/config/validate").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.resolutionError).toMatch(/Invalid JSON in environment variable/);
+    expect(res.body.errors).toHaveLength(1);
+    expect(res.body.wouldActivate).toEqual({ source: null, sinks: [] });
+  });
+
+  it("distinguishes a malformed request body (400) from an invalid config (200)", async () => {
+    const { app } = await buildApp(() => startupConfig());
+
+    const bad = await request(app).post("/config/validate").send({ sinks: "console" });
+    expect(bad.status).toBe(400);
+    expect(bad.body.error).toMatch(/'sinks' must be an array/);
+
+    const badEntry = await request(app)
+      .post("/config/validate")
+      .send({ sinks: [{ config: {} }] });
+    expect(badEntry.status).toBe(400);
+    expect(badEntry.body.error).toMatch(/'sinks\[0\]\.type' must be a non-empty string/);
+  });
+
+  it("redacts secrets in the echoed candidate config", async () => {
+    const { app } = await buildApp(() => startupConfig());
+
+    const res = await request(app)
+      .post("/config/validate")
+      .send({ source: { type: "rest", config: { url: "http://r", token: "s3cret" } } });
+
+    expect(res.body.source.config.token).not.toBe("s3cret");
+    expect(res.body.source.config.url).toBe("http://r");
+  });
+
+  it("reports warnings without failing validation", async () => {
+    const { app } = await buildApp(() => startupConfig());
+
+    const res = await request(app)
+      .post("/config/validate")
+      .send({ sinks: [{ type: "redpanda", config: { brokers: "b:9092", topci: "v" } }] });
+
+    expect(res.body.valid).toBe(true);
+    expect(res.body.warnings[0]).toMatch(/unknown field "topci"/);
+    expect(res.body.wouldActivate.sinks).toEqual(["redpanda"]);
+  });
+});
+
+describe("PluginManager.validateConfig", () => {
+  it("is side-effect free on a manager with no plugins connected", () => {
+    const manager = new PluginManager();
+    const connect = vi.fn();
+    manager.registerSink("console", () => ({
+      type: "console",
+      name: "Console",
+      configSchema: [],
+      connect,
+      disconnect: async () => {},
+      publishUpdates: async () => {},
+      healthCheck: async () => ({ healthy: true }),
+    }));
+
+    const report = manager.validateConfig({ sinks: [{ type: "console", config: {} }] });
+
+    expect(report.valid).toBe(true);
+    expect(connect).not.toHaveBeenCalled();
+    expect(manager.getConfig().activeSinks).toEqual([]);
+  });
+});

--- a/apps/adapter/src/index.ts
+++ b/apps/adapter/src/index.ts
@@ -5,6 +5,7 @@ import { PluginManager } from "./plugins/manager";
 import { validateVehicleUpdates } from "./validation/vehicleUpdate";
 import { REALISM_SCHEMA } from "./realism/config";
 import { loadConfig, logConfig } from "./utils/config";
+import { createConfigValidateHandler } from "./routes/configValidate";
 import { createLogger } from "./utils/logger";
 import { correlationIdMiddleware } from "./middleware/correlationId";
 import { errorHandlerMiddleware } from "./middleware/errorHandler";
@@ -47,6 +48,29 @@ pluginManager.registerSink("console", () => new ConsoleSink());
 async function startup(): Promise<void> {
   const config = loadConfig();
   logConfig(config);
+
+  // Malformed configuration is NOT a fail-soft condition. An unreachable
+  // backend is (see below) — but a typo'd plugin type, a missing required
+  // field or a wrong value type would otherwise produce a plugin that is
+  // silently skipped, leaving a stack that boots looking healthy and emits
+  // nothing. Validate the resolved set against each plugin's own configSchema
+  // and refuse to start when it is wrong, so the operator sees the reason.
+  const validation = pluginManager.validateConfig({
+    source: config.source,
+    sinks: config.sinks,
+  });
+  for (const warning of validation.warnings) {
+    logger.warn({ issue: warning }, "Suspicious plugin configuration");
+  }
+  if (!validation.valid) {
+    throw new Error(
+      `Invalid plugin configuration — refusing to start:\n${validation.errors
+        .map((e) => `  - ${e}`)
+        .join(
+          "\n"
+        )}\nFix the configuration (env vars or ADAPTER_CONFIG_FILE), or dry-run it with POST /config/validate.`
+    );
+  }
 
   // Wire the source resiliently: a source whose backend is unreachable at
   // startup (e.g. the fleet connector or a DB being down) must NOT take the
@@ -221,6 +245,18 @@ async function startup(): Promise<void> {
       },
     });
   });
+
+  // Dry-run: report what the current (or a supplied) configuration WOULD
+  // activate, with a per-plugin reason for anything malformed. Mutates nothing
+  // and connects to nothing. With no body it re-resolves env + config file from
+  // scratch, so an operator can edit the file and re-check without a restart.
+  app.post(
+    "/config/validate",
+    createConfigValidateHandler({
+      manager: pluginManager,
+      resolveStartupConfig: () => loadConfig(),
+    })
+  );
 
   app.post("/config/source", async (req, res) => {
     const { type, config: pluginConfig } = req.body;

--- a/apps/adapter/src/plugins/manager.ts
+++ b/apps/adapter/src/plugins/manager.ts
@@ -10,6 +10,11 @@ import type {
   PublishResult,
 } from "./types";
 import { PluginRegistry } from "./registry";
+import {
+  validatePluginSet,
+  type CandidatePluginSet,
+  type ConfigValidationReport,
+} from "./validation";
 import { HealthAggregator } from "./health-aggregator";
 import { Publisher } from "./publisher";
 import { RealismEngine } from "../realism/RealismEngine";
@@ -249,6 +254,18 @@ export class PluginManager {
       this.registry.getSourceInfos(),
       this.registry.getSinkInfos()
     );
+  }
+
+  /**
+   * Dry-run validation of a candidate plugin set against the registered
+   * plugins' `configSchema`s.
+   *
+   * Pure and side-effect free: nothing is instantiated, connected, replaced or
+   * removed, and no backend is contacted. It answers "is this configuration
+   * well-formed, and what would it activate?" — never "is the backend up?".
+   */
+  validateConfig(candidate: CandidatePluginSet): ConfigValidationReport {
+    return validatePluginSet(candidate, this.registry);
   }
 
   getConfig(): AdapterConfig {

--- a/apps/adapter/src/plugins/validation.test.ts
+++ b/apps/adapter/src/plugins/validation.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import { PluginRegistry } from "./registry";
+import { validatePluginSet } from "./validation";
+import type { ConfigField, DataSink, DataSource } from "./types";
+
+/**
+ * Fake plugins with realistic `configSchema`s. Using fakes (rather than the
+ * real graphql/redpanda plugins) keeps this test free of external deps while
+ * exercising every ConfigField type the real plugins declare.
+ */
+function makeSource(type: string, configSchema: ConfigField[]): DataSource {
+  return {
+    type,
+    name: `${type} source`,
+    configSchema,
+    connect: async () => {
+      throw new Error("connect() must not be called during validation");
+    },
+    disconnect: async () => {},
+    getVehicles: async () => [],
+    healthCheck: async () => ({ healthy: true }),
+  };
+}
+
+function makeSink(type: string, configSchema: ConfigField[]): DataSink {
+  return {
+    type,
+    name: `${type} sink`,
+    configSchema,
+    connect: async () => {
+      throw new Error("connect() must not be called during validation");
+    },
+    disconnect: async () => {},
+    publishUpdates: async () => {},
+    healthCheck: async () => ({ healthy: true }),
+  };
+}
+
+const SOURCE_SCHEMA: ConfigField[] = [
+  { name: "url", label: "URL", type: "string", required: true },
+  { name: "token", label: "Auth Token", type: "password" },
+  { name: "maxVehicles", label: "Max Vehicles", type: "number", default: 0 },
+  { name: "fieldMap", label: "Field Map", type: "json" },
+  {
+    name: "method",
+    label: "Method",
+    type: "select",
+    options: [
+      { label: "GET", value: "GET" },
+      { label: "POST", value: "POST" },
+    ],
+  },
+];
+
+const SINK_SCHEMA: ConfigField[] = [
+  { name: "brokers", label: "Brokers", type: "string", required: true },
+  { name: "topic", label: "Topic", type: "string" },
+  { name: "batchSize", label: "Batch Size", type: "number" },
+  { name: "tlsRejectUnauthorized", label: "TLS Reject", type: "boolean" },
+  { name: "saslPassword", label: "SASL Password", type: "password" },
+  {
+    name: "saslMechanism",
+    label: "SASL Mechanism",
+    type: "select",
+    options: [
+      { label: "PLAIN", value: "plain" },
+      { label: "SCRAM-SHA-256", value: "scram-sha-256" },
+    ],
+  },
+];
+
+function makeRegistry(): PluginRegistry {
+  const registry = new PluginRegistry();
+  registry.registerSource("rest", () => makeSource("rest", SOURCE_SCHEMA));
+  registry.registerSource("static", () => makeSource("static", []));
+  registry.registerSink("redpanda", () => makeSink("redpanda", SINK_SCHEMA));
+  registry.registerSink("console", () => makeSink("console", []));
+  return registry;
+}
+
+describe("validatePluginSet", () => {
+  const registry = makeRegistry();
+
+  it("accepts a well-formed set and reports what would be activated", () => {
+    const report = validatePluginSet(
+      {
+        source: { type: "rest", config: { url: "http://roster", method: "GET" } },
+        sinks: [
+          { type: "redpanda", config: { brokers: "b:9092", batchSize: 500 } },
+          { type: "console", config: {} },
+        ],
+      },
+      registry
+    );
+
+    expect(report.valid).toBe(true);
+    expect(report.errors).toEqual([]);
+    expect(report.wouldActivate).toEqual({ source: "rest", sinks: ["redpanda", "console"] });
+  });
+
+  it("rejects an unknown plugin type with the registered types and a typo hint", () => {
+    const report = validatePluginSet({ sinks: [{ type: "redpandaa", config: {} }] }, registry);
+
+    expect(report.valid).toBe(false);
+    expect(report.sinks[0].issues[0].message).toMatch(/unknown sink type "redpandaa"/);
+    expect(report.sinks[0].issues[0].message).toMatch(/registered types: redpanda, console/);
+    expect(report.sinks[0].issues[0].message).toMatch(/did you mean "redpanda"\?/);
+    expect(report.wouldActivate.sinks).toEqual([]);
+  });
+
+  it("rejects a missing required field", () => {
+    const report = validatePluginSet({ source: { type: "rest", config: {} } }, registry);
+
+    expect(report.valid).toBe(false);
+    expect(report.errors).toContain('source(rest).url: required field "url" is missing or empty');
+    expect(report.wouldActivate.source).toBeNull();
+  });
+
+  it("treats an empty string in a required field as missing", () => {
+    const report = validatePluginSet({ source: { type: "rest", config: { url: "" } } }, registry);
+    expect(report.valid).toBe(false);
+    expect(report.errors[0]).toMatch(/required field "url" is missing or empty/);
+  });
+
+  it("rejects a wrong value type with a precise per-field message", () => {
+    const report = validatePluginSet(
+      {
+        source: {
+          type: "rest",
+          config: { url: { host: "roster" }, maxVehicles: "many", fieldMap: 7 },
+        },
+      },
+      registry
+    );
+
+    expect(report.valid).toBe(false);
+    expect(report.errors).toEqual([
+      "source(rest).url: must be a string (got an object)",
+      'source(rest).maxVehicles: must be a number (got string "many")',
+      "source(rest).fieldMap: must be a JSON object (got number 7)",
+    ]);
+  });
+
+  it("rejects a select value that is not one of the declared options", () => {
+    const report = validatePluginSet(
+      { source: { type: "rest", config: { url: "http://r", method: "PUT" } } },
+      registry
+    );
+
+    expect(report.valid).toBe(false);
+    expect(report.errors[0]).toBe(
+      'source(rest).method: must be one of [GET, POST] (got string "PUT")'
+    );
+  });
+
+  it("accepts coercions the plugins themselves perform", () => {
+    const report = validatePluginSet(
+      {
+        sinks: [
+          {
+            type: "redpanda",
+            config: {
+              brokers: "b:9092",
+              batchSize: "250",
+              tlsRejectUnauthorized: "false",
+              // Real sinks lowercase the mechanism before use.
+              saslMechanism: "PLAIN",
+            },
+          },
+        ],
+      },
+      registry
+    );
+
+    expect(report.errors).toEqual([]);
+    expect(report.valid).toBe(true);
+  });
+
+  it("warns (but stays valid) on an unknown field, with a did-you-mean hint", () => {
+    const report = validatePluginSet(
+      { sinks: [{ type: "redpanda", config: { brokers: "b:9092", topci: "vehicles" } }] },
+      registry
+    );
+
+    expect(report.valid).toBe(true);
+    expect(report.warnings).toEqual([
+      'sink(redpanda).topci: unknown field "topci" — it is not in this plugin\'s config schema and will be ignored; did you mean "topic"?',
+    ]);
+    expect(report.wouldActivate.sinks).toEqual(["redpanda"]);
+  });
+
+  it("redacts secrets in the echoed config", () => {
+    const report = validatePluginSet(
+      { source: { type: "rest", config: { url: "http://r", token: "s3cret" } } },
+      registry
+    );
+
+    expect(report.source?.config.token).not.toBe("s3cret");
+    expect(report.source?.config.url).toBe("http://r");
+  });
+
+  it("keeps valid plugins activatable when a sibling is malformed", () => {
+    const report = validatePluginSet(
+      {
+        source: { type: "rest", config: {} },
+        sinks: [
+          { type: "console", config: {} },
+          { type: "redpanda", config: {} },
+        ],
+      },
+      registry
+    );
+
+    expect(report.valid).toBe(false);
+    expect(report.wouldActivate).toEqual({ source: null, sinks: ["console"] });
+  });
+
+  it("echoes the origin label it was given", () => {
+    const report = validatePluginSet(
+      { source: { type: "static", config: {}, origin: "env+file" } },
+      registry
+    );
+    expect(report.source?.origin).toBe("env+file");
+  });
+});

--- a/apps/adapter/src/plugins/validation.ts
+++ b/apps/adapter/src/plugins/validation.ts
@@ -1,0 +1,295 @@
+import type { ConfigField, PluginConfig } from "./types";
+
+/**
+ * Schema-driven validation of a *candidate* plugin set.
+ *
+ * Every plugin already self-describes its configuration via `configSchema`
+ * (`ConfigField[]`), so this module validates against that description instead
+ * of hand-written per-plugin checks. It is pure: nothing is instantiated,
+ * connected, or mutated — it only reads registered metadata.
+ *
+ * Two failure classes are deliberately kept apart:
+ *
+ *  - **error**   — malformed configuration (unknown plugin type, missing
+ *                  required field, wrong value type). The operator must fix it;
+ *                  the adapter refuses to start on these.
+ *  - **warning** — suspicious but survivable (an unknown key that the plugin
+ *                  will ignore, usually a typo).
+ *
+ * Backend reachability is explicitly NOT part of this: a plugin whose config is
+ * valid but whose broker is down is the intentional fail-soft case, reported by
+ * `GET /health`, not here.
+ */
+
+export type IssueSeverity = "error" | "warning";
+
+export interface ConfigIssue {
+  /** Config key the issue is about; `null` for whole-plugin issues. */
+  field: string | null;
+  severity: IssueSeverity;
+  message: string;
+}
+
+export interface PluginValidation {
+  kind: "source" | "sink";
+  type: string;
+  /** True when the plugin has no error-severity issues (warnings are allowed). */
+  valid: boolean;
+  /** Where the config came from (env / file / both), when the caller knows. */
+  origin?: string;
+  /** The candidate config, with secrets redacted — safe to return over HTTP. */
+  config: PluginConfig;
+  issues: ConfigIssue[];
+}
+
+export interface ConfigValidationReport {
+  /** True when neither the source nor any sink has an error-severity issue. */
+  valid: boolean;
+  source: PluginValidation | null;
+  sinks: PluginValidation[];
+  /** What would actually be activated: only plugins whose config is valid. */
+  wouldActivate: { source: string | null; sinks: string[] };
+  /** Flattened error messages, prefixed with `source(type)` / `sink(type)`. */
+  errors: string[];
+  /** Flattened warning messages, same prefixing. */
+  warnings: string[];
+}
+
+export interface CandidatePlugin {
+  type: string;
+  config?: PluginConfig;
+  /** Optional provenance label, echoed back in the report. */
+  origin?: string;
+}
+
+export interface CandidatePluginSet {
+  source?: CandidatePlugin | null;
+  sinks?: CandidatePlugin[];
+}
+
+/**
+ * The slice of `PluginRegistry` this validator needs. Declared structurally so
+ * tests (and any future registry) can supply a stand-in without a real manager.
+ */
+export interface PluginSchemaProvider {
+  getSourceTypes(): string[];
+  getSinkTypes(): string[];
+  getSourceSchema(type: string): ConfigField[];
+  getSinkSchema(type: string): ConfigField[];
+  redactSourceConfig(configs: Record<string, PluginConfig>): Record<string, PluginConfig>;
+  redactSinkConfig(configs: Record<string, PluginConfig>): Record<string, PluginConfig>;
+}
+
+function describe(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  const t = typeof value;
+  if (t === "object") return "an object";
+  return `${t} ${JSON.stringify(value)}`;
+}
+
+/** Levenshtein distance, used only for "did you mean" hints on typos. */
+function editDistance(a: string, b: string): number {
+  const prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  const curr = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length];
+}
+
+/** Closest candidate within a small edit distance, for typo hints. */
+function suggest(value: string, candidates: string[]): string | null {
+  let best: string | null = null;
+  let bestScore = Number.POSITIVE_INFINITY;
+  const lower = value.toLowerCase();
+  for (const candidate of candidates) {
+    const score = editDistance(lower, candidate.toLowerCase());
+    if (score < bestScore) {
+      bestScore = score;
+      best = candidate;
+    }
+  }
+  const threshold = Math.max(2, Math.floor(value.length / 3));
+  return best !== null && bestScore <= threshold ? best : null;
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === undefined || value === null || value === "";
+}
+
+/**
+ * Validate one value against its declared `ConfigField`. Returns `null` when
+ * the value is acceptable.
+ *
+ * Coercions that the plugins themselves perform are accepted (numeric strings
+ * for `number`, `"true"`/`"false"` for `boolean`, case-insensitive `select`
+ * values), so validation never rejects a config that would actually work.
+ */
+function checkValue(field: ConfigField, value: unknown): ConfigIssue | null {
+  const error = (message: string): ConfigIssue => ({
+    field: field.name,
+    severity: "error",
+    message,
+  });
+
+  switch (field.type) {
+    case "number": {
+      const n =
+        typeof value === "number"
+          ? value
+          : typeof value === "string" && value.trim() !== ""
+            ? Number(value)
+            : Number.NaN;
+      return Number.isFinite(n) ? null : error(`must be a number (got ${describe(value)})`);
+    }
+    case "boolean": {
+      if (typeof value === "boolean") return null;
+      if (typeof value === "string" && ["true", "false"].includes(value.toLowerCase())) return null;
+      return error(`must be a boolean (got ${describe(value)})`);
+    }
+    case "json": {
+      if (typeof value === "object") return null;
+      if (typeof value === "string") {
+        try {
+          JSON.parse(value);
+          return null;
+        } catch {
+          return error("must be a JSON object (the string value is not parseable JSON)");
+        }
+      }
+      return error(`must be a JSON object (got ${describe(value)})`);
+    }
+    case "select": {
+      const allowed = (field.options ?? []).map((o) => o.value);
+      if (allowed.length === 0) return null;
+      const normalized = String(value).toLowerCase();
+      if (allowed.some((a) => a.toLowerCase() === normalized)) return null;
+      return error(`must be one of [${allowed.join(", ")}] (got ${describe(value)})`);
+    }
+    default: {
+      // "string" and "password"
+      return typeof value === "string" ? null : error(`must be a string (got ${describe(value)})`);
+    }
+  }
+}
+
+/** Validate a single plugin's config against its schema. */
+export function validatePluginConfig(config: PluginConfig, schema: ConfigField[]): ConfigIssue[] {
+  const issues: ConfigIssue[] = [];
+  const known = schema.map((f) => f.name);
+
+  for (const field of schema) {
+    const value = config[field.name];
+    if (isEmpty(value)) {
+      if (field.required) {
+        issues.push({
+          field: field.name,
+          severity: "error",
+          message: `required field "${field.name}" is missing or empty`,
+        });
+      }
+      continue;
+    }
+    const issue = checkValue(field, value);
+    if (issue) issues.push(issue);
+  }
+
+  for (const key of Object.keys(config)) {
+    if (known.includes(key)) continue;
+    const hint = suggest(key, known);
+    issues.push({
+      field: key,
+      severity: "warning",
+      message: `unknown field "${key}" — it is not in this plugin's config schema and will be ignored${
+        hint ? `; did you mean "${hint}"?` : ""
+      }`,
+    });
+  }
+
+  return issues;
+}
+
+function validateOne(
+  kind: "source" | "sink",
+  candidate: CandidatePlugin,
+  registry: PluginSchemaProvider
+): PluginValidation {
+  const type = candidate.type;
+  const config = candidate.config ?? {};
+  const knownTypes = kind === "source" ? registry.getSourceTypes() : registry.getSinkTypes();
+  const redacted =
+    kind === "source"
+      ? registry.redactSourceConfig({ [type]: config })[type]
+      : registry.redactSinkConfig({ [type]: config })[type];
+
+  if (!knownTypes.includes(type)) {
+    const hint = suggest(type, knownTypes);
+    return {
+      kind,
+      type,
+      valid: false,
+      origin: candidate.origin,
+      config: redacted,
+      issues: [
+        {
+          field: null,
+          severity: "error",
+          message: `unknown ${kind} type "${type}" (registered types: ${knownTypes.join(", ")})${
+            hint ? `; did you mean "${hint}"?` : ""
+          }`,
+        },
+      ],
+    };
+  }
+
+  const schema = kind === "source" ? registry.getSourceSchema(type) : registry.getSinkSchema(type);
+  const issues = validatePluginConfig(config, schema);
+
+  return {
+    kind,
+    type,
+    valid: !issues.some((i) => i.severity === "error"),
+    origin: candidate.origin,
+    config: redacted,
+    issues,
+  };
+}
+
+/**
+ * Validate a whole candidate plugin set (one source + N sinks) against the
+ * registered plugins' `configSchema`s, and report what would be activated.
+ */
+export function validatePluginSet(
+  candidate: CandidatePluginSet,
+  registry: PluginSchemaProvider
+): ConfigValidationReport {
+  const source = candidate.source ? validateOne("source", candidate.source, registry) : null;
+  const sinks = (candidate.sinks ?? []).map((s) => validateOne("sink", s, registry));
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  for (const plugin of source ? [source, ...sinks] : sinks) {
+    for (const issue of plugin.issues) {
+      const line = `${plugin.kind}(${plugin.type})${issue.field ? `.${issue.field}` : ""}: ${issue.message}`;
+      (issue.severity === "error" ? errors : warnings).push(line);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    source,
+    sinks,
+    wouldActivate: {
+      source: source?.valid ? source.type : null,
+      sinks: sinks.filter((s) => s.valid).map((s) => s.type),
+    },
+    errors,
+    warnings,
+  };
+}

--- a/apps/adapter/src/routes/configValidate.ts
+++ b/apps/adapter/src/routes/configValidate.ts
@@ -1,0 +1,155 @@
+import type { Request, Response } from "express";
+import type { AdapterConfig, PluginConfig } from "../plugins/types";
+import type { CandidatePlugin, ConfigValidationReport } from "../plugins/validation";
+import type { StartupConfig } from "../utils/config";
+
+/**
+ * `POST /config/validate` — dry-run configuration check.
+ *
+ * Reports what the current (or a supplied) configuration WOULD activate, with a
+ * precise per-plugin reason for anything malformed. It never mutates the running
+ * plugin set and never contacts a backend.
+ *
+ * The two failure modes the adapter must not conflate:
+ *
+ *  - **Malformed config** — reported here as `valid: false` with per-plugin
+ *    errors. The operator has to fix it; startup refuses to boot on it.
+ *  - **Valid config, unreachable backend** — NOT detectable here (by design, we
+ *    do not connect). That case is intentionally fail-soft at startup and shows
+ *    up as an unhealthy/absent plugin in `GET /health`.
+ */
+
+const DRY_RUN_NOTE =
+  "Dry run: no plugin was instantiated, connected, replaced or removed. Backend " +
+  "reachability is NOT tested here — a plugin reported valid can still be skipped " +
+  "at startup if its backend is unreachable, which is intentional fail-soft " +
+  "behaviour and is visible in GET /health.";
+
+export interface ConfigValidateDeps {
+  manager: {
+    validateConfig(candidate: {
+      source?: CandidatePlugin | null;
+      sinks?: CandidatePlugin[];
+    }): ConfigValidationReport;
+    getConfig(): AdapterConfig;
+  };
+  /**
+   * Re-resolve the startup configuration (env vars + config file) from scratch,
+   * so an operator can edit the file and re-check without restarting.
+   */
+  resolveStartupConfig: () => StartupConfig;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Parse one `{ type, config }` entry from the request body. Throws on garbage. */
+function parseCandidate(raw: unknown, label: string): CandidatePlugin {
+  if (!isPlainObject(raw)) {
+    throw new Error(`'${label}' must be an object of the form { type, config }`);
+  }
+  if (typeof raw.type !== "string" || raw.type.trim() === "") {
+    throw new Error(`'${label}.type' must be a non-empty string`);
+  }
+  if (raw.config != null && !isPlainObject(raw.config)) {
+    throw new Error(`'${label}.config' must be a JSON object`);
+  }
+  return {
+    type: raw.type.trim(),
+    config: (raw.config as PluginConfig | undefined) ?? {},
+    origin: "request",
+  };
+}
+
+export function createConfigValidateHandler(deps: ConfigValidateDeps) {
+  return function configValidateHandler(req: Request, res: Response): void {
+    const body: unknown = req.body ?? {};
+    if (!isPlainObject(body)) {
+      res.status(400).json({ error: "Request body must be a JSON object" });
+      return;
+    }
+
+    const active = deps.manager.getConfig();
+    const activeSet = { source: active.activeSource, sinks: [...active.activeSinks] };
+
+    const hasCandidate = "source" in body || "sinks" in body;
+
+    let candidate: { source?: CandidatePlugin | null; sinks?: CandidatePlugin[] };
+    let checked: "request-body" | "startup-config";
+    let configFile: string | null = null;
+
+    if (hasCandidate) {
+      // A caller-supplied candidate: reject a malformed *request* with 400.
+      // That is distinct from a well-formed request describing invalid config,
+      // which is a 200 report with valid:false.
+      try {
+        const source = body.source == null ? null : parseCandidate(body.source, "source");
+        let sinks: CandidatePlugin[] = [];
+        if (body.sinks != null) {
+          if (!Array.isArray(body.sinks)) {
+            throw new Error("'sinks' must be an array of { type, config } objects");
+          }
+          sinks = body.sinks.map((s, i) => parseCandidate(s, `sinks[${i}]`));
+        }
+        candidate = { source, sinks };
+      } catch (err) {
+        res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+        return;
+      }
+      checked = "request-body";
+    } else {
+      checked = "startup-config";
+      try {
+        const resolved = deps.resolveStartupConfig();
+        configFile = resolved.origins.configFile;
+        candidate = {
+          source: {
+            type: resolved.source.type,
+            config: resolved.source.config,
+            origin: resolved.origins.source,
+          },
+          sinks: resolved.sinks.map((s) => ({
+            type: s.type,
+            config: s.config,
+            origin: resolved.origins.sinks[s.type],
+          })),
+        };
+      } catch (err) {
+        // Resolution itself failed (bad JSON in an env var, unreadable or
+        // malformed config file). Still a configuration error the operator must
+        // fix — reported as an invalid config, not a server fault.
+        const message = err instanceof Error ? err.message : String(err);
+        res.json({
+          valid: false,
+          checked,
+          configFile: null,
+          resolutionError: message,
+          source: null,
+          sinks: [],
+          wouldActivate: { source: null, sinks: [] },
+          active: activeSet,
+          errors: [message],
+          warnings: [],
+          backendConnectivity: { checked: false, note: DRY_RUN_NOTE },
+        });
+        return;
+      }
+    }
+
+    const report = deps.manager.validateConfig(candidate);
+
+    res.json({
+      valid: report.valid,
+      checked,
+      configFile,
+      source: report.source,
+      sinks: report.sinks,
+      wouldActivate: report.wouldActivate,
+      active: activeSet,
+      errors: report.errors,
+      warnings: report.warnings,
+      backendConnectivity: { checked: false, note: DRY_RUN_NOTE },
+    });
+  };
+}

--- a/apps/adapter/src/utils/config.ts
+++ b/apps/adapter/src/utils/config.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import { z } from "zod";
 import { createLogger } from "./logger";
+import { loadPluginConfigFile, type FileReader, type PluginConfigFile } from "./configFile";
 
 const logger = createLogger("config");
 
@@ -27,6 +28,13 @@ export const envSchema = z.object({
 
   /** JSON config for the realism engine (off by default). */
   REALISM_CONFIG: z.string().default(""),
+
+  /**
+   * Optional path to a JSON file holding the source/sink/realism configuration
+   * (the readable alternative to the JSON-in-env-var form). Environment
+   * variables take precedence over the file — see `loadConfig`.
+   */
+  ADAPTER_CONFIG_FILE: z.string().default(""),
 
   /**
    * Base URL of the simulator, used to fetch recordings for replay/emit.
@@ -80,22 +88,31 @@ function parseCorsOrigins(raw: string): string[] | "*" {
     .filter(Boolean);
 }
 
-function parseSinks(
-  env: Record<string, string | undefined>
-): Array<{ type: string; config: Record<string, unknown> }> {
-  const types = env.SINK_TYPES;
-  if (!types) return [];
-  return types
-    .split(",")
-    .map((t) => t.trim())
-    .filter(Boolean)
-    .map((type) => ({
-      type,
-      config: parseJSON(
-        env[`SINK_${type.toUpperCase()}_CONFIG`],
-        `SINK_${type.toUpperCase()}_CONFIG`
-      ),
-    }));
+/** Where a resolved piece of plugin configuration came from. */
+export type ConfigOrigin = "env" | "file" | "env+file" | "default";
+
+function originOf(fromEnv: boolean, fromFile: boolean): ConfigOrigin {
+  if (fromEnv && fromFile) return "env+file";
+  if (fromEnv) return "env";
+  if (fromFile) return "file";
+  return "default";
+}
+
+/** True when an env var is present and not blank (zod defaults hide this). */
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+export interface ConfigOrigins {
+  /** Absolute path of the config file that contributed, or null when unused. */
+  configFile: string | null;
+  /** Provenance of the source entry. */
+  source: ConfigOrigin;
+  /** Provenance of the *list* of sink types. */
+  sinkList: ConfigOrigin;
+  /** Provenance of each sink's config object, keyed by sink type. */
+  sinks: Record<string, ConfigOrigin>;
+  realism: ConfigOrigin;
 }
 
 export interface StartupConfig {
@@ -105,31 +122,110 @@ export interface StartupConfig {
   sinks: Array<{ type: string; config: Record<string, unknown> }>;
   realism: Record<string, unknown>;
   simulatorUrl: string;
+  /** Provenance of each resolved piece, for logs and `POST /config/validate`. */
+  origins: ConfigOrigins;
 }
 
-export function loadConfig(env: Record<string, string | undefined> = process.env): StartupConfig {
+/**
+ * Resolve the startup configuration from environment variables and, when
+ * `ADAPTER_CONFIG_FILE` is set, a JSON config file.
+ *
+ * ## Precedence: environment variables win over the file
+ *
+ * The file is the readable base; env vars are the per-deployment override
+ * (12-factor: the environment is the last word, so a container can override a
+ * baked-in file without rewriting it). Concretely:
+ *
+ *  - `SOURCE_TYPE` overrides the file's `source.type`. When the two name
+ *    *different* types, the file's `source.config` is dropped: plugin configs
+ *    are type-specific, so carrying it over would be nonsense.
+ *  - `SOURCE_CONFIG` is **shallow-merged over** the file's `source.config`
+ *    (key by key, env wins), so a file can hold the bulk of the config while an
+ *    env var overrides a single key such as a URL or a secret.
+ *  - `SINK_TYPES` overrides the file's sink *list* wholesale. Otherwise the
+ *    list comes from the file.
+ *  - `SINK_<TYPE>_CONFIG` is shallow-merged over the file's config for the same
+ *    sink type, same rule as the source.
+ *  - `REALISM_CONFIG` is shallow-merged over the file's `realism`.
+ *
+ * Anything malformed (bad JSON in an env var, unreadable/malformed file)
+ * throws: that is a configuration error, not a fail-soft condition.
+ */
+export function loadConfig(
+  env: Record<string, string | undefined> = process.env,
+  readFile?: FileReader
+): StartupConfig {
   const parsed = parseEnv(env);
 
-  const sourceConfig = parseJSON(parsed.SOURCE_CONFIG, "SOURCE_CONFIG");
-  if (parsed.SOURCE_TYPE === "static" && !sourceConfig.count) {
+  const loadedFile = loadPluginConfigFile(parsed.ADAPTER_CONFIG_FILE, readFile);
+  const file: PluginConfigFile | null = loadedFile?.contents ?? null;
+
+  // --- source ---------------------------------------------------------
+  const envSourceTypeSet = isSet(env.SOURCE_TYPE);
+  const envSourceConfigSet = isSet(parsed.SOURCE_CONFIG);
+  const fileSource = file?.source ?? null;
+
+  const sourceType = envSourceTypeSet ? parsed.SOURCE_TYPE : (fileSource?.type ?? "static");
+  // Only inherit the file's config when it describes the same plugin type.
+  const fileSourceConfig = fileSource && fileSource.type === sourceType ? fileSource.config : {};
+  const sourceConfig: Record<string, unknown> = {
+    ...fileSourceConfig,
+    ...parseJSON(parsed.SOURCE_CONFIG, "SOURCE_CONFIG"),
+  };
+  if (sourceType === "static" && !sourceConfig.count) {
     sourceConfig.count = 20;
   }
 
-  const sinks = parseSinks(env);
+  // --- sinks ----------------------------------------------------------
+  const envSinkTypesSet = isSet(env.SINK_TYPES);
+  const fileSinks = file?.sinks ?? [];
 
-  if (sinks.length === 0 && !parsed.SINK_TYPES) {
-    sinks.push({ type: "console", config: {} });
+  let sinkTypes: string[];
+  let sinkListOrigin: ConfigOrigin;
+  if (envSinkTypesSet) {
+    sinkTypes = parsed.SINK_TYPES.split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    sinkListOrigin = "env";
+  } else if (fileSinks.length > 0) {
+    sinkTypes = fileSinks.map((s) => s.type);
+    sinkListOrigin = "file";
+  } else {
+    sinkTypes = ["console"];
+    sinkListOrigin = "default";
   }
 
-  const realism = parseJSON(parsed.REALISM_CONFIG, "REALISM_CONFIG");
+  const sinkOrigins: Record<string, ConfigOrigin> = {};
+  const sinks = sinkTypes.map((type) => {
+    const envVar = `SINK_${type.toUpperCase()}_CONFIG`;
+    const envConfigSet = isSet(env[envVar]);
+    const fileEntry = fileSinks.find((s) => s.type === type);
+    sinkOrigins[type] = originOf(envConfigSet, fileEntry != null);
+    return {
+      type,
+      config: { ...(fileEntry?.config ?? {}), ...parseJSON(env[envVar], envVar) },
+    };
+  });
+
+  // --- realism --------------------------------------------------------
+  const envRealismSet = isSet(parsed.REALISM_CONFIG);
+  const fileRealism = file?.realism ?? {};
+  const realism = { ...fileRealism, ...parseJSON(parsed.REALISM_CONFIG, "REALISM_CONFIG") };
 
   return {
     port: parsed.PORT,
     corsOrigins: parseCorsOrigins(parsed.CORS_ORIGINS),
-    source: { type: parsed.SOURCE_TYPE, config: sourceConfig },
+    source: { type: sourceType, config: sourceConfig },
     sinks,
     realism,
     simulatorUrl: parsed.SIMULATOR_URL,
+    origins: {
+      configFile: loadedFile?.path ?? null,
+      source: originOf(envSourceTypeSet || envSourceConfigSet, fileSource != null),
+      sinkList: sinkListOrigin,
+      sinks: sinkOrigins,
+      realism: originOf(envRealismSet, Object.keys(fileRealism).length > 0),
+    },
   };
 }
 
@@ -143,6 +239,8 @@ export function logConfig(cfg: StartupConfig): void {
     port: cfg.port,
     source: { type: cfg.source.type, config: "••••••" },
     sinks: redactedSinks,
+    configFile: cfg.origins.configFile,
+    origins: { source: cfg.origins.source, sinks: cfg.origins.sinks },
   };
   logger.info({ config: redacted }, "Adapter config");
 }

--- a/apps/adapter/src/utils/configFile.test.ts
+++ b/apps/adapter/src/utils/configFile.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from "vitest";
+import { loadConfig } from "./config";
+import { loadPluginConfigFile } from "./configFile";
+
+vi.mock("dotenv", () => ({ default: { config: vi.fn() } }));
+
+/** Fake filesystem reader so the suite never touches disk. */
+function reader(contents: unknown) {
+  return vi.fn(() => (typeof contents === "string" ? contents : JSON.stringify(contents)));
+}
+
+const FILE = "/etc/moveet/adapter.json";
+
+describe("loadPluginConfigFile", () => {
+  it("returns null when no path is configured", () => {
+    expect(loadPluginConfigFile(undefined)).toBeNull();
+    expect(loadPluginConfigFile("")).toBeNull();
+    expect(loadPluginConfigFile("   ")).toBeNull();
+  });
+
+  it("resolves the path to an absolute path and reports it", () => {
+    const read = reader({ sinks: [{ type: "console" }] });
+    const loaded = loadPluginConfigFile("relative/adapter.json", read);
+    expect(loaded?.path.startsWith("/")).toBe(true);
+    expect(read).toHaveBeenCalledWith(loaded?.path);
+  });
+
+  it("defaults missing sections", () => {
+    const loaded = loadPluginConfigFile(FILE, reader({}));
+    expect(loaded?.contents).toEqual({ sinks: [], realism: {} });
+  });
+
+  it("throws naming the file when it cannot be read", () => {
+    const read = vi.fn(() => {
+      throw new Error("ENOENT: no such file or directory");
+    });
+    expect(() => loadPluginConfigFile(FILE, read)).toThrow(
+      /Cannot read adapter config file .*adapter\.json .*ENOENT/
+    );
+  });
+
+  it("throws naming the file when the JSON is malformed", () => {
+    expect(() => loadPluginConfigFile(FILE, reader("{broken"))).toThrow(
+      /Invalid JSON in adapter config file .*adapter\.json/
+    );
+  });
+
+  it("rejects a non-object document", () => {
+    expect(() => loadPluginConfigFile(FILE, reader([1, 2, 3]))).toThrow(
+      /expected a JSON object with optional "source", "sinks" and "realism" keys/
+    );
+  });
+
+  it("rejects an unknown top-level key (a typo must not be silently ignored)", () => {
+    const read = reader({ sink: [{ type: "console" }] });
+    expect(() => loadPluginConfigFile(FILE, read)).toThrow(/Invalid adapter config file/);
+    expect(() => loadPluginConfigFile(FILE, read)).toThrow(/sink/);
+  });
+
+  it("rejects a plugin entry without a type", () => {
+    expect(() => loadPluginConfigFile(FILE, reader({ sinks: [{ config: {} }] }))).toThrow(
+      /sinks\.0\.type/
+    );
+  });
+
+  it("rejects an unknown key inside a plugin entry", () => {
+    const read = reader({ sinks: [{ type: "console", conifg: {} }] });
+    expect(() => loadPluginConfigFile(FILE, read)).toThrow(/conifg/);
+  });
+});
+
+describe("loadConfig with ADAPTER_CONFIG_FILE", () => {
+  it("loads source, sinks and realism from the file when no env vars are set", () => {
+    const read = reader({
+      source: { type: "rest", config: { url: "http://roster.local" } },
+      sinks: [
+        { type: "redpanda", config: { brokers: "broker:9092", topic: "t" } },
+        { type: "console", config: { verbose: true } },
+      ],
+      realism: { enabled: true },
+    });
+
+    const cfg = loadConfig({ ADAPTER_CONFIG_FILE: FILE }, read);
+
+    expect(cfg.source).toEqual({ type: "rest", config: { url: "http://roster.local" } });
+    expect(cfg.sinks).toEqual([
+      { type: "redpanda", config: { brokers: "broker:9092", topic: "t" } },
+      { type: "console", config: { verbose: true } },
+    ]);
+    expect(cfg.realism).toEqual({ enabled: true });
+    expect(cfg.origins.configFile).toBe(FILE);
+    expect(cfg.origins.source).toBe("file");
+    expect(cfg.origins.sinkList).toBe("file");
+  });
+
+  it("lets SOURCE_CONFIG override the file key by key (env wins, file fills the rest)", () => {
+    const read = reader({
+      source: { type: "rest", config: { url: "http://file.local", vehiclePath: "assignments" } },
+    });
+
+    const cfg = loadConfig(
+      { ADAPTER_CONFIG_FILE: FILE, SOURCE_CONFIG: '{"url":"http://env.local"}' },
+      read
+    );
+
+    expect(cfg.source.config).toEqual({
+      url: "http://env.local",
+      vehiclePath: "assignments",
+    });
+    expect(cfg.origins.source).toBe("env+file");
+  });
+
+  it("lets SOURCE_TYPE override the file type and drops the file's config for the other type", () => {
+    const read = reader({
+      source: { type: "rest", config: { url: "http://file.local" } },
+    });
+
+    const cfg = loadConfig({ ADAPTER_CONFIG_FILE: FILE, SOURCE_TYPE: "static" }, read);
+
+    expect(cfg.source.type).toBe("static");
+    expect(cfg.source.config).toEqual({ count: 20 });
+  });
+
+  it("lets SINK_TYPES replace the file's sink list wholesale", () => {
+    const read = reader({
+      sinks: [
+        { type: "redpanda", config: { brokers: "broker:9092" } },
+        { type: "redis", config: { host: "cache" } },
+      ],
+    });
+
+    const cfg = loadConfig({ ADAPTER_CONFIG_FILE: FILE, SINK_TYPES: "redpanda" }, read);
+
+    expect(cfg.sinks).toEqual([{ type: "redpanda", config: { brokers: "broker:9092" } }]);
+    expect(cfg.origins.sinkList).toBe("env");
+    expect(cfg.origins.sinks.redpanda).toBe("file");
+  });
+
+  it("shallow-merges SINK_<TYPE>_CONFIG over the file entry of the same type", () => {
+    const read = reader({
+      sinks: [{ type: "redpanda", config: { brokers: "file:9092", topic: "from-file" } }],
+    });
+
+    const cfg = loadConfig(
+      { ADAPTER_CONFIG_FILE: FILE, SINK_REDPANDA_CONFIG: '{"brokers":"env:9092"}' },
+      read
+    );
+
+    expect(cfg.sinks).toEqual([
+      { type: "redpanda", config: { brokers: "env:9092", topic: "from-file" } },
+    ]);
+    expect(cfg.origins.sinks.redpanda).toBe("env+file");
+  });
+
+  it("shallow-merges REALISM_CONFIG over the file's realism section", () => {
+    const read = reader({ realism: { enabled: true, jitterMs: 800 } });
+
+    const cfg = loadConfig({ ADAPTER_CONFIG_FILE: FILE, REALISM_CONFIG: '{"jitterMs":100}' }, read);
+
+    expect(cfg.realism).toEqual({ enabled: true, jitterMs: 100 });
+    expect(cfg.origins.realism).toBe("env+file");
+  });
+
+  it("still falls back to the default console sink when neither env nor file define sinks", () => {
+    const cfg = loadConfig(
+      { ADAPTER_CONFIG_FILE: FILE },
+      reader({ source: { type: "static", config: { count: 5 } } })
+    );
+
+    expect(cfg.sinks).toEqual([{ type: "console", config: {} }]);
+    expect(cfg.origins.sinkList).toBe("default");
+    expect(cfg.source.config).toEqual({ count: 5 });
+  });
+
+  it("propagates a broken config file as a thrown configuration error", () => {
+    const read = vi.fn(() => {
+      throw new Error("ENOENT: no such file or directory");
+    });
+    expect(() => loadConfig({ ADAPTER_CONFIG_FILE: FILE }, read)).toThrow(
+      /Cannot read adapter config file/
+    );
+  });
+
+  it("does not read any file when ADAPTER_CONFIG_FILE is unset", () => {
+    const read = reader({});
+    const cfg = loadConfig({ SOURCE_TYPE: "static" }, read);
+    expect(read).not.toHaveBeenCalled();
+    expect(cfg.origins.configFile).toBeNull();
+    expect(cfg.origins.source).toBe("env");
+  });
+});

--- a/apps/adapter/src/utils/configFile.ts
+++ b/apps/adapter/src/utils/configFile.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { z } from "zod";
+
+/**
+ * File-based plugin configuration.
+ *
+ * `SOURCE_CONFIG` / `SINK_<TYPE>_CONFIG` are JSON documents squeezed into
+ * environment variables — hard to read, hard to diff, and easy to typo. This
+ * module offers the same information as a plain JSON file whose path is given
+ * by `ADAPTER_CONFIG_FILE`.
+ *
+ * The file is only a *transport*: it is merged with the env form in
+ * `utils/config.ts` and the merged result is validated by the single
+ * schema-driven validator in `plugins/validation.ts`. There is one validation
+ * story, not two.
+ */
+
+/** One plugin entry: a registered type plus its plugin-specific config object. */
+const pluginEntrySchema = z.strictObject({
+  type: z.string().trim().min(1, "must be a non-empty string"),
+  config: z.record(z.string(), z.unknown()).default({}),
+});
+
+/**
+ * Shape of the config file. Strict on purpose: a misspelled top-level key
+ * (`"sink"` instead of `"sinks"`) is exactly the silent-misconfiguration this
+ * feature exists to eliminate, so it is an error rather than an ignored key.
+ */
+export const pluginConfigFileSchema = z.strictObject({
+  source: pluginEntrySchema.optional(),
+  sinks: z.array(pluginEntrySchema).default([]),
+  realism: z.record(z.string(), z.unknown()).default({}),
+});
+
+export type PluginConfigFile = z.infer<typeof pluginConfigFileSchema>;
+
+export interface LoadedConfigFile {
+  /** Absolute path the config was read from (useful in logs and API output). */
+  path: string;
+  contents: PluginConfigFile;
+}
+
+/** Injectable reader so tests never touch the real filesystem. */
+export type FileReader = (path: string) => string;
+
+/**
+ * Read and shape-validate the plugin config file.
+ *
+ * Returns `null` when no path is configured. Every other failure throws: a
+ * configured-but-broken file is a configuration error the operator must fix,
+ * never something to silently ignore.
+ */
+export function loadPluginConfigFile(
+  filePath: string | undefined,
+  readFile: FileReader = (p) => readFileSync(p, "utf8")
+): LoadedConfigFile | null {
+  const trimmed = filePath?.trim();
+  if (!trimmed) return null;
+
+  const absolute = resolvePath(trimmed);
+
+  let raw: string;
+  try {
+    raw = readFile(absolute);
+  } catch (err) {
+    throw new Error(
+      `Cannot read adapter config file ${absolute} (from ADAPTER_CONFIG_FILE): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err }
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Invalid JSON in adapter config file ${absolute}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err }
+    );
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `Invalid adapter config file ${absolute}: expected a JSON object with optional "source", "sinks" and "realism" keys`
+    );
+  }
+
+  const result = pluginConfigFileSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.length > 0 ? i.path.join(".") : "<root>"}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid adapter config file ${absolute}:\n${issues}`);
+  }
+
+  return { path: absolute, contents: result.data };
+}

--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -22,6 +22,12 @@ SPEED_VARIATION=0.1
 # Lower values mean vehicles move slower in heat zones
 HEATZONE_SPEED_FACTOR=0.5
 
+# Scale generated heat-zone intensity with the simulated clock (true/false).
+# Uses the same time-of-day demand curve as the traffic model, so zones bloom
+# at rush hour and fade overnight; re-broadcast once per simulated hour.
+# Manually-drawn zones always keep the intensity the operator set.
+HEATZONE_TIME_SCALING=false
+
 # Number of default vehicles when running without adapter
 VEHICLE_COUNT=70
 

--- a/apps/simulator/src/__tests__/HeatZoneTimeOfDay.test.ts
+++ b/apps/simulator/src/__tests__/HeatZoneTimeOfDay.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import path from "path";
+import { HeatZoneManager } from "../modules/HeatZoneManager";
+import { RoadNetwork } from "../modules/RoadNetwork";
+import { HEAT_ZONE_TIME } from "../constants";
+import { DEFAULT_TRAFFIC_PROFILE, type TrafficProfile } from "../utils/trafficProfiles";
+import type { Edge, HeatZoneFeature, Node } from "../types";
+
+/**
+ * Hours picked straight out of DEFAULT_TRAFFIC_PROFILE so the tests assert
+ * against the SAME curve TrafficManager uses rather than a private copy.
+ */
+const MORNING_RUSH_HOUR = 8; // 07-09, demand 2.0 on trunk/primary
+const EVENING_RUSH_HOUR = 18; // 17-19, demand 2.5 on trunk/primary
+const MIDDAY_HOUR = 13; // no range matches, demand 1.0
+const NIGHT_HOUR = 2; // 00-05, demand 0.3 on all roads
+
+/** Minimal 4-node network with one 3-way intersection zones can be placed on. */
+function buildFixture(): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [
+    { id: "n1", coordinates: [45.5017, -73.5673], connections: [] },
+    { id: "n2", coordinates: [45.502, -73.567], connections: [] },
+    { id: "n3", coordinates: [45.5023, -73.5667], connections: [] },
+    { id: "hub", coordinates: [45.5026, -73.5664], connections: [] },
+  ];
+  const edge = (id: string, start: Node, end: Node): Edge => ({
+    id,
+    streetId: "s1",
+    start,
+    end,
+    distance: 0.5,
+    bearing: 45,
+    highway: "residential",
+    maxSpeed: 30,
+    surface: "unknown",
+    oneway: false,
+  });
+  const edges: Edge[] = [
+    edge("e1", nodes[0], nodes[1]),
+    edge("e2", nodes[1], nodes[2]),
+    edge("e3", nodes[2], nodes[3]),
+  ];
+  nodes[0].connections = [edges[0]];
+  nodes[1].connections = [edges[1]];
+  nodes[2].connections = [edges[2]];
+  nodes[3].connections = [edges[0], edges[1], edges[2]];
+  return { nodes, edges };
+}
+
+const SQUARE: number[][] = [
+  [-73.5673, 45.5017],
+  [-73.5663, 45.5017],
+  [-73.5663, 45.5027],
+  [-73.5673, 45.5027],
+  [-73.5673, 45.5017],
+];
+
+describe("heat-zone time-of-day intensity", () => {
+  let manager: HeatZoneManager;
+  let fixture: ReturnType<typeof buildFixture>;
+
+  beforeEach(() => {
+    manager = new HeatZoneManager();
+    fixture = buildFixture();
+  });
+
+  /** Seeds `count` generated zones with a deterministic base intensity. */
+  function seedGenerated(count = 3, intensity = 0.4): void {
+    manager.generateHeatedZones(fixture.edges, fixture.nodes, {
+      count,
+      minIntensity: intensity,
+      maxIntensity: intensity,
+    });
+  }
+
+  describe("generated zones", () => {
+    it("blooms at rush hour and fades overnight", () => {
+      seedGenerated();
+
+      manager.applyTimeOfDay(NIGHT_HOUR);
+      const night = manager.getZones().map((z) => z.intensity);
+
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      const rush = manager.getZones().map((z) => z.intensity);
+
+      expect(night.length).toBeGreaterThan(0);
+      for (let i = 0; i < night.length; i++) {
+        expect(rush[i]).toBeGreaterThan(night[i]);
+      }
+    });
+
+    it("scales by the shared traffic demand curve, not a private one", () => {
+      const base = 0.3;
+      seedGenerated(2, base);
+
+      const expectAll = (expected: number) => {
+        for (const zone of manager.getZones()) expect(zone.intensity).toBeCloseTo(expected, 6);
+      };
+
+      manager.applyTimeOfDay(MIDDAY_HOUR);
+      expectAll(base * 1.0);
+
+      manager.applyTimeOfDay(MORNING_RUSH_HOUR);
+      expectAll(base * 2.0);
+
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      expectAll(base * 2.5);
+
+      manager.applyTimeOfDay(NIGHT_HOUR);
+      expectAll(base * 0.3);
+    });
+
+    it("follows a custom traffic profile instead of the default", () => {
+      const custom: TrafficProfile = {
+        name: "custom",
+        timeRanges: [{ start: 13, end: 14, demandMultiplier: 2.0, affectedHighways: ["primary"] }],
+      };
+      seedGenerated(1, 0.25);
+
+      manager.applyTimeOfDay(MIDDAY_HOUR, custom);
+      expect(manager.getZones()[0].intensity).toBeCloseTo(0.5, 6);
+
+      // Default profile has no rush hour at 13:00.
+      manager.applyTimeOfDay(MIDDAY_HOUR, DEFAULT_TRAFFIC_PROFILE);
+      expect(manager.getZones()[0].intensity).toBeCloseTo(0.25, 6);
+    });
+
+    it("always rescales from the base intensity, so repeated calls are idempotent", () => {
+      seedGenerated(2, 0.4);
+
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      const once = manager.getZones().map((z) => z.intensity);
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      const thrice = manager.getZones().map((z) => z.intensity);
+
+      expect(thrice).toEqual(once);
+      // Round-tripping through night and back restores the rush-hour value
+      // exactly (no compounding).
+      manager.applyTimeOfDay(NIGHT_HOUR);
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      expect(manager.getZones().map((z) => z.intensity)).toEqual(once);
+    });
+
+    it("clamps to [MIN_INTENSITY, 1]", () => {
+      seedGenerated(2, 1);
+      manager.applyTimeOfDay(EVENING_RUSH_HOUR);
+      for (const zone of manager.getZones()) expect(zone.intensity).toBe(1);
+
+      const dim = new HeatZoneManager();
+      const f = buildFixture();
+      dim.generateHeatedZones(f.edges, f.nodes, {
+        count: 1,
+        minIntensity: 0.01,
+        maxIntensity: 0.01,
+      });
+      dim.applyTimeOfDay(NIGHT_HOUR);
+      expect(dim.getZones()[0].intensity).toBe(HEAT_ZONE_TIME.MIN_INTENSITY);
+    });
+
+    it("scales zones generated after the hour was applied", () => {
+      manager.applyTimeOfDay(NIGHT_HOUR);
+      seedGenerated(1, 0.4);
+      expect(manager.getZones()[0].intensity).toBeCloseTo(0.4 * 0.3, 6);
+      expect(manager.getZones()[0].baseIntensity).toBe(0.4);
+    });
+
+    it("leaves intensity untouched until a time of day is applied", () => {
+      seedGenerated(3, 0.4);
+      for (const zone of manager.getZones()) expect(zone.intensity).toBe(0.4);
+      expect(manager.getTimeOfDayMultiplier()).toBe(1);
+    });
+  });
+
+  describe("manually-drawn zones", () => {
+    it("keeps the operator's intensity at every hour", () => {
+      manager.addZone({ polygon: SQUARE, intensity: 0.8 });
+
+      for (const hour of [NIGHT_HOUR, MORNING_RUSH_HOUR, MIDDAY_HOUR, EVENING_RUSH_HOUR]) {
+        manager.applyTimeOfDay(hour);
+        expect(manager.getZones()[0].intensity).toBe(0.8);
+        expect(manager.getZones()[0].origin).toBe("manual");
+      }
+    });
+
+    it("does not make applyTimeOfDay report a change on its own", () => {
+      manager.addZone({ polygon: SQUARE, intensity: 0.8 });
+      expect(manager.applyTimeOfDay(EVENING_RUSH_HOUR)).toBe(false);
+      expect(manager.applyTimeOfDay(NIGHT_HOUR)).toBe(false);
+    });
+
+    it("promotes a generated zone to manual when an operator patches intensity", () => {
+      seedGenerated(1, 0.4);
+      const id = manager.getZones()[0].id as string;
+
+      manager.applyTimeOfDay(MIDDAY_HOUR);
+      manager.updateZone(id, { intensity: 0.9 });
+      manager.applyTimeOfDay(NIGHT_HOUR);
+
+      expect(manager.getZones()[0].intensity).toBe(0.9);
+      expect(manager.getZones()[0].origin).toBe("manual");
+    });
+
+    it("keeps scaling a generated zone whose geometry (only) was edited", () => {
+      seedGenerated(1, 0.4);
+      const id = manager.getZones()[0].id as string;
+
+      manager.updateZone(id, { polygon: SQUARE });
+      manager.applyTimeOfDay(NIGHT_HOUR);
+
+      expect(manager.getZones()[0].origin).toBe("generated");
+      expect(manager.getZones()[0].intensity).toBeCloseTo(0.4 * 0.3, 6);
+    });
+  });
+
+  describe("legacy / injected zones", () => {
+    it("never rescales a zone that carries no base intensity", () => {
+      // Mimics a zone injected straight into the array (restore, tests, older
+      // snapshots) with neither `origin` nor `baseIntensity`.
+      manager.getZones().push({
+        id: "legacy",
+        polygon: SQUARE,
+        intensity: 0.55,
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(manager.applyTimeOfDay(EVENING_RUSH_HOUR)).toBe(false);
+      expect(manager.getZones()[0].intensity).toBe(0.55);
+    });
+  });
+
+  describe("change reporting", () => {
+    it("reports true only when an intensity actually moves", () => {
+      seedGenerated(2, 0.4);
+
+      expect(manager.applyTimeOfDay(MIDDAY_HOUR)).toBe(false); // 1.0x == unscaled
+      expect(manager.applyTimeOfDay(EVENING_RUSH_HOUR)).toBe(true);
+      expect(manager.applyTimeOfDay(EVENING_RUSH_HOUR)).toBe(false); // same range
+      expect(manager.applyTimeOfDay(18)).toBe(false); // still 17-19
+      expect(manager.applyTimeOfDay(NIGHT_HOUR)).toBe(true);
+    });
+
+    it("reports false when there are no zones at all", () => {
+      expect(manager.applyTimeOfDay(EVENING_RUSH_HOUR)).toBe(false);
+    });
+  });
+});
+
+describe("RoadNetwork.applyHeatZoneTimeOfDay", () => {
+  const testGeojsonPath = path.join(__dirname, "fixtures", "test-network.geojson");
+  let network: RoadNetwork;
+
+  beforeEach(() => {
+    network = new RoadNetwork(testGeojsonPath);
+  });
+
+  it("broadcasts the full zone list only when an intensity changed", () => {
+    const emitted: HeatZoneFeature[][] = [];
+    network.seedHeatZones(3);
+    network.on("heatzones", (zones: HeatZoneFeature[]) => emitted.push(zones));
+
+    expect(network.applyHeatZoneTimeOfDay(MIDDAY_HOUR)).toBe(false);
+    expect(emitted).toHaveLength(0);
+
+    expect(network.applyHeatZoneTimeOfDay(EVENING_RUSH_HOUR)).toBe(true);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].length).toBe(network.exportHeatZones().length);
+
+    // Same demand range → no second broadcast.
+    expect(network.applyHeatZoneTimeOfDay(17)).toBe(false);
+    expect(emitted).toHaveLength(1);
+
+    expect(network.applyHeatZoneTimeOfDay(NIGHT_HOUR)).toBe(true);
+    expect(emitted).toHaveLength(2);
+
+    const rushMax = Math.max(...emitted[0].map((f) => f.properties.intensity));
+    const nightMax = Math.max(...emitted[1].map((f) => f.properties.intensity));
+    expect(nightMax).toBeLessThan(rushMax);
+  });
+
+  it("leaves a manually-added zone out of the rescale", () => {
+    const manual = network.addHeatZone({ polygon: SQUARE, intensity: 0.7 });
+    network.applyHeatZoneTimeOfDay(NIGHT_HOUR);
+    const after = network.exportHeatZones().find((f) => f.properties.id === manual.properties.id);
+    expect(after?.properties.intensity).toBe(0.7);
+  });
+});

--- a/apps/simulator/src/__tests__/setup/eventWiringHeatZoneTime.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiringHeatZoneTime.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+// wireEvents reads HEATZONE_TIME_SCALING (and ANALYTICS_INTERVAL) from the
+// config singleton at call time, so the flag is flipped here rather than
+// through process.env.
+vi.mock("../../utils/config", () => ({
+  config: {
+    analyticsInterval: 5000,
+    heatZoneTimeScaling: true,
+  },
+}));
+
+vi.mock("../../utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { wireEvents, type EventWiringContext } from "../../setup/eventWiring";
+import { HeatZoneManager } from "../../modules/HeatZoneManager";
+import { SimulationClock } from "../../modules/SimulationClock";
+import { GeoFenceManager } from "../../modules/GeoFenceManager";
+import { DEFAULT_TRAFFIC_PROFILE } from "../../utils/trafficProfiles";
+import type { Edge, Node } from "../../types";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function buildNodes(): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [
+    { id: "n1", coordinates: [45.5017, -73.5673], connections: [] },
+    { id: "n2", coordinates: [45.502, -73.567], connections: [] },
+    { id: "n3", coordinates: [45.5023, -73.5667], connections: [] },
+    { id: "hub", coordinates: [45.5026, -73.5664], connections: [] },
+  ];
+  const mk = (id: string, start: Node, end: Node): Edge => ({
+    id,
+    streetId: "s1",
+    start,
+    end,
+    distance: 0.5,
+    bearing: 45,
+    highway: "residential",
+    maxSpeed: 30,
+    surface: "unknown",
+    oneway: false,
+  });
+  const edges = [
+    mk("e1", nodes[0], nodes[1]),
+    mk("e2", nodes[1], nodes[2]),
+    mk("e3", nodes[2], nodes[3]),
+  ];
+  nodes[3].connections = edges;
+  return { nodes, edges };
+}
+
+/**
+ * A minimal RoadNetwork stand-in backed by a REAL HeatZoneManager, so the
+ * recompute → "heatzones" emit → broadcaster path is genuinely exercised.
+ */
+function createFakeNetwork(heatZones: HeatZoneManager) {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    applyHeatZoneTimeOfDay: vi.fn((hour: number, profile = DEFAULT_TRAFFIC_PROFILE) => {
+      const changed = heatZones.applyTimeOfDay(hour, profile);
+      if (changed) emitter.emit("heatzones", heatZones.exportHeatedZonesAsFeatures());
+      return changed;
+    }),
+  });
+}
+
+describe("wireEvents — heat-zone time-of-day scaling", () => {
+  let heatZones: HeatZoneManager;
+  let network: ReturnType<typeof createFakeNetwork>;
+  let clock: SimulationClock;
+  let broadcast: ReturnType<typeof vi.fn>;
+  let recordEvent: ReturnType<typeof vi.fn>;
+  let result: ReturnType<typeof wireEvents>;
+
+  /** Wires events with the clock parked at `startHour`. */
+  function wire(startHour: number): void {
+    clock = new SimulationClock({ startHour, speedMultiplier: 1 });
+    broadcast = vi.fn();
+    recordEvent = vi.fn();
+
+    const vehicleManager = Object.assign(new EventEmitter(), {
+      clock,
+      getTrafficProfile: vi.fn(() => DEFAULT_TRAFFIC_PROFILE),
+      getTrafficSnapshot: vi.fn().mockReturnValue({ edges: {} }),
+      analytics: { getSnapshot: vi.fn().mockReturnValue({}) },
+    });
+
+    const ctx = {
+      network,
+      vehicleManager,
+      fleetManager: new EventEmitter(),
+      incidentManager: new EventEmitter(),
+      recordingManager: Object.assign(new EventEmitter(), {
+        captureVehicleSnapshot: vi.fn(),
+        recordEvent,
+      }),
+      simulationController: new EventEmitter(),
+      broadcaster: {
+        queueVehicleUpdate: vi.fn(),
+        broadcast,
+        clearVehicles: vi.fn(),
+        clientCount: 1,
+      },
+      geoFenceManager: new GeoFenceManager(),
+      scenarioManager: new EventEmitter(),
+      generationManager: new EventEmitter(),
+    } as unknown as EventWiringContext;
+
+    result = wireEvents(ctx);
+  }
+
+  const heatzoneBroadcasts = () =>
+    broadcast.mock.calls.filter(([channel]) => channel === "heatzones");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    heatZones = new HeatZoneManager();
+    const { nodes, edges } = buildNodes();
+    heatZones.generateHeatedZones(edges, nodes, { count: 3, minIntensity: 0.4, maxIntensity: 0.4 });
+    network = createFakeNetwork(heatZones);
+  });
+
+  afterEach(() => {
+    clearInterval(result.trafficBroadcastInterval);
+    clearInterval(result.analyticsBroadcastInterval);
+    clearInterval(result.recordingBatchInterval);
+    vi.useRealTimers();
+  });
+
+  it("seeds the current simulated hour at wiring time", () => {
+    // 02:00 is inside the profile's 00-05 night range (0.3x demand).
+    wire(2);
+    expect(network.applyHeatZoneTimeOfDay).toHaveBeenCalledTimes(1);
+    expect(network.applyHeatZoneTimeOfDay).toHaveBeenCalledWith(2, DEFAULT_TRAFFIC_PROFILE);
+    for (const zone of heatZones.getZones()) expect(zone.intensity).toBeCloseTo(0.4 * 0.3, 6);
+    expect(heatzoneBroadcasts()).toHaveLength(1);
+  });
+
+  it("recomputes once per simulated hour, not once per tick", () => {
+    wire(2);
+    network.applyHeatZoneTimeOfDay.mockClear();
+
+    // 600 ticks of 1s each = 10 simulated minutes, all inside hour 02.
+    for (let i = 0; i < 600; i++) clock.tick(1000);
+    expect(network.applyHeatZoneTimeOfDay).not.toHaveBeenCalled();
+
+    // Cross into 03:00 — exactly one recompute for the whole hour.
+    for (let i = 0; i < 3000; i++) clock.tick(1000);
+    expect(clock.getHour()).toBe(3);
+    expect(network.applyHeatZoneTimeOfDay).toHaveBeenCalledTimes(1);
+    expect(network.applyHeatZoneTimeOfDay).toHaveBeenCalledWith(3, DEFAULT_TRAFFIC_PROFILE);
+  });
+
+  it("broadcasts only on hours where the demand curve actually moves", () => {
+    // Start at 05:00: outside every profile range → 1.0x, nothing to change.
+    wire(5);
+    expect(heatzoneBroadcasts()).toHaveLength(0);
+
+    clock.tick(2 * HOUR_MS); // 07:00 — morning rush begins (2.0x)
+    expect(clock.getHour()).toBe(7);
+    expect(heatzoneBroadcasts()).toHaveLength(1);
+
+    clock.tick(HOUR_MS); // 08:00 — still morning rush, same multiplier
+    expect(heatzoneBroadcasts()).toHaveLength(1);
+
+    clock.tick(HOUR_MS); // 09:00 — back to 1.0x
+    expect(heatzoneBroadcasts()).toHaveLength(2);
+
+    const rush = heatzoneBroadcasts()[0][1] as Array<{ properties: { intensity: number } }>;
+    const midday = heatzoneBroadcasts()[1][1] as Array<{ properties: { intensity: number } }>;
+    expect(rush[0].properties.intensity).toBeGreaterThan(midday[0].properties.intensity);
+  });
+
+  it("records rescaled zones through the recording layer too", () => {
+    wire(2);
+    expect(recordEvent).toHaveBeenCalledWith("heatzone", expect.any(Array));
+  });
+
+  it("keeps manual zones fixed across simulated hours", () => {
+    heatZones.addZone({
+      polygon: [
+        [-73.5673, 45.5017],
+        [-73.5663, 45.5017],
+        [-73.5663, 45.5027],
+        [-73.5673, 45.5017],
+      ],
+      intensity: 0.85,
+    });
+    wire(5);
+
+    clock.tick(2 * HOUR_MS); // 07:00
+    clock.tick(12 * HOUR_MS); // 19:00
+    clock.tick(7 * HOUR_MS); // 02:00 next day
+
+    const manual = heatZones.getZones().find((z) => z.origin === "manual");
+    expect(manual?.intensity).toBe(0.85);
+  });
+});

--- a/apps/simulator/src/constants.ts
+++ b/apps/simulator/src/constants.ts
@@ -29,6 +29,35 @@ export const HEAT_ZONE_DEFAULTS = {
   MAX_TOTAL: 100,
 } as const;
 
+/**
+ * Tuning for time-of-day heat-zone intensity scaling (see
+ * `HeatZoneManager.applyTimeOfDay`). The curve itself is NOT defined here — it
+ * is the traffic demand curve from `utils/trafficProfiles`, reused verbatim so
+ * congestion and heat zones can never drift apart.
+ */
+export const HEAT_ZONE_TIME = {
+  /**
+   * Highway class the demand curve is sampled with. Generated zones sit on
+   * high-connectivity intersections, i.e. arterial junctions, so the profile's
+   * `trunk`/`primary` rush-hour ranges are the ones that should apply. Sampling
+   * with a class the rush-hour ranges do not cover would silently flatten the
+   * curve to 1.0 during rush hour.
+   */
+  HIGHWAY: "primary",
+  /**
+   * Floor for a time-scaled intensity. Overnight demand (0.3x) must dim a zone,
+   * not erase it — a zone that renders as nothing is indistinguishable from a
+   * deleted zone on the map.
+   */
+  MIN_INTENSITY: 0.05,
+  /**
+   * Minimum absolute intensity change before a rescale counts as "changed" and
+   * triggers a broadcast. Guards against emitting a full zone list for
+   * floating-point noise when the hour advances inside the same demand range.
+   */
+  EPSILON: 0.001,
+} as const;
+
 // Vehicle state management
 export const VEHICLE_CONSTANTS = {
   /** Maximum number of visited edges to track per vehicle before clearing */

--- a/apps/simulator/src/modules/HeatZoneManager.ts
+++ b/apps/simulator/src/modules/HeatZoneManager.ts
@@ -1,7 +1,12 @@
 import { point, destination, distance, lineString, bezierSpline } from "@turf/turf";
 import crypto from "crypto";
 import type { Edge, Node, HeatZone, HeatZoneFeature } from "../types";
-import { SPATIAL_GRID, HEAT_ZONE_DEFAULTS } from "../constants";
+import { SPATIAL_GRID, HEAT_ZONE_DEFAULTS, HEAT_ZONE_TIME } from "../constants";
+import {
+  DEFAULT_TRAFFIC_PROFILE,
+  getDemandMultiplier,
+  type TrafficProfile,
+} from "../utils/trafficProfiles";
 import logger from "../utils/logger";
 
 /**
@@ -25,6 +30,16 @@ export class HeatZoneManager {
   // typically 0-1 for most positions on the map.
   private spatialGrid: Map<string, HeatZone[]> = new Map();
   private static readonly GRID_CELL_SIZE = SPATIAL_GRID.CELL_SIZE;
+
+  /**
+   * Simulated hour the zone intensities are currently scaled for, or null when
+   * time-of-day scaling has never been applied. null keeps the legacy
+   * behaviour exactly: intensity is whatever the zone was created with.
+   */
+  private scaledHour: number | null = null;
+
+  /** Traffic profile the last `applyTimeOfDay` sampled its demand curve from. */
+  private profile: TrafficProfile = DEFAULT_TRAFFIC_PROFILE;
 
   constructor() {}
 
@@ -132,10 +147,17 @@ export class HeatZoneManager {
 
     // APPEND generated zones to any existing (drawn or previously-seeded)
     // zones instead of replacing them, and index each new zone into the grid.
+    // Generated zones are owned by the simulation, so they carry a
+    // `baseIntensity` and are immediately brought in line with whatever
+    // simulated hour the manager is currently scaled to (a zone seeded at
+    // 03:00 must not appear at full rush-hour intensity until the next hour
+    // boundary).
     const generated: HeatZone[] = this.smoothPolygons(newZones).map((zone) => ({
       id: zone.properties.id,
       polygon: zone.geometry.coordinates,
-      intensity: zone.properties.intensity,
+      intensity: this.scaleIntensity(zone.properties.intensity),
+      baseIntensity: zone.properties.intensity,
+      origin: "generated" as const,
       timestamp: zone.properties.timestamp,
       radius: this.deriveRadius(zone.geometry.coordinates),
     }));
@@ -152,6 +174,9 @@ export class HeatZoneManager {
    * Adds a single manually-drawn zone. Assigns a stable id (unless one is
    * supplied) and a creation timestamp, indexes it into the spatial grid, and
    * returns the exported GeoJSON feature.
+   *
+   * The zone is tagged `origin: "manual"`, which permanently exempts it from
+   * time-of-day scaling — see {@link applyTimeOfDay}.
    */
   public addZone(input: { polygon: number[][]; intensity: number; id?: string }): HeatZoneFeature {
     if (this.zones.length >= HEAT_ZONE_DEFAULTS.MAX_TOTAL) {
@@ -161,6 +186,8 @@ export class HeatZoneManager {
       id: input.id ?? crypto.randomUUID(),
       polygon: input.polygon,
       intensity: input.intensity,
+      baseIntensity: input.intensity,
+      origin: "manual",
       timestamp: new Date().toISOString(),
       radius: this.deriveRadius(input.polygon),
     };
@@ -173,6 +200,11 @@ export class HeatZoneManager {
    * Updates a zone's geometry and/or intensity. Re-indexes the spatial grid
    * only when the geometry changes. Returns the updated feature, or null if no
    * zone has the given id.
+   *
+   * An explicit intensity patch is an operator decision, so it also promotes
+   * the zone to `origin: "manual"`: from then on the clock leaves it alone.
+   * Without this, a generated zone an operator just dialled down would be
+   * silently overwritten at the next hour boundary.
    */
   public updateZone(
     id: string,
@@ -188,7 +220,11 @@ export class HeatZoneManager {
       zone.polygon = patch.polygon;
       zone.radius = this.deriveRadius(patch.polygon);
     }
-    if (patch.intensity !== undefined) zone.intensity = patch.intensity;
+    if (patch.intensity !== undefined) {
+      zone.intensity = patch.intensity;
+      zone.baseIntensity = patch.intensity;
+      zone.origin = "manual";
+    }
 
     if (geometryChanged) this.indexZone(zone);
     return this.zoneToFeature(zone);
@@ -211,6 +247,79 @@ export class HeatZoneManager {
   public clearZones(): void {
     this.zones = [];
     this.spatialGrid.clear();
+  }
+
+  // ─── Time-of-day intensity ──────────────────────────────────────────
+
+  /**
+   * Rescales generated zones for a simulated hour so heat zones bloom at rush
+   * hour and fade overnight.
+   *
+   * The curve is NOT a new one: it is the same `getDemandMultiplier` demand
+   * curve `TrafficManager.getCongestionFactor` uses, sampled with the same
+   * `TrafficProfile` and the arterial highway class generated zones sit on
+   * ({@link HEAT_ZONE_TIME.HIGHWAY}). One curve, two consumers — congestion and
+   * heat zones cannot drift apart, and editing a profile's `timeRanges` moves
+   * both.
+   *
+   * `intensity = clamp(baseIntensity * demand(hour), MIN_INTENSITY, 1)`.
+   * Scaling always derives from `baseIntensity`, never from the current
+   * (already-scaled) intensity, so repeated calls are idempotent and hour
+   * transitions never compound.
+   *
+   * Manually-drawn zones are deliberately excluded. An operator who drew a zone
+   * at 0.8 asserted a fact about the world ("this market is congested"); the
+   * clock re-deciding that for them would make the map disagree with the
+   * control that produced it, with no way for the operator to tell the two
+   * apart. Structural zones are the simulation's own artefact and are free to
+   * breathe; operator intent is not.
+   *
+   * @param hour - Simulated hour of day (0-23), typically `SimulationClock.getHour()`.
+   * @param profile - Traffic profile to sample; defaults to the built-in profile.
+   * @returns true if at least one zone's intensity moved by more than
+   *          {@link HEAT_ZONE_TIME.EPSILON} — i.e. whether a broadcast is warranted.
+   */
+  public applyTimeOfDay(hour: number, profile: TrafficProfile = DEFAULT_TRAFFIC_PROFILE): boolean {
+    this.scaledHour = hour;
+    this.profile = profile;
+
+    let changed = false;
+    for (const zone of this.zones) {
+      if (!this.isTimeScaled(zone)) continue;
+      const next = this.scaleIntensity(zone.baseIntensity as number);
+      if (Math.abs(next - zone.intensity) > HEAT_ZONE_TIME.EPSILON) changed = true;
+      zone.intensity = next;
+    }
+    return changed;
+  }
+
+  /**
+   * The demand multiplier currently applied to generated zones (1 when
+   * time-of-day scaling has not been applied). Exposed for diagnostics/tests.
+   */
+  public getTimeOfDayMultiplier(): number {
+    if (this.scaledHour === null) return 1;
+    return getDemandMultiplier(this.profile, this.scaledHour, HEAT_ZONE_TIME.HIGHWAY);
+  }
+
+  /**
+   * Only zones the simulation owns AND that carry a base intensity are scaled.
+   * Legacy/test-injected zones (no `baseIntensity`) and manual zones keep the
+   * intensity they were given.
+   */
+  private isTimeScaled(zone: HeatZone): boolean {
+    return zone.origin === "generated" && typeof zone.baseIntensity === "number";
+  }
+
+  /**
+   * Applies the current hour's demand multiplier to a base intensity. A no-op
+   * until `applyTimeOfDay` has been called at least once, which is what keeps
+   * the feature opt-in.
+   */
+  private scaleIntensity(baseIntensity: number): number {
+    if (this.scaledHour === null) return baseIntensity;
+    const demand = this.getTimeOfDayMultiplier();
+    return Math.min(1, Math.max(HEAT_ZONE_TIME.MIN_INTENSITY, baseIntensity * demand));
   }
 
   /**

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import type { FeatureCollection } from "geojson";
 import type { Node, Edge, Route, HeatZoneFeature, POI, BoundingBox } from "../types";
 import { HEAT_ZONE_DEFAULTS } from "../constants";
+import type { TrafficProfile } from "../utils/trafficProfiles";
 import type { CacheStats } from "../utils/LRUCache";
 import { HeatZoneManager } from "./HeatZoneManager";
 import { PathfindingPool } from "./PathfindingPool";
@@ -400,6 +401,19 @@ export class RoadNetwork extends EventEmitter {
     const existed = this.heatZoneManager.removeZone(id);
     if (existed) this.emit("heatzones", this.exportHeatZones());
     return existed;
+  }
+
+  /**
+   * Rescales generated heat zones for the given simulated hour (see
+   * `HeatZoneManager.applyTimeOfDay`) and broadcasts the full list only when an
+   * intensity actually moved. Manually-drawn zones are untouched.
+   *
+   * @returns whether anything changed (and therefore whether "heatzones" was emitted).
+   */
+  public applyHeatZoneTimeOfDay(hour: number, profile?: TrafficProfile): boolean {
+    const changed = this.heatZoneManager.applyTimeOfDay(hour, profile);
+    if (changed) this.emit("heatzones", this.exportHeatZones());
+    return changed;
   }
 
   /**

--- a/apps/simulator/src/setup/eventWiring.ts
+++ b/apps/simulator/src/setup/eventWiring.ts
@@ -279,6 +279,35 @@ export function wireEvents(ctx: EventWiringContext): {
     }
   }, analyticsIntervalMs);
 
+  // ─── Heat-zone intensity follows the simulated clock ────────────────
+  // Cadence is the clock's own "hour:changed" event, i.e. once per SIMULATED
+  // hour — not a wall-clock timer and not the game tick. At the default 1x
+  // speed multiplier that is one recompute an hour; at 60x, one a minute. The
+  // recompute is O(zones) (<= HEAT_ZONE_DEFAULTS.MAX_TOTAL = 100) and only
+  // emits "heatzones" when an intensity actually moved, so an hour boundary
+  // that stays inside the same demand range costs nothing on the wire.
+  // Off by default (HEATZONE_TIME_SCALING) so existing deployments are unchanged.
+  //
+  // Wired LAST on purpose: it emits "heatzones" synchronously while seeding the
+  // current hour, so every subscriber above (broadcaster AND the recording
+  // layer) must already be attached.
+  if (config.heatZoneTimeScaling) {
+    const clock = vehicleManager.clock;
+    if (clock) {
+      const rescaleHeatZones = (hour: number): void => {
+        // Sample the LIVE traffic profile rather than a cached copy, so a
+        // runtime profile change moves congestion and heat zones together.
+        network.applyHeatZoneTimeOfDay(hour, vehicleManager.getTrafficProfile());
+      };
+      clock.on("hour:changed", rescaleHeatZones);
+      // Seed the current hour immediately, otherwise zones would stay at their
+      // unscaled intensity until the first hour boundary is crossed.
+      rescaleHeatZones(clock.getHour());
+    } else {
+      logger.warn("HEATZONE_TIME_SCALING is on but no simulation clock is available; skipping.");
+    }
+  }
+
   return {
     trafficBroadcastInterval,
     analyticsBroadcastInterval,

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -153,7 +153,29 @@ export interface HeatZone {
    */
   id?: string;
   polygon: number[][];
+  /**
+   * Effective intensity (0-1) as broadcast/rendered. When time-of-day scaling
+   * is active this is `baseIntensity` scaled by the traffic demand curve for
+   * the current simulated hour; otherwise it equals `baseIntensity`.
+   */
   intensity: number; // 0-1 scale
+  /**
+   * Intrinsic intensity the zone was created with, before any time-of-day
+   * scaling. Kept separate so rescaling is idempotent (scaling always derives
+   * from the base, never from an already-scaled value). Optional for
+   * legacy/test-injected zones that bypass the create path.
+   */
+  baseIntensity?: number;
+  /**
+   * Where the zone came from:
+   *  - "generated" — derived from road-network intersection density; the
+   *    simulation owns its intensity, so it breathes with the clock.
+   *  - "manual" — drawn (or explicitly re-intensified) by an operator; its
+   *    intensity is left exactly as authored.
+   * Optional for legacy/test-injected zones; treated as "generated" only when
+   * a base intensity is present, so untagged zones are never rescaled.
+   */
+  origin?: "generated" | "manual";
   timestamp: string;
   /**
    * Representative radius (km) cached from the polygon bounding box when the

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -38,6 +38,22 @@ const envObjectSchema = z.object({
   /** Speed multiplier inside heat zones [0, 1] */
   HEATZONE_SPEED_FACTOR: z.coerce.number().min(0).max(1).default(0.5),
 
+  /**
+   * Bind heat-zone intensity to the simulated clock. When enabled, zones
+   * generated from intersection density are rescaled at every simulated hour
+   * boundary by the SAME time-of-day demand curve TrafficManager uses
+   * (`utils/trafficProfiles`), so they bloom at rush hour and fade overnight,
+   * and a "heatzones" broadcast goes out whenever an intensity actually moves.
+   * Manually-drawn zones always keep the operator's intensity.
+   *
+   * Opt-in (default false): existing deployments keep today's static zones and
+   * today's broadcast volume until they ask for the behaviour.
+   */
+  HEATZONE_TIME_SCALING: z
+    .enum(["true", "false", "1", "0", ""])
+    .default("false")
+    .transform((v) => v === "true" || v === "1"),
+
   /** Timeout for adapter sync requests in ms */
   SYNC_ADAPTER_TIMEOUT: z.coerce.number().int().min(0).default(5000),
 
@@ -177,6 +193,7 @@ function buildConfig(env: EnvConfig) {
     turnThreshold: env.TURN_THRESHOLD,
     speedVariation: env.SPEED_VARIATION,
     heatZoneSpeedFactor: env.HEATZONE_SPEED_FACTOR,
+    heatZoneTimeScaling: env.HEATZONE_TIME_SCALING,
     syncAdapterTimeout: env.SYNC_ADAPTER_TIMEOUT,
     adapterSyncInterval: env.ADAPTER_SYNC_INTERVAL,
     vehicleCount: env.VEHICLE_COUNT,

--- a/apps/simulator/vitest.config.ts
+++ b/apps/simulator/vitest.config.ts
@@ -10,10 +10,16 @@ export default defineConfig({
       exclude: ["node_modules/", "dist/", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts"],
       thresholds: {
         // Global floor: the whole simulator must stay at least here.
-        lines: 50,
-        branches: 50,
-        functions: 50,
-        statements: 50,
+        //
+        // Locally measured 2026-07-25 over the full suite (1664 tests):
+        // lines 94.87%, statements 93.68%, functions 94.44%, branches 82.40%.
+        // Floors sit ~2-3 points under those numbers so ordinary churn (and the
+        // usual local/CI v8 branch-accounting drift) does not redden CI, while a
+        // real coverage regression still fails the build.
+        lines: 92,
+        branches: 79,
+        functions: 92,
+        statements: 91,
         // Per-file floors pin the hot/critical simulation paths well above the
         // global floor, so a regression that guts one of them reddens CI even
         // while the aggregate stays green. Glob keys are matched per file.

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -36,8 +36,11 @@ import ErrorBoundary, { SectionErrorFallback } from "./components/ErrorBoundary"
 import { useAnalytics } from "./hooks/useAnalytics";
 import { useNetwork } from "./hooks/useNetwork";
 import { useRoads } from "./hooks/useRoads";
-import { useDataReady } from "./data/useData";
+import { useDataReady, useOptionsContext } from "./data/useData";
 import LoadingOverlay from "./components/LoadingOverlay";
+import StartHint from "./components/StartHint";
+import { useVersionCheck } from "./hooks/useVersionCheck";
+import { toast } from "./lib/toast";
 import { Toaster } from "./components/ui/sonner";
 
 export default function App() {
@@ -180,6 +183,23 @@ export default function App() {
     setSelectedItem(null);
   }, [onUnselectVehicle, setSelectedItem]);
 
+  // ─── First-run start affordance ─────────────────────────────────
+  // The sim boots paused; StartHint owns its own (one-shot) visibility, this
+  // only supplies the action. Options come from the shared context rather than
+  // useOptions() so we don't add a second fetch/subscription for one button.
+  const { options } = useOptionsContext();
+  const onStartFromHint = useCallback(async () => {
+    const res = await client.start(options);
+    if (res?.error) {
+      toast.error(`Failed to start simulation: ${res.error}`);
+      return;
+    }
+    toast.success("Simulation started");
+  }, [options]);
+
+  // Long-open tabs keep running the bundle they loaded with; poll for redeploys.
+  useVersionCheck();
+
   const maxSpeedRef = useRef(60);
   useTracking(vehicles, filters.selected, status.interval);
 
@@ -244,6 +264,11 @@ export default function App() {
               onToggle={toggleFleetVisibility}
             />
             <TypeLegend hiddenVehicleTypes={hiddenVehicleTypes} onToggle={toggleVehicleType} />
+            <StartHint
+              running={status.running}
+              ready={!mapLoading && connected}
+              onStart={onStartFromHint}
+            />
             <Dock
               status={status}
               connected={connected}

--- a/apps/ui/src/Controls/Adapter/adapterPanelSwitch.test.tsx
+++ b/apps/ui/src/Controls/Adapter/adapterPanelSwitch.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigResponse, HealthResponse } from "./adapterClient";
+
+/**
+ * Regression cover for fleetsim-all-8lcy ("Adapter sheet close race clobbers
+ * next panel selection").
+ *
+ * The original bug lived in the pre-dock nav-rail: `AdapterDrawer` was a Radix
+ * `Sheet` wired as `onClose={closePanel}`, so clicking a different nav item set
+ * `activePanel` to the new panel and *then* the closing Sheet fired
+ * `onOpenChange(false)` -> `closePanel()` -> `activePanel = null`. The click
+ * looked like a no-op and had to be repeated.
+ *
+ * That drawer no longer exists — the adapter UI is now `SinksPanel` rendered
+ * into the single shared `DockPanel`, and switching clusters is one
+ * `setOpenCluster` call. These tests pin that behaviour so the race cannot be
+ * reintroduced: a close handler must never run as a side effect of a panel
+ * switch, while a genuine outside click / Escape must still close.
+ */
+
+vi.mock("@/utils/client", async () => {
+  const { createMockClient } = await import("@/test/mocks/client");
+  return {
+    default: {
+      ...createMockClient(),
+      getClock: vi.fn().mockResolvedValue({ data: undefined }),
+    },
+  };
+});
+
+const health: HealthResponse = {
+  source: { type: "simulator", healthy: true },
+  sinks: [{ type: "kafka", healthy: true }],
+  availableSources: [],
+  availableSinks: [],
+};
+
+const config: ConfigResponse = {
+  activeSource: "simulator",
+  activeSinks: ["kafka"],
+  sourceConfig: {},
+  sinkConfig: {},
+  status: health,
+};
+
+vi.mock("./adapterClient", () => ({
+  getHealth: vi.fn(() => Promise.resolve(health)),
+  getConfig: vi.fn(() => Promise.resolve(config)),
+  setSource: vi.fn(),
+  addSink: vi.fn(),
+  removeSink: vi.fn(),
+  setRealism: vi.fn(),
+}));
+
+// Imported after the mocks so the hoisted factories are in place.
+import Dock, { type DockProps } from "@/Dock/Dock";
+import type { DispatchFlow } from "@/hooks/useDispatchFlow";
+import { DispatchState } from "@/hooks/useDispatchState";
+import { createStatus } from "@/test/mocks/types";
+import type { Modifiers } from "@/types";
+
+const modifiers: Modifiers = {
+  showDirections: true,
+  showHeatzones: false,
+  showHeatmap: false,
+  showVehicles: true,
+  showPOIs: false,
+  showTrafficOverlay: false,
+  showBreadcrumbs: false,
+  showSpeedLimits: false,
+};
+
+function dockProps(): DockProps {
+  return {
+    connected: true,
+    status: createStatus({ running: true }),
+    isRecording: false,
+    onStartRecording: async () => {},
+    onStopRecording: async () => {},
+
+    replayStatus: { mode: "live" },
+    onPauseReplay: async () => {},
+    onResumeReplay: async () => {},
+    onStopReplay: async () => {},
+    onSeekReplay: async () => {},
+    onSetReplaySpeed: async () => {},
+
+    vehicles: [],
+    filter: "",
+    onFilterChange: () => {},
+    onSelectVehicle: () => {},
+    onHoverVehicle: () => {},
+    onUnhoverVehicle: () => {},
+    maxSpeed: 60,
+    vehicleFleetMap: new Map(),
+    fleets: [],
+    onCreateFleet: async () => {},
+    onDeleteFleet: async () => {},
+    onAssignVehicle: async () => {},
+    onUnassignVehicle: async () => {},
+    fleetsError: null,
+    // Only `dispatchState` / `selectedForDispatch` are read by the dock bar
+    // itself (the badge); the Fleet panel is never opened in these tests.
+    dispatch: {
+      dispatchState: DispatchState.BROWSE,
+      selectedForDispatch: [],
+    } as unknown as DispatchFlow,
+
+    incidents: {
+      incidents: [],
+      createRandom: async () => {},
+      remove: async () => {},
+      error: null,
+    },
+    geofences: {
+      fences: [],
+      onFenceToggle: () => {},
+      onFenceDelete: () => {},
+      alerts: [],
+      drawingActive: false,
+      vertexCount: 0,
+      onStartDrawing: () => {},
+      onCancelDrawing: () => {},
+      onConfirmDrawing: () => {},
+    },
+    analytics: { summary: null, fleetHistory: new Map(), summaryHistory: [] },
+    toggles: { modifiers, onChangeModifiers: () => () => {} },
+    recordings: {
+      recordings: [],
+      replayStatus: { mode: "live" },
+      onStartReplay: async () => {},
+      onRefreshRecordings: () => {},
+    },
+    advanced: { maxSpeedRef: { current: 60 } },
+  };
+}
+
+/** Open the adapter ("Sinks & Source") panel and wait for its content. */
+async function openAdapterPanel(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Sinks & Source" }));
+  expect(await screen.findByRole("region", { name: "Sinks & Source" })).toBeInTheDocument();
+}
+
+describe("adapter panel <-> other panel switching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("switches from the adapter panel to Monitor in a single click", async () => {
+    const user = userEvent.setup();
+    render(<Dock {...dockProps()} />);
+
+    await openAdapterPanel(user);
+    expect(screen.getByRole("button", { name: "Sinks & Source" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    // One click on a different cluster must land on that cluster. The bug was
+    // that the adapter drawer's own close handler fired afterwards and reset
+    // the selection back to "nothing open".
+    await user.click(screen.getByRole("button", { name: "Monitor" }));
+
+    expect(await screen.findByRole("region", { name: "Monitor" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Monitor" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Sinks & Source" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    expect(screen.queryByRole("region", { name: "Sinks & Source" })).not.toBeInTheDocument();
+
+    // Still open a tick later — a deferred close would show up here.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.getByRole("region", { name: "Monitor" })).toBeInTheDocument();
+  });
+
+  it("switches from the adapter panel to Tempo details in a single click", async () => {
+    const user = userEvent.setup();
+    render(<Dock {...dockProps()} />);
+
+    await openAdapterPanel(user);
+
+    await user.click(screen.getByRole("button", { name: "Tempo details" }));
+
+    expect(await screen.findByRole("region", { name: "Tempo" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Sinks & Source" })).not.toBeInTheDocument();
+  });
+
+  it("switches back into the adapter panel from another panel in a single click", async () => {
+    const user = userEvent.setup();
+    render(<Dock {...dockProps()} />);
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    expect(await screen.findByRole("region", { name: "Settings" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Sinks & Source" }));
+
+    expect(await screen.findByRole("region", { name: "Sinks & Source" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Settings" })).not.toBeInTheDocument();
+  });
+
+  it("still closes the adapter panel when its own cluster is clicked again", async () => {
+    const user = userEvent.setup();
+    render(<Dock {...dockProps()} />);
+
+    await openAdapterPanel(user);
+    await user.click(screen.getByRole("button", { name: "Sinks & Source" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("region", { name: "Sinks & Source" })).not.toBeInTheDocument()
+    );
+  });
+
+  it("still closes the adapter panel on a genuine outside click", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <button type="button">outside</button>
+        <Dock {...dockProps()} />
+      </div>
+    );
+
+    await openAdapterPanel(user);
+    await user.click(screen.getByRole("button", { name: "outside" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("region", { name: "Sinks & Source" })).not.toBeInTheDocument()
+    );
+  });
+});

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.test.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.test.tsx
@@ -46,6 +46,10 @@ interface LayerLike {
     onClick?: (info: { object?: GeoFence }) => boolean;
     updateTriggers?: Record<string, unknown>;
     getLineWidth: (d: GeoFence) => number;
+    getSize?: number;
+    fontSettings?: { sdf?: boolean; radius?: number; buffer?: number };
+    outlineWidth?: number;
+    outlineColor?: number[];
   };
 }
 
@@ -110,6 +114,40 @@ describe("GeofenceLayer", () => {
     expect(layer.props.pickable).toBe(false);
     expect(layer.props.onClick!({ object: fence })).toBe(false);
     expect(onSelectFence).not.toHaveBeenCalled();
+  });
+
+  it("labels enable SDF fonts so the outline props actually render", () => {
+    // deck.gl warns "fontSettings.sdf is required to render outline" and drops
+    // the outline entirely unless the atlas is an SDF one.
+    render(<GeofenceLayer fences={[makeFence()]} />);
+
+    const { fontSettings, outlineWidth, outlineColor } = getLayer("geofence-labels").props;
+
+    expect(fontSettings?.sdf).toBe(true);
+    expect(outlineWidth).toBeGreaterThan(0);
+    expect(outlineColor).toEqual([0, 0, 0, 204]);
+  });
+
+  it("sizes the label halo so it stays inside the SDF atlas and is visible on screen", () => {
+    render(<GeofenceLayer fences={[makeFence()]} />);
+
+    const { fontSettings, outlineWidth, getSize } = getLayer("geofence-labels").props;
+    const radius = fontSettings?.radius ?? 12;
+    const buffer = fontSettings?.buffer ?? 4;
+    const atlasFontSize = 64; // fontSettings.fontSize default
+
+    // deck.gl divides outlineWidth by radius to get a 0..1 outline buffer, so
+    // anything above the radius is clamped and the halo stops growing.
+    expect(outlineWidth!).toBeLessThanOrEqual(radius);
+
+    // Halo extent in atlas pixels; the glyph padding must be able to hold it,
+    // otherwise the halo is clipped by the neighbouring glyph cell.
+    const haloAtlasPx = 0.75 * outlineWidth!;
+    expect(haloAtlasPx).toBeLessThanOrEqual(buffer);
+
+    // ...and it has to survive the atlas → screen downscale.
+    const haloScreenPx = haloAtlasPx * ((getSize ?? 0) / atlasFontSize);
+    expect(haloScreenPx).toBeGreaterThanOrEqual(1);
   });
 
   it("draws the selected fence with a thicker outline and pins it via updateTriggers", () => {

--- a/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
+++ b/apps/ui/src/Map/Geofence/GeofenceLayer.tsx
@@ -134,8 +134,26 @@ export default function GeofenceLayer({
             enter: (value: number[]) => [value[0], value[1], value[2], 0],
           },
         },
-        outlineColor: [0, 0, 0, 153],
-        outlineWidth: 3,
+        // deck.gl only draws an outline for SDF atlases — without `sdf: true`
+        // it logs "fontSettings.sdf is required to render outline" and the
+        // outline props are silently ignored.
+        //
+        // With SDF, the halo width is measured in font-atlas pixels (atlas is
+        // rendered at fontSettings.fontSize = 64) and works out to
+        // 0.75 * outlineWidth, then scales down by getSize / 64. So
+        // outlineWidth 8 → 6 atlas px → ~1px on screen at getSize 11, which is
+        // a legible halo. Two atlas settings have to keep up with that:
+        //   - radius (default 12): distance is only encoded up to
+        //     radius * (1 - cutoff) px outside the glyph; 16 keeps the halo at
+        //     half the encoded range, away from the smoothing clamp.
+        //   - buffer (default 4): glyph padding in the atlas clips the halo,
+        //     so it must be >= the 6 atlas px the halo occupies.
+        fontSettings: { sdf: true, radius: 16, buffer: 8 },
+        outlineWidth: 8,
+        // In the halo band the shader takes its alpha from outlineColor, so
+        // 0.8 keeps labels readable over bright fills without fully hiding the
+        // polygon underneath.
+        outlineColor: [0, 0, 0, 204],
       }),
     ];
   }, [fences, selectedFenceId, onSelectFence, selectable]);

--- a/apps/ui/src/Map/POIs.tsx
+++ b/apps/ui/src/Map/POIs.tsx
@@ -145,7 +145,13 @@ export default function POIs({ visible, onClick }: POIMarkerProps) {
         getPixelOffset: [0, 17],
         fontFamily: "inherit",
         fontWeight: "600",
-        outlineWidth: 2,
+        // SDF is required for deck.gl to draw an outline at all; see the fuller
+        // explanation on the geofence label layer. Halo is 0.75 * outlineWidth
+        // atlas px scaled by getSize / 64, so outlineWidth 8 → 6 atlas px →
+        // ~1.1px on screen at getSize 12. radius must be >= outlineWidth and
+        // buffer >= the halo's 6 atlas px, or the atlas clips it.
+        fontSettings: { sdf: true, radius: 16, buffer: 8 },
+        outlineWidth: 8,
         outlineColor: [8, 10, 12, 235],
         pickable: false,
       }),

--- a/apps/ui/src/Map/Road.tsx
+++ b/apps/ui/src/Map/Road.tsx
@@ -75,7 +75,13 @@ export default function DirectionMap({ road }: DirectionProps) {
         getTextAnchor: "middle",
         getAlignmentBaseline: "center",
         fontFamily: "inherit",
-        outlineWidth: 2,
+        // SDF is required for deck.gl to draw an outline at all; see the fuller
+        // explanation on the geofence label layer. Halo is 0.75 * outlineWidth
+        // atlas px scaled by getSize / 64, so outlineWidth 8 → 6 atlas px →
+        // ~1.3px on screen at getSize 14. radius must be >= outlineWidth and
+        // buffer >= the halo's 6 atlas px, or the atlas clips it.
+        fontSettings: { sdf: true, radius: 16, buffer: 8 },
+        outlineWidth: 8,
         outlineColor: [0, 0, 0, 180],
         pickable: false,
       }),

--- a/apps/ui/src/Map/__tests__/textLayerOutlines.test.ts
+++ b/apps/ui/src/Map/__tests__/textLayerOutlines.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * deck.gl silently ignores `outlineWidth` / `outlineColor` on a TextLayer whose
+ * font atlas is not SDF, and logs "fontSettings.sdf is required to render
+ * outline". Three layers shipped that way (geofence labels, road labels, POI
+ * labels) before anyone noticed the outlines were simply absent.
+ *
+ * This is a source guard rather than a props assertion: the layers live behind
+ * map context and a RAF loop, so mounting each one to inspect its props costs
+ * far more than it catches. Instead, every map source file that asks for an
+ * outline must also opt into SDF and size the atlas to fit the halo.
+ *
+ * The check is file-scoped, so it would miss a file with two TextLayers where
+ * only one is SDF. That is an accepted limitation — today no map file has more
+ * than one text layer, and the failure it does catch (an outline that renders
+ * as nothing) is the one that actually shipped.
+ */
+
+const MAP_DIRS = ["src/Map", "src/components/Map"];
+
+function collectSourceFiles(dir: string): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries.flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return collectSourceFiles(full);
+    if (!/\.tsx?$/.test(entry)) return [];
+    if (/\.test\.tsx?$/.test(entry)) return [];
+    return [full];
+  });
+}
+
+const sources = MAP_DIRS.flatMap((dir) => collectSourceFiles(dir)).map((path) => ({
+  path,
+  text: readFileSync(path, "utf8"),
+}));
+
+const withOutline = sources.filter(({ text }) => text.includes("outlineWidth"));
+
+describe("map text layer outlines", () => {
+  it("finds the layers that request an outline", () => {
+    // Guards the guard: if the layers move or get renamed, this test should
+    // start failing rather than silently checking an empty set.
+    expect(withOutline.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(withOutline.map(({ path }) => path))("%s opts into an SDF atlas", (path) => {
+    const { text } = withOutline.find((s) => s.path === path)!;
+    expect(text).toMatch(/sdf:\s*true/);
+  });
+
+  it.each(
+    withOutline.map(({ path }) => path)
+  )("%s sizes the atlas to fit the halo it asks for", (path) => {
+    const { text } = withOutline.find((s) => s.path === path)!;
+    const outlineWidth = Number(text.match(/outlineWidth:\s*([\d.]+)/)?.[1]);
+    const radius = Number(text.match(/radius:\s*([\d.]+)/)?.[1]);
+    const buffer = Number(text.match(/buffer:\s*([\d.]+)/)?.[1]);
+
+    expect(Number.isFinite(outlineWidth)).toBe(true);
+    expect(Number.isFinite(radius)).toBe(true);
+    expect(Number.isFinite(buffer)).toBe(true);
+
+    // Above `radius`, deck.gl clamps and the halo stops growing.
+    expect(outlineWidth).toBeLessThanOrEqual(radius);
+    // The halo occupies 0.75 * outlineWidth atlas px; `buffer` is the glyph's
+    // padding in the atlas, so anything smaller clips it.
+    expect(buffer).toBeGreaterThanOrEqual(0.75 * outlineWidth);
+  });
+});

--- a/apps/ui/src/components/StartHint.test.tsx
+++ b/apps/ui/src/components/StartHint.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import StartHint from "./StartHint";
+
+const noop = () => {};
+
+describe("StartHint", () => {
+  it("renders while the simulation is idle and ready", () => {
+    render(<StartHint running={false} ready onStart={noop} />);
+    expect(screen.getByText("Simulation is paused")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start simulation" })).toBeInTheDocument();
+  });
+
+  it("renders nothing while the simulation is running", () => {
+    const { container } = render(<StartHint running ready onStart={noop} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing before the app is ready", () => {
+    const { container } = render(<StartHint running={false} ready={false} onStart={noop} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("disappears once the run begins and stays gone when paused again", () => {
+    const { container, rerender } = render(<StartHint running={false} ready onStart={noop} />);
+    expect(screen.getByText("Simulation is paused")).toBeInTheDocument();
+
+    rerender(<StartHint running ready onStart={noop} />);
+    expect(container).toBeEmptyDOMElement();
+
+    // Pausing later must not resurrect the first-run tutorial.
+    rerender(<StartHint running={false} ready onStart={noop} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("calls onStart when the start button is pressed", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn().mockResolvedValue(undefined);
+    render(<StartHint running={false} ready onStart={onStart} />);
+
+    await user.click(screen.getByRole("button", { name: "Start simulation" }));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a pending state while starting", async () => {
+    const user = userEvent.setup();
+    let resolveStart: () => void = noop;
+    const onStart = vi.fn(() => new Promise<void>((resolve) => (resolveStart = resolve)));
+    render(<StartHint running={false} ready onStart={onStart} />);
+
+    await user.click(screen.getByRole("button", { name: "Start simulation" }));
+    expect(await screen.findByText("Starting…")).toBeInTheDocument();
+
+    resolveStart();
+    await waitFor(() => expect(screen.getByText("Start simulation")).toBeInTheDocument());
+  });
+
+  it("can be dismissed permanently", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<StartHint running={false} ready onStart={noop} />);
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ui/src/components/StartHint.tsx
+++ b/apps/ui/src/components/StartHint.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { CloseIcon, Play } from "@/components/Icons";
+
+export interface StartHintProps {
+  /** The simulation's `running` flag (from the sim status feed). */
+  running: boolean;
+  /**
+   * Whether the app is far enough along to act on the hint — map data loaded
+   * and the simulator reachable. Keeps the hint off the loading overlay and
+   * from offering a Start that would fail.
+   */
+  ready: boolean;
+  /** Starts the simulation. Awaited so the button can show a pending state. */
+  onStart: () => unknown;
+  className?: string;
+}
+
+/**
+ * First-run affordance: the simulator boots PAUSED, so without this the app
+ * opens on a static map with no obvious next action — the play control is one
+ * unlabeled icon among many in the bottom dock.
+ *
+ * Visibility is deliberately one-shot. It shows only while the run has never
+ * started in this session; once `running` flips true it is retired for good,
+ * so pausing later does NOT bring the tutorial back at someone who has clearly
+ * found the transport controls. Dismissing does the same, permanently.
+ *
+ * Sits above the dock rather than over the map centre: it is a small glass pill
+ * on the same visual system as the dock (surface-glass + border + elevation),
+ * and only its own box takes pointer events, so the map stays fully draggable.
+ */
+export default function StartHint({ running, ready, onStart, className }: StartHintProps) {
+  const [dismissed, setDismissed] = useState(false);
+  const [hasRun, setHasRun] = useState(running);
+  const [starting, setStarting] = useState(false);
+
+  useEffect(() => {
+    if (running) setHasRun(true);
+  }, [running]);
+
+  const handleStart = useCallback(async () => {
+    setStarting(true);
+    try {
+      await onStart();
+    } finally {
+      setStarting(false);
+    }
+  }, [onStart]);
+
+  const visible = ready && !running && !hasRun && !dismissed;
+  if (!visible) return null;
+
+  return (
+    <div
+      role="status"
+      aria-label="Simulation paused"
+      className={cn(
+        "absolute bottom-[104px] left-1/2 z-40 -translate-x-1/2",
+        "flex max-w-[calc(100vw-2rem)] items-center gap-3 rounded-md border border-border px-3 py-2",
+        "surface-glass shadow-elevated backdrop-blur-xl animate-fade-up",
+        className
+      )}
+    >
+      <div className="flex min-w-0 flex-col">
+        <span className="text-xs font-medium text-foreground">Simulation is paused</span>
+        <span className="truncate text-[11px] text-muted-foreground">
+          Start it to put vehicles on the road.
+        </span>
+      </div>
+      <Button onClick={handleStart} disabled={starting} aria-label="Start simulation">
+        <Play />
+        {starting ? "Starting…" : "Start simulation"}
+      </Button>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        title="Dismiss"
+        className={cn(
+          "flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+          "transition-[color,background-color] duration-fast ease-standard",
+          "hover:bg-foreground/[0.035] hover:text-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "[&_svg]:size-3.5"
+        )}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/useVersionCheck.test.ts
+++ b/apps/ui/src/hooks/useVersionCheck.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useVersionCheck } from "./useVersionCheck";
+import { NEW_VERSION_MESSAGE, VERSION_POLL_INTERVAL_MS } from "@/lib/versionCheck";
+import { toast } from "@/lib/toast";
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const infoMock = vi.mocked(toast.info);
+
+/** A fetch stub that always answers version.json with `buildId`. */
+function deployed(buildId: string) {
+  return vi.fn(async () => ({
+    ok: true,
+    text: async () => JSON.stringify({ buildId }),
+  })) as unknown as typeof fetch;
+}
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => hidden });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  infoMock.mockClear();
+  vi.stubEnv("VITE_BUILD_ID", "build-1");
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("useVersionCheck", () => {
+  it("is a no-op in dev, where HMR already handles reloads", async () => {
+    // Vitest runs with import.meta.env.DEV === true, so the default enablement
+    // must switch the whole thing off — no polling, no toast.
+    expect(import.meta.env.DEV).toBe(true);
+    const fetchImpl = deployed("build-2");
+    renderHook(() => useVersionCheck({ fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(VERSION_POLL_INTERVAL_MS * 3);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it("polls by default once DEV is false", async () => {
+    vi.stubEnv("DEV", false);
+    const fetchImpl = deployed("build-1");
+    renderHook(() => useVersionCheck({ fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(VERSION_POLL_INTERVAL_MS);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not toast while the served build matches", async () => {
+    const fetchImpl = deployed("build-1");
+    renderHook(() => useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it("toasts with a reload action when the served build differs", async () => {
+    const fetchImpl = deployed("build-2");
+    renderHook(() => useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    const [message, options] = infoMock.mock.calls[0];
+    expect(message).toBe(NEW_VERSION_MESSAGE);
+    expect(options?.action?.label).toBe("Reload");
+    expect(options?.duration).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("only nags once and stops polling afterwards", async () => {
+    const fetchImpl = deployed("build-2");
+    renderHook(() => useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays quiet when the bundle carries no build stamp", async () => {
+    vi.stubEnv("VITE_BUILD_ID", "");
+    const fetchImpl = deployed("build-2");
+    renderHook(() => useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it("stays quiet when version.json cannot be read", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      text: async () => "<!doctype html>",
+    })) as unknown as typeof fetch;
+    renderHook(() => useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl }));
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it("pauses while the tab is hidden and rechecks immediately on return", async () => {
+    const fetchImpl = deployed("build-1");
+    renderHook(() => useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl }));
+
+    setHidden(true);
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    setHidden(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops polling on unmount", async () => {
+    const fetchImpl = deployed("build-1");
+    const { unmount } = renderHook(() =>
+      useVersionCheck({ enabled: true, intervalMs: 1000, fetchImpl })
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/src/hooks/useVersionCheck.ts
+++ b/apps/ui/src/hooks/useVersionCheck.ts
@@ -1,0 +1,91 @@
+import { useEffect } from "react";
+import { toast } from "@/lib/toast";
+import {
+  currentBuildId,
+  fetchDeployedBuildId,
+  NEW_VERSION_MESSAGE,
+  shouldNotifyUpdate,
+  VERSION_POLL_INTERVAL_MS,
+} from "@/lib/versionCheck";
+
+export interface UseVersionCheckOptions {
+  /** Poll period in ms. Defaults to 5 minutes. */
+  intervalMs?: number;
+  /**
+   * Overrides the default enablement. Defaults to `!import.meta.env.DEV` —
+   * in dev, Vite's HMR already replaces modules in place, so polling would be
+   * pure noise (and `version.json` is not even emitted by the dev server).
+   */
+  enabled?: boolean;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Polls the deployed `version.json` and, when the served build no longer
+ * matches the one this tab is running, raises a single sonner toast offering a
+ * reload. See `src/lib/versionCheck.ts` for why this works against a bare
+ * static file server.
+ *
+ * Polling pauses while the tab is hidden (a background tab cannot act on the
+ * prompt anyway) and runs one immediate check when it becomes visible again —
+ * which is exactly when a user returns to a tab that has been open for hours.
+ * After the prompt fires, polling stops for good: one nag is enough.
+ */
+export function useVersionCheck({
+  intervalMs = VERSION_POLL_INTERVAL_MS,
+  enabled,
+  fetchImpl,
+}: UseVersionCheckOptions = {}): void {
+  const active = enabled ?? !import.meta.env.DEV;
+
+  useEffect(() => {
+    if (!active) return;
+    const current = currentBuildId();
+    // Unstamped bundle (dev server, tests): nothing meaningful to compare.
+    if (!current) return;
+
+    let cancelled = false;
+    let notified = false;
+    let timer: ReturnType<typeof setInterval> | undefined;
+
+    const stop = () => {
+      if (timer !== undefined) {
+        clearInterval(timer);
+        timer = undefined;
+      }
+    };
+    const start = () => {
+      if (timer === undefined) timer = setInterval(check, intervalMs);
+    };
+
+    async function check() {
+      if (cancelled || notified || document.hidden) return;
+      const deployed = await fetchDeployedBuildId(fetchImpl);
+      if (cancelled || notified || !shouldNotifyUpdate(current, deployed)) return;
+      notified = true;
+      stop();
+      toast.info(NEW_VERSION_MESSAGE, {
+        duration: Number.POSITIVE_INFINITY,
+        action: { label: "Reload", onClick: () => window.location.reload() },
+      });
+    }
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stop();
+        return;
+      }
+      start();
+      void check();
+    };
+
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      cancelled = true;
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [active, intervalMs, fetchImpl]);
+}

--- a/apps/ui/src/lib/toast.ts
+++ b/apps/ui/src/lib/toast.ts
@@ -4,10 +4,17 @@
  */
 import { toast as sonnerToast } from "sonner";
 
+export interface ToastOptions {
+  /** Optional inline action button (e.g. "Reload" on the new-version prompt). */
+  action?: { label: string; onClick: () => void };
+  /** Auto-dismiss delay in ms. `Infinity` keeps the toast until dismissed. */
+  duration?: number;
+}
+
 export const toast = {
-  success: (message: string) => sonnerToast.success(message),
-  error: (message: string) => sonnerToast.error(message),
-  info: (message: string) => sonnerToast.info(message),
+  success: (message: string, options?: ToastOptions) => sonnerToast.success(message, options),
+  error: (message: string, options?: ToastOptions) => sonnerToast.error(message, options),
+  info: (message: string, options?: ToastOptions) => sonnerToast.info(message, options),
 };
 
 /** Coerce an unknown thrown value into a human-readable message. */

--- a/apps/ui/src/lib/versionCheck.test.ts
+++ b/apps/ui/src/lib/versionCheck.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  currentBuildId,
+  fetchDeployedBuildId,
+  shouldNotifyUpdate,
+  versionUrl,
+  VERSION_FILE,
+} from "./versionCheck";
+
+function jsonResponse(body: string, init: { ok?: boolean } = {}) {
+  return {
+    ok: init.ok ?? true,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("versionUrl", () => {
+  it("resolves against a root base", () => {
+    expect(versionUrl("/")).toBe(`/${VERSION_FILE}`);
+  });
+
+  it("adds the missing separator for a sub-path base", () => {
+    expect(versionUrl("/app")).toBe(`/app/${VERSION_FILE}`);
+    expect(versionUrl("/app/")).toBe(`/app/${VERSION_FILE}`);
+  });
+});
+
+describe("currentBuildId", () => {
+  it("is empty when the bundle carries no stamp", () => {
+    expect(currentBuildId()).toBe("");
+  });
+
+  it("returns the baked-in stamp", () => {
+    vi.stubEnv("VITE_BUILD_ID", "abc123");
+    expect(currentBuildId()).toBe("abc123");
+  });
+});
+
+describe("shouldNotifyUpdate", () => {
+  it("notifies only when both ids are known and differ", () => {
+    expect(shouldNotifyUpdate("a", "b")).toBe(true);
+  });
+
+  it("stays quiet when the ids match", () => {
+    expect(shouldNotifyUpdate("a", "a")).toBe(false);
+  });
+
+  it("stays quiet when either side is unknown", () => {
+    expect(shouldNotifyUpdate("", "b")).toBe(false);
+    expect(shouldNotifyUpdate("a", null)).toBe(false);
+    expect(shouldNotifyUpdate("", null)).toBe(false);
+  });
+});
+
+describe("fetchDeployedBuildId", () => {
+  it("reads buildId from version.json and bypasses the HTTP cache", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(JSON.stringify({ buildId: "deployed-1" })));
+    await expect(
+      fetchDeployedBuildId(fetchImpl as unknown as typeof fetch, "/version.json")
+    ).resolves.toBe("deployed-1");
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toMatch(/^\/version\.json\?t=\d+$/);
+    expect(init.cache).toBe("no-store");
+  });
+
+  it("returns null on a non-ok response", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse("", { ok: false }));
+    await expect(
+      fetchDeployedBuildId(fetchImpl as unknown as typeof fetch, "/version.json")
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the SPA fallback serves index.html instead", async () => {
+    // Caddy's `try_files {path} /index.html` answers 200 with HTML when the
+    // file is missing — that must read as "unknown", never as "changed".
+    const fetchImpl = vi.fn(async () => jsonResponse("<!doctype html><html></html>"));
+    await expect(
+      fetchDeployedBuildId(fetchImpl as unknown as typeof fetch, "/version.json")
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when buildId is missing or not a string", async () => {
+    const missing = vi.fn(async () => jsonResponse(JSON.stringify({})));
+    const wrongType = vi.fn(async () => jsonResponse(JSON.stringify({ buildId: 7 })));
+    await expect(
+      fetchDeployedBuildId(missing as unknown as typeof fetch, "/version.json")
+    ).resolves.toBeNull();
+    await expect(
+      fetchDeployedBuildId(wrongType as unknown as typeof fetch, "/version.json")
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when the network throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    await expect(
+      fetchDeployedBuildId(fetchImpl as unknown as typeof fetch, "/version.json")
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/ui/src/lib/versionCheck.ts
+++ b/apps/ui/src/lib/versionCheck.ts
@@ -1,0 +1,73 @@
+/**
+ * Build-version detection for the deployed SPA.
+ *
+ * The UI ships as static hashed assets behind a bare Caddy `file_server`
+ * (`try_files {path} /index.html`). `index.html` revalidates via Etag, but a
+ * tab that is already open never re-fetches it, so after a redeploy that tab
+ * keeps running the OLD hashed bundle until someone hard-refreshes. That has
+ * already burned real debugging time (a stale bundle read as a render-perf
+ * regression), so the app asks the server what it is currently serving.
+ *
+ * The mechanism is deliberately dumb: `vite.config.ts` stamps every build with
+ * a `buildId`, bakes it into the bundle (`import.meta.env.VITE_BUILD_ID`) and
+ * writes the same value to `dist/version.json`. Polling that file with
+ * `cache: "no-store"` returns whatever is on disk right now — no server-side
+ * support, no cache headers to configure, nothing Caddy has to know about.
+ *
+ * This module is pure/side-effect free; `useVersionCheck` owns the scheduling.
+ */
+
+/** Static file emitted alongside the hashed assets by the build-stamp plugin. */
+export const VERSION_FILE = "version.json";
+
+/** 5 minutes: often enough to catch a deploy, rare enough to be invisible. */
+export const VERSION_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+export const NEW_VERSION_MESSAGE = "A new version of Moveet is available";
+
+/** The build id baked into the bundle currently executing. */
+export function currentBuildId(): string {
+  const id: unknown = import.meta.env.VITE_BUILD_ID;
+  return typeof id === "string" ? id : "";
+}
+
+/** Resolve `version.json` against the app's base path (usually `/`). */
+export function versionUrl(base: string = import.meta.env.BASE_URL || "/"): string {
+  return `${base.endsWith("/") ? base : `${base}/`}${VERSION_FILE}`;
+}
+
+/**
+ * Read the build id the server is currently handing out.
+ *
+ * Returns `null` for every failure mode — offline, 404, or the SPA fallback
+ * answering with `index.html` at 200 (HTML fails to parse as JSON). "Unknown"
+ * must never be mistaken for "changed", so the caller stays silent on `null`.
+ */
+export async function fetchDeployedBuildId(
+  fetchImpl: typeof fetch = globalThis.fetch,
+  url: string = versionUrl()
+): Promise<string | null> {
+  try {
+    const res = await fetchImpl(`${url}?t=${Date.now()}`, {
+      cache: "no-store",
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const parsed: unknown = JSON.parse(await res.text());
+    if (!parsed || typeof parsed !== "object") return null;
+    const id = (parsed as { buildId?: unknown }).buildId;
+    return typeof id === "string" && id ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the running bundle is stale. Both ids must be known: an unstamped
+ * build (dev, or a test bundle) and an unreadable `version.json` both mean
+ * "cannot tell", which is not the same as "out of date".
+ */
+export function shouldNotifyUpdate(current: string, deployed: string | null): boolean {
+  if (!current || !deployed) return false;
+  return current !== deployed;
+}

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,11 +1,45 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+/**
+ * Identity of this build. Baked into the bundle (`import.meta.env.VITE_BUILD_ID`)
+ * AND written to `dist/version.json`, so a long-open tab can compare the code it
+ * is running against the code the server is currently handing out. CI can pin it
+ * (BUILD_ID=<git sha>); otherwise a build timestamp is enough — every rebuild
+ * produces a different value, which is the only property the check needs.
+ */
+const buildId = process.env.BUILD_ID || `${Date.now().toString(36)}`;
+
+/**
+ * Emits `version.json` next to the hashed assets. It is a plain static file, so
+ * the bare Caddy `file_server` in the `ui` Docker target serves it with no
+ * server-side support; the client fetches it with `cache: "no-store"` to bypass
+ * the HTTP cache. Note Caddy's `try_files {path} /index.html` means a missing
+ * version.json answers with index.html at 200 — the client treats unparseable
+ * responses as "unknown" and stays quiet.
+ */
+function buildStampPlugin(): Plugin {
+  return {
+    name: "moveet:build-stamp",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: `${JSON.stringify({ buildId })}\n`,
+      });
+    },
+  };
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), buildStampPlugin()],
+  define: {
+    "import.meta.env.VITE_BUILD_ID": JSON.stringify(buildId),
+  },
   server: {
     port: 5012,
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,11 @@ services:
     build:
       context: .
       target: ui
+      args:
+        # Stamps the build so an open tab can tell it is running an old bundle.
+        # Defaults to a build timestamp, which makes every rebuild look new;
+        # export BUILD_ID=$(git rev-parse --short HEAD) to tie it to the code.
+        BUILD_ID: ${BUILD_ID:-}
     ports:
       - "5012:8080"
 


### PR DESCRIPTION
Six independently-scoped improvements, plus two defects found while working on them. Nothing here depends on anything else here, so this can be split if you would rather review it in pieces.

## ⚠️ Breaking change

**Malformed adapter plugin configuration now refuses to start the service.**

Fail-soft on an *unreachable backend* is unchanged and deliberate — that distinction is the point of the change. What was wrong is that a typo'd plugin type or a missing required field produced a silently skipped plugin, so a misconfigured stack booted looking healthy and emitted nothing.

Unknown configuration keys remain warnings only, so an undocumented key cannot break a working deployment. The validator was run against this repo's own `docker-compose.yml`, `docker-compose.ghcr.yml` and all four `.env.example` recipes before landing: all valid, zero warnings.

Under the repo's release-please settings (`bump-minor-pre-major`), this releases as **0.1.0** rather than 0.0.11.

## Changes

### ui — stale-bundle detection and reload prompt

The dashboard is a static SPA served by a bare file server. `index.html` revalidates via Etag, but a long-open tab never re-fetches it, so after a redeploy the tab keeps running the previous hashed bundle indefinitely with no signal. This has already cost real debugging time once, presenting as a rendering problem.

The build is now stamped and the same id written to `dist/version.json`, which the tab polls with `cache: "no-store"` and compares against the id baked into its own bundle. On a mismatch it offers a reload once, then stops polling. A static file was chosen over scraping `index.html` for hashed asset names because `try_files {path} /index.html` only rewrites paths that do not exist, so a real file is never shadowed.

Every failure mode — non-2xx, network error, missing field, and the SPA fallback answering 200 with HTML that fails `JSON.parse` — resolves to "unknown" rather than "changed", so it cannot false-positive. Disabled in dev, paused while the tab is hidden.

`BUILD_ID` is plumbed through the `Dockerfile`, `docker-compose.yml` and the release workflow. Its default is a build timestamp, so without this every rebuild — including a no-op one — would prompt every open tab.

### ui — first-run start affordance

The simulator boots paused, so a first load shows a static map with no obvious next step and the start control sitting among other dock controls. The hint latches off after the first run, so pausing later does not resurrect it, and it only appears once connected, so it never offers a start that would fail against an unreachable simulator.

### ui — label outlines were never rendering

deck.gl silently ignores `outlineWidth` and `outlineColor` unless the font atlas is SDF, and logs `fontSettings.sdf is required to render outline`.

Enabling `sdf: true` alone would not have fixed it. Under SDF the halo is `0.75 × outlineWidth` in *font-atlas* pixels (the atlas renders at 64px), then scaled by `getSize / 64` — so the existing `outlineWidth: 2-3` worked out to well under one screen pixel. `fontSettings.radius` must also be at least `outlineWidth` or deck.gl clamps, and `buffer` must cover the halo or the atlas padding clips it.

Geofence labels were the reported case; road and POI labels had the identical defect. All three are fixed. A source guard test now fails if any map layer requests an outline without a correctly-sized SDF atlas — verified by mutation, not just by passing.

### simulator — time-of-day heat zones

Heat-zone intensity can now follow the simulated clock, so zones bloom at rush hour and fade overnight. Opt-in via `HEATZONE_TIME_SCALING`, default off, so existing deployments are unchanged.

It reuses the demand curve the traffic model already applies rather than introducing a second one that could drift from it. Sampling the arterial road class matters here: the profile's rush-hour ranges only apply to trunk and primary roads, so sampling a residential class would have flattened rush hour to 1.0× and made the feature silently do nothing.

Intensity always derives from a stored base value, never the current one, so rescales are idempotent and hour transitions do not compound. Operator-drawn zones are left alone — someone who drew a zone at a given intensity asserted something, and there is no affordance distinguishing that from a generated value. An explicit intensity edit promotes a generated zone to manual, so an operator dialling one down is not overwritten at the next hour boundary.

Recomputes once per simulated hour and broadcasts only when a value actually moves, so an hour boundary inside the same demand range costs nothing on the wire.

### simulator — coverage gate raised

The gate was 50% against measured coverage in the low 90s. Raised to 92 lines / 91 statements / 92 functions / 79 branches, with margin under each measured value. Branches gets a wider margin because the config already documents local-versus-CI branch-accounting drift.

### adapter — configuration file and dry-run validation

Plugin configuration was JSON strings inside environment variables, which combined badly with intentional fail-soft startup: a typo produced a skipped plugin and a stack that looked healthy.

Configuration can now come from a file via `ADAPTER_CONFIG_FILE`, with environment variables overriding it (the file is the readable base, env is the per-deployment override). Both forms resolve into the same structure and pass through the same validator, so there is one validation path rather than two.

`POST /config/validate` dry-runs a configuration and reports what it *would* activate with a per-plugin reason for anything malformed. It mutates nothing and connects to nothing; reachability stays the job of `GET /health`. With no body it re-resolves from scratch, so a file can be edited and re-checked without a restart.

## Known limitation

Heat-zone intensity does not affect vehicle speed. A flat speed factor applies to any in-zone position regardless of intensity, so a vehicle crossing a high-intensity zone at rush hour is slowed exactly as much as one crossing the same zone faded overnight. Time-varying zones are therefore currently visual.

That matches what was asked for, and making the penalty intensity-proportional is a physics change that would shift vehicle behaviour across the whole test suite and needs to be reconciled with the existing congestion model rather than stacked on top of it. Tracked as a follow-up rather than smuggled in here.

Separately, `coverage.all` is off, so the reported 93-95% describes tested-and-imported files only — entry points and wiring are absent from the report. The gate is self-consistent because CI uses the same config, but enabling it is a real decision needing its own re-tuning pass.

## Verification

Full monorepo, after combining every change:

- `npm test` — **3384 tests across 226 files, all passing** (simulator 1685/80, ui 934/83, adapter 636/49, network 59/9, server-kit 41/4, shared-types 29/1)
- `npm run type-check` — 6/6 packages
- `npm run build` — 4/4 packages
- `npm run test:repo` — 12/12
- simulator coverage — 93.72 statements / 82.47 branches / 94.49 functions / 94.89 lines, clearing the new gate with margin
- `npx biome lint .` — 598 files, 56 warnings / 38 infos, identical to `main`; no new findings
- `BUILD_ID=<value> npm run build` — emits the value in `dist/version.json` and in the entry chunk

Labelled `e2e` so the docker-compose smoke job runs against the modified `Dockerfile`.

## Note on one reported issue

An issue in this batch described a panel-switching race in a nav-rail and drawer architecture. That architecture was removed by the dock redesign already on `main`, so there was no code left to fix. The regression test ships anyway, validated by reintroducing the bug's shape and confirming it fails, so the race cannot return with a future panel refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
