### PR TITLE
feat(simulator): device-level fault injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A real-time vehicle fleet simulator that runs vehicles on actual road networks w
 | 🚘 **Breadcrumb trails**     | Per-vehicle position history rendered as fading path overlays on the map                                                                                                                                                      |
 | 🚦 **Fleet management**      | Group vehicles into named, colour-coded fleets; assign/unassign at runtime                                                                                                                                                    |
 | 📦 **Job dispatch lifecycle** | Pickup/dropoff jobs assigned by nearest / best-ETA / named vehicle, driven through the full status lifecycle with per-leg ETAs and SLA-breach tracking; placed with two map clicks                                            |
+| 🔌 **Device fault injection** | Per-vehicle device faults injected in the simulator — frozen GPS, clock skew/drift, duplicate and out-of-order messages, battery death, teleport/spoofing — reproducible under a fixed seed, editable at runtime, visible on the WebSocket feed and the adapter push            |
 | 🔍 **POI + road search**     | Typeahead combining road names and points of interest; dispatches selected vehicles to result                                                                                                                                 |
 | 🖥 **Operator UI**           | Icon-rail sidebar (Vehicles · Fleets · Incidents · Geofences · Recordings · Visibility · Speed · Adapter) + bottom dock with live and replay controls                                                                         |
 | 🔌 **Adapter plugins**       | Hot-swappable source and sink plugins; configure via env vars or REST API at runtime                                                                                                                                          |
@@ -242,6 +243,23 @@ SLA breach along the way.
 | `POST`   | `/jobs/:id/cancel`   | Cancel a live job and release its vehicle         |
 | `DELETE` | `/jobs/:id`          | Remove a finished job from the board              |
 
+### Device faults
+
+Faults injected as properties of the simulated **device** (frozen GPS, clock skew,
+duplicate and out-of-order messages, battery death, teleport/spoofing), as opposed
+to the adapter's realism engine, which degrades the **transport**. Off by default;
+reproducible under a fixed seed. See `apps/simulator/README.md` for the profile
+shape and per-fault semantics.
+
+| Method   | Path                     | Description                                        |
+| -------- | ------------------------ | -------------------------------------------------- |
+| `GET`    | `/faults`                | Configuration plus a live device-state snapshot     |
+| `POST`   | `/faults`                | Update the configuration at runtime                 |
+| `GET`    | `/faults/status`         | Live per-device state and trigger counts            |
+| `POST`   | `/faults/reset`          | Clear latched device state, keeping the config      |
+| `PUT`    | `/faults/vehicles/:id`   | Set one vehicle's fault profile                     |
+| `DELETE` | `/faults/vehicles/:id`   | Remove one vehicle's fault profile                  |
+
 ### Incidents
 
 | Method   | Path                | Description                             |
@@ -311,6 +329,7 @@ Connect to `ws://localhost:5010`. On connect the server sends a `status` and `op
 | `incident:cleared` | server → client | Incident resolved                                         |
 | `vehicle:rerouted` | server → client | Vehicle rerouted around incident                          |
 | `geofence:event`   | server → client | Vehicle entered or exited a geofence zone                 |
+| `faults:config`    | server → client | Device fault-injection configuration changed              |
 
 ---
 

--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -98,3 +98,22 @@ MAX_SYNC_BACKOFF_MS=60000
 # Size (N x N) of the coarse sector grid used for geographically-uniform random
 # spawn/destination/POI selection
 SECTORS_N=10
+
+# Device-level fault injection
+# Faults are properties of the simulated DEVICE (frozen GPS, skewed clock,
+# duplicate/out-of-order messages, dead battery, teleport/spoofing), injected
+# before telemetry leaves the simulator. Distinct from the adapter's realism
+# engine, which models the transport; the two compose.
+# Off by default: with this false, or with no profile configured, the telemetry
+# is byte-for-byte what it was.
+FAULTS_ENABLED=false
+# Seed for the per-device RNG streams. Every fault type is reproducible only
+# when this is set; leave empty for Math.random.
+FAULT_SEED=
+# Fault profiles as JSON: {"default":{...},"vehicles":{"<vehicleId>":{...}}}
+# A malformed value aborts startup rather than silently arming nothing. Example:
+# {"default":{"frozenGps":{"probability":0.02,"minDurationMs":5000,"maxDurationMs":30000},
+#             "clockSkew":{"offsetMs":1500,"driftMsPerMinute":10}},
+#  "vehicles":{"vehicle-7":{"battery":{"initialPercent":40,"drainPercentPerHour":30,"dieAtPercent":5}}}}
+# Runtime-editable via POST /faults and PUT /faults/vehicles/:id.
+FAULT_PROFILES=

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -12,6 +12,7 @@ Vehicle location simulator for fleet management systems. Simulates multiple vehi
 - **Geofences**: enter/exit detection with events
 - **Fleets**: fleet definitions and vehicle assignment
 - **Jobs**: pickup/dropoff work orders with vehicle assignment (nearest / best-ETA / manual), a full status lifecycle driven by the vehicle's own routing events, per-leg ETAs, and SLA-breach tracking
+- **Device Fault Injection**: per-vehicle device faults — frozen GPS, clock skew/drift, duplicate and out-of-order messages, battery death, teleport/spoofing — reproducible under a fixed seed and configurable at runtime
 - **Recording & Replay**: capture a live run to NDJSON and replay it
 - **Headless Generation**: deterministic fast-forward generation of recordings
 - **Analytics**: per-tick fleet/vehicle stats, broadcast and persisted as a time-series
@@ -83,6 +84,9 @@ All config is parsed and validated through a single zod schema in `src/utils/con
 | `REDIS_URL`                   | Redis connection URL; **required when `WS_TRANSPORT=redis`** (and by the gateway)        | (empty)                |
 | `WS_PUBSUB_CHANNEL`           | Redis pub/sub channel the simulator publishes to and the gateway subscribes to           | moveet:ws:broadcast    |
 | `WS_GATEWAY_PORT`             | Port the standalone WS gateway listens on                                                | 5020                   |
+| `FAULTS_ENABLED`              | Enable device-level fault injection                                                      | false                  |
+| `FAULT_SEED`                  | Seed for the per-device fault RNG streams; empty = unseeded (`Math.random`)               | (empty)                |
+| `FAULT_PROFILES`              | Fault profiles as JSON: `{"default":{...},"vehicles":{"<id>":{...}}}`                     | (empty)                |
 
 > Note: there is no `USE_ADAPTER` or `SYNC_ADAPTER` flag. The adapter is enabled simply by setting `ADAPTER_URL`.
 
@@ -220,6 +224,90 @@ Get current simulation options.
 
 Update simulation options.
 
+### Device Fault Injection
+
+Faults are properties of the simulated **device** — a GPS tracker whose fix freezes, whose
+clock is wrong, that retransmits, that reorders, that teleports, that runs out of battery.
+That is a different concern from the adapter's realism engine, which models the **transport**
+(correlated GPS noise, connectivity dropouts, jittered cadence). The two compose: a device
+fault is injected before the telemetry ever leaves the simulator, so it is visible on the
+WebSocket feed *and* in the adapter push.
+
+Off by default. With `FAULTS_ENABLED=false`, or with no profile configured, the telemetry is
+byte-for-byte what it was — no `timestamp` or `faults` fields appear on the wire.
+
+| Fault           | What the device does                                                          |
+| --------------- | ----------------------------------------------------------------------------- |
+| `frozen_gps`    | Latches its last fix and replays it for a window while the vehicle moves on    |
+| `clock_skew`    | Stamps fixes with a wrong (and optionally drifting) clock                      |
+| `duplicate`     | Retransmits a sample it already sent, timestamp and all                        |
+| `out_of_order`  | Withholds a sample so a newer one overtakes it on the wire                     |
+| `battery_dead`  | Drains a battery and goes completely silent when it dies                       |
+| `teleport`      | Reports a position it cannot be at, as a glitch or a sustained spoofing window |
+
+Each fault is reproducible under a fixed `FAULT_SEED`: every device draws from its **own**
+`mulberry32` stream seeded from `(seed, vehicleId)`, so a fault sequence does not depend on
+how many other vehicles exist or in what order they tick.
+
+**Where the faults show up**
+
+- `update` WebSocket frames and recordings carry the device's sample, not the truth. One
+  report can become several frames (a duplicate, or a withheld sample released behind a
+  newer one) or none at all (dead battery). Note the broadcaster coalesces to the latest
+  frame per vehicle per 100 ms flush, so duplicates and reordering are best observed on the
+  adapter push.
+- `GET /vehicles` serves each device's currently-reported fix, so a frozen or dead device
+  does not appear to un-freeze whenever something polls it.
+- The adapter push (`POST /sync`) carries the device samples **in emission order**, with
+  duplicates and reordering intact, each with its own device `timestamp` and the applied
+  faults under `metadata.faults`. This is the fidelity path for a downstream consumer
+  testing against the stream.
+
+#### `GET /faults`
+
+Current configuration plus a live status snapshot.
+
+#### `POST /faults`
+
+Update the configuration at runtime. Every field is optional, so `enabled` can be flipped
+without restating the profiles; `default: null` clears the fleet-wide profile. Toggling
+`enabled` or changing `seed` discards all per-device state, so a reseeded run starts from a
+clean device.
+
+```bash
+curl -XPOST localhost:5010/faults -H 'content-type: application/json' -d '{
+  "enabled": true,
+  "seed": 1337,
+  "default": {
+    "frozenGps": { "probability": 0.02, "minDurationMs": 5000, "maxDurationMs": 30000 },
+    "clockSkew": { "offsetMs": 1500, "driftMsPerMinute": 10 }
+  }
+}'
+```
+
+#### `PUT /faults/vehicles/:id` · `DELETE /faults/vehicles/:id`
+
+Set or remove one vehicle's profile. A per-vehicle profile **replaces** the fleet-wide
+default for that vehicle rather than merging with it.
+
+```bash
+curl -XPUT localhost:5010/faults/vehicles/vehicle-7 -H 'content-type: application/json' -d '{
+  "battery": { "initialPercent": 40, "drainPercentPerHour": 30, "dieAtPercent": 5 },
+  "teleport": { "probability": 0.01, "radiusMeters": 2000, "holdMs": 10000 }
+}'
+```
+
+#### `GET /faults/status` · `POST /faults/reset`
+
+Live per-device state (frozen/teleporting/dead counts, withheld samples, queue depth,
+cumulative trigger counts), and a reset that clears that state while keeping the
+configuration — how a repeatable run is started over from a known device state.
+
+Profile bodies go through the same zod schemas that validate `FAULT_PROFILES` at startup,
+and unknown keys are **rejected**: a mistyped fault name would otherwise leave an operator
+believing a fault was armed when it was not. A malformed `FAULT_PROFILES` aborts startup for
+the same reason.
+
 ### Observability
 
 #### `GET /metrics`
@@ -238,9 +326,9 @@ continuous across the simulator → adapter hop.
 
 Connect to `ws://localhost:5010` for real-time updates.
 
-**Message Types** (non-exhaustive): `vehicle`/`vehicles`, `status`, `clock`, `options`, `heatzones`, `direction`, `traffic`, `analytics`, `waypoint:reached`, `route:completed`, `vehicle:rerouted`, `incident:created`, `incident:cleared`, `geofence:event`, `fleet:created`/`fleet:deleted`/`fleet:assigned`, `scenario:*`, `replay:status`, `generate:progress`/`generate:complete`/`generate:error`, `reset`.
+**Message Types** (non-exhaustive): `vehicle`/`vehicles`, `status`, `clock`, `options`, `heatzones`, `direction`, `traffic`, `analytics`, `waypoint:reached`, `route:completed`, `vehicle:rerouted`, `incident:created`, `incident:cleared`, `geofence:event`, `fleet:created`/`fleet:deleted`/`fleet:assigned`, `scenario:*`, `replay:status`, `generate:progress`/`generate:complete`/`generate:error`, `faults:config`, `reset`.
 
-Beyond the endpoints shown above, the API also exposes incidents (`/incidents`), geofences (`/geofences`), fleets (`/fleets`), jobs (`/jobs`), analytics (`/analytics/*`), traffic (`/traffic`, `/traffic-profile`), clock (`/clock`), speed limits (`/speed-limits`), recording, replay (`/replay/status`), scenarios, and state persistence (`/state/save`, `/state/restore`, `/state/snapshots`). See the OpenAPI/Scalar reference served by the app for the full set.
+Beyond the endpoints shown above, the API also exposes incidents (`/incidents`), geofences (`/geofences`), fleets (`/fleets`), jobs (`/jobs`), device faults (`/faults`), analytics (`/analytics/*`), traffic (`/traffic`, `/traffic-profile`), clock (`/clock`), speed limits (`/speed-limits`), recording, replay (`/replay/status`), scenarios, and state persistence (`/state/save`, `/state/restore`, `/state/snapshots`). See the OpenAPI/Scalar reference served by the app for the full set.
 
 ## Docker Usage
 

--- a/apps/simulator/openapi.yaml
+++ b/apps/simulator/openapi.yaml
@@ -36,6 +36,8 @@ tags:
     description: Fleet grouping and vehicle assignment
   - name: Jobs
     description: Trip/job dispatch lifecycle — create, assign, cancel, and track jobs
+  - name: Faults
+    description: Device-level fault injection — per-vehicle fault profiles and live device state
   - name: Analytics
     description: Fleet and vehicle performance analytics
   - name: Geofences
@@ -1626,6 +1628,160 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  # ─── Device Fault Injection ─────────────────────────────────────────
+  /faults:
+    get:
+      operationId: getFaults
+      summary: Get the device fault-injection configuration and live device state
+      description: >
+        Faults are properties of the simulated DEVICE (frozen GPS, skewed clock,
+        duplicate and out-of-order messages, dead battery, teleport/spoofing),
+        injected before telemetry leaves the simulator. This is distinct from the
+        adapter's realism engine, which models the transport; the two compose.
+      tags: [Faults]
+      responses:
+        "200":
+          description: Configuration plus a live status snapshot
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/DeviceFaultConfig"
+                  - type: object
+                    properties:
+                      status:
+                        $ref: "#/components/schemas/DeviceFaultStatus"
+    post:
+      operationId: configureFaults
+      summary: Update the fault-injection configuration at runtime
+      description: >
+        Every field is optional, so `enabled` can be flipped without restating
+        the profiles. `default: null` clears the fleet-wide profile. Toggling
+        `enabled` or changing `seed` discards all per-device state, so a reseeded
+        run starts from a clean device.
+      tags: [Faults]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                seed:
+                  type: integer
+                  description: Seed for the per-device RNG streams; required for reproducibility
+                default:
+                  nullable: true
+                  allOf:
+                    - $ref: "#/components/schemas/DeviceFaultProfile"
+                vehicles:
+                  type: object
+                  additionalProperties:
+                    $ref: "#/components/schemas/DeviceFaultProfile"
+      responses:
+        "200":
+          description: Resolved configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceFaultConfig"
+        "400":
+          description: Validation failed (unknown key, or a value out of range)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /faults/status:
+    get:
+      operationId: getFaultStatus
+      summary: Live per-device fault state
+      tags: [Faults]
+      responses:
+        "200":
+          description: Device counts, queue depth, and cumulative trigger counts
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceFaultStatus"
+
+  /faults/reset:
+    post:
+      operationId: resetFaults
+      summary: Clear latched device state, keeping the configuration
+      description: >
+        Discards drained batteries, open frozen windows, withheld samples,
+        queued telemetry and the trigger counters. Used to start a repeatable
+        run over from a known device state.
+      tags: [Faults]
+      responses:
+        "200":
+          description: Status after the reset
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceFaultStatus"
+
+  /faults/vehicles/{id}:
+    put:
+      operationId: setVehicleFaultProfile
+      summary: Set one vehicle's fault profile
+      description: >
+        A per-vehicle profile replaces the fleet-wide default outright for that
+        vehicle; it is not merged with it. The vehicle's latched device state is
+        dropped so the new profile starts from a clean device.
+      tags: [Faults]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeviceFaultProfile"
+      responses:
+        "200":
+          description: Resolved configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceFaultConfig"
+        "400":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    delete:
+      operationId: clearVehicleFaultProfile
+      summary: Remove one vehicle's fault profile
+      tags: [Faults]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Resolved configuration after removal
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeviceFaultConfig"
+        "404":
+          description: The vehicle had no fault profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   # ─── State Persistence ──────────────────────────────────────────────
   /state/save:
     post:
@@ -3177,3 +3333,151 @@ components:
                 type: number
               type:
                 type: string
+
+    # ─── Device Fault Injection ──────────────────────────────────────
+    DeviceFaultKind:
+      type: string
+      enum: [frozen_gps, clock_skew, duplicate, out_of_order, battery_dead, teleport]
+
+    DeviceFaultProfile:
+      type: object
+      description: >
+        Per-fault tuning for one simulated device. Every group is opt-in; an
+        omitted group means that fault is not armed. Unknown keys are rejected,
+        so a typo cannot silently arm nothing.
+      additionalProperties: false
+      properties:
+        frozenGps:
+          type: object
+          description: The device latches its last fix and keeps reporting it
+          additionalProperties: false
+          required: [probability, minDurationMs, maxDurationMs]
+          properties:
+            probability:
+              type: number
+              minimum: 0
+              maximum: 1
+              description: Chance per report of entering a frozen window
+            minDurationMs:
+              type: integer
+              minimum: 0
+            maxDurationMs:
+              type: integer
+              minimum: 0
+        clockSkew:
+          type: object
+          description: The device stamps its fixes with the wrong time
+          additionalProperties: false
+          required: [offsetMs]
+          properties:
+            offsetMs:
+              type: integer
+            driftMsPerMinute:
+              type: number
+              description: Extra skew accumulated per minute of device uptime
+        duplicate:
+          type: object
+          description: The device retransmits a sample it already sent
+          additionalProperties: false
+          required: [probability, maxCopies]
+          properties:
+            probability:
+              type: number
+              minimum: 0
+              maximum: 1
+            maxCopies:
+              type: integer
+              minimum: 1
+              maximum: 10
+              description: Maximum extra copies emitted alongside the original
+        outOfOrder:
+          type: object
+          description: The device withholds a sample so a newer one overtakes it
+          additionalProperties: false
+          required: [probability, holdMs]
+          properties:
+            probability:
+              type: number
+              minimum: 0
+              maximum: 1
+            holdMs:
+              type: integer
+              minimum: 0
+        battery:
+          type: object
+          description: The device runs on a battery and goes silent when it dies
+          additionalProperties: false
+          required: [initialPercent, drainPercentPerHour, dieAtPercent]
+          properties:
+            initialPercent:
+              type: number
+              minimum: 0
+              maximum: 100
+            drainPercentPerHour:
+              type: number
+              minimum: 0
+            dieAtPercent:
+              type: number
+              minimum: 0
+              maximum: 100
+        teleport:
+          type: object
+          description: The reported position jumps somewhere it cannot be
+          additionalProperties: false
+          required: [probability, radiusMeters, holdMs]
+          properties:
+            probability:
+              type: number
+              minimum: 0
+              maximum: 1
+            radiusMeters:
+              type: number
+              minimum: 0
+            holdMs:
+              type: integer
+              minimum: 0
+              description: How long the bogus offset persists; 0 = single-sample glitch
+
+    DeviceFaultConfig:
+      type: object
+      required: [enabled, vehicles]
+      properties:
+        enabled:
+          type: boolean
+        seed:
+          type: integer
+          description: Omitted means unseeded (Math.random) — nothing is reproducible
+        default:
+          $ref: "#/components/schemas/DeviceFaultProfile"
+        vehicles:
+          type: object
+          description: Per-vehicle overrides keyed by vehicle id
+          additionalProperties:
+            $ref: "#/components/schemas/DeviceFaultProfile"
+
+    DeviceFaultStatus:
+      type: object
+      required: [enabled, devices, frozen, teleporting, dead, held, queued, counts]
+      properties:
+        enabled:
+          type: boolean
+        devices:
+          type: integer
+          description: Devices the fault layer currently holds state for
+        frozen:
+          type: integer
+        teleporting:
+          type: integer
+        dead:
+          type: integer
+        held:
+          type: integer
+          description: Samples withheld by the out-of-order fault, awaiting release
+        queued:
+          type: integer
+          description: Faulted samples queued for the next adapter push
+        counts:
+          type: object
+          description: Cumulative per-kind trigger counts since the last reset
+          additionalProperties:
+            type: integer

--- a/apps/simulator/src/__tests__/deviceFaultEgress.test.ts
+++ b/apps/simulator/src/__tests__/deviceFaultEgress.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "path";
+import { VehicleManager } from "../modules/VehicleManager";
+import { FleetManager } from "../modules/FleetManager";
+import { RoadNetwork } from "../modules/RoadNetwork";
+import { AdapterSyncManager } from "../modules/AdapterSyncManager";
+import { config } from "../utils/config";
+import type { Vehicle, VehicleDTO } from "../types";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
+
+/**
+ * Device faults must be observable in the OUTGOING telemetry, not just inside
+ * the fault module. These tests cover the two egress paths: the `update` event
+ * (WebSocket + recording) and the periodic adapter push.
+ */
+
+describe("device fault egress — vehicle update stream", () => {
+  let network: RoadNetwork;
+  let manager: VehicleManager;
+  let origVehicleCount: number;
+  let origAdapterURL: string;
+
+  beforeEach(() => {
+    origVehicleCount = config.vehicleCount;
+    origAdapterURL = config.adapterURL;
+    (config as any).vehicleCount = 2;
+    (config as any).adapterURL = "";
+
+    network = new RoadNetwork(FIXTURE_PATH);
+
+    // Skip pathfinding during init — the tiny fixture network cannot route.
+    const proto = VehicleManager.prototype as any;
+    const origSetRandom = proto.setRandomDestination;
+    proto.setRandomDestination = function () {};
+    manager = new VehicleManager(network, new FleetManager());
+    proto.setRandomDestination = origSetRandom;
+  });
+
+  afterEach(() => {
+    (config as any).vehicleCount = origVehicleCount;
+    (config as any).adapterURL = origAdapterURL;
+    for (const v of manager.getVehicles()) manager.stopVehicleMovement(v.id);
+    manager.stopLocationUpdates();
+  });
+
+  function firstVehicle(): Vehicle {
+    return manager.registry.getAll().values().next().value as Vehicle;
+  }
+
+  function dtoFor(vehicle: Vehicle): VehicleDTO {
+    return {
+      id: vehicle.id,
+      name: vehicle.name,
+      type: vehicle.type,
+      position: vehicle.position,
+      speed: vehicle.speed,
+      heading: vehicle.bearing,
+    };
+  }
+
+  it("forwards the game-loop DTO untouched while no fault is armed", () => {
+    const updates: VehicleDTO[] = [];
+    manager.on("update", (dto: VehicleDTO) => updates.push(dto));
+    const input = dtoFor(firstVehicle());
+
+    manager.gameLoop.emit("update", input);
+
+    expect(updates).toEqual([input]);
+    expect(updates[0]!.timestamp).toBeUndefined();
+    expect(updates[0]!.faults).toBeUndefined();
+  });
+
+  it("emits the device's faulted sample once a profile is armed", () => {
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      default: { clockSkew: { offsetMs: 4000 } },
+    });
+    const updates: VehicleDTO[] = [];
+    manager.on("update", (dto: VehicleDTO) => updates.push(dto));
+
+    manager.gameLoop.emit("update", dtoFor(firstVehicle()));
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.faults).toMatchObject({ active: ["clock_skew"], skewMs: 4000 });
+    expect(updates[0]!.timestamp).toBeGreaterThan(0);
+  });
+
+  it("fans one report out to several frames when the device duplicates", () => {
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      default: { duplicate: { probability: 1, maxCopies: 1 } },
+    });
+    const updates: VehicleDTO[] = [];
+    manager.on("update", (dto: VehicleDTO) => updates.push(dto));
+
+    manager.gameLoop.emit("update", dtoFor(firstVehicle()));
+
+    expect(updates).toHaveLength(2);
+    expect(updates[1]!.faults?.active).toContain("duplicate");
+  });
+
+  it("emits no frame at all for a device whose battery has died", () => {
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      default: { battery: { initialPercent: 0, drainPercentPerHour: 1, dieAtPercent: 0 } },
+    });
+    const updates: VehicleDTO[] = [];
+    manager.on("update", (dto: VehicleDTO) => updates.push(dto));
+
+    manager.gameLoop.emit("update", dtoFor(firstVehicle()));
+
+    expect(updates).toEqual([]);
+    expect(manager.faults.getStatus().dead).toBe(1);
+  });
+
+  it("serves the device's frozen fix from GET /vehicles, not the true position", () => {
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      default: { frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 } },
+    });
+    const vehicle = firstVehicle();
+    manager.gameLoop.emit("update", dtoFor(vehicle));
+    const frozenAt: [number, number] = [...vehicle.position] as [number, number];
+
+    // The vehicle moves on, but its device is stuck.
+    vehicle.position = [frozenAt[0] + 0.02, frozenAt[1] + 0.02];
+
+    const listed = manager.getVehicles().find((v) => v.id === vehicle.id)!;
+    expect(listed.position).toEqual(frozenAt);
+    expect(listed.faults?.active).toContain("frozen_gps");
+  });
+
+  it("keeps reporting the frozen fix on an out-of-band fleet-assignment frame", () => {
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      default: { frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 } },
+    });
+    const vehicle = firstVehicle();
+    manager.gameLoop.emit("update", dtoFor(vehicle));
+    const frozenAt: [number, number] = [...vehicle.position] as [number, number];
+    vehicle.position = [frozenAt[0] + 0.02, frozenAt[1] + 0.02];
+
+    const fleet = manager.fleets.createFleet("F1");
+    const updates: VehicleDTO[] = [];
+    manager.on("update", (dto: VehicleDTO) => updates.push(dto));
+
+    expect(manager.assignVehicleToFleet(vehicle.id, fleet.id)).toBe(true);
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.position).toEqual(frozenAt);
+  });
+
+  it("clears latched device state on simulation reset, keeping the config", async () => {
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      default: { frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 } },
+    });
+    manager.gameLoop.emit("update", dtoFor(firstVehicle()));
+    expect(manager.faults.getStatus().devices).toBe(1);
+
+    const proto = VehicleManager.prototype as any;
+    const origSetRandom = proto.setRandomDestination;
+    proto.setRandomDestination = function () {};
+    try {
+      await manager.reset();
+    } finally {
+      proto.setRandomDestination = origSetRandom;
+    }
+
+    expect(manager.faults.getStatus().devices).toBe(0);
+    expect(manager.faults.isActive()).toBe(true);
+  });
+});
+
+describe("device fault egress — adapter push", () => {
+  let syncManager: AdapterSyncManager;
+  let origAdapterURL: string;
+
+  beforeEach(() => {
+    origAdapterURL = config.adapterURL;
+    (config as any).adapterURL = "";
+    syncManager = new AdapterSyncManager();
+  });
+
+  afterEach(() => {
+    (config as any).adapterURL = origAdapterURL;
+    syncManager.stopLocationUpdates();
+  });
+
+  const vehicle = {
+    id: "v1",
+    name: "V1",
+    type: "car" as const,
+    position: [-1.3, 36.85] as [number, number],
+    currentEdge: { id: "e1" } as any,
+    speed: 30,
+    bearing: 90,
+    progress: 0,
+    sourceMetadata: { deviceId: "dev-1" },
+  };
+
+  function sample(overrides: Partial<VehicleDTO> = {}): VehicleDTO {
+    return {
+      id: "v1",
+      name: "V1",
+      type: "car",
+      position: [-1.3, 36.85],
+      speed: 30,
+      heading: 90,
+      timestamp: 1_700_000_000_000,
+      faults: { active: ["clock_skew"], skewMs: 5000 },
+      ...overrides,
+    };
+  }
+
+  /** Runs exactly one sync cycle and returns the pushed payload. */
+  async function pushOnce(
+    getFaulted: (() => VehicleDTO[] | null) | undefined
+  ): Promise<{ vehicles: any[] } | undefined> {
+    const adapter = (syncManager as any).adapter;
+    const syncSpy = vi.spyOn(adapter, "sync").mockResolvedValue(undefined);
+    const getVehicles = function* () {
+      yield vehicle;
+    };
+
+    vi.useFakeTimers();
+    try {
+      syncManager.startLocationUpdates(1000, getVehicles as any, getFaulted);
+      await vi.advanceTimersByTimeAsync(1000);
+    } finally {
+      syncManager.stopLocationUpdates();
+      vi.useRealTimers();
+    }
+    return syncSpy.mock.calls[0]?.[0] as { vehicles: any[] } | undefined;
+  }
+
+  it("pushes the true-position snapshot when no fault egress is supplied", async () => {
+    const payload = await pushOnce(undefined);
+
+    expect(payload!.vehicles).toHaveLength(1);
+    expect(payload!.vehicles[0]).toEqual({
+      id: "v1",
+      name: "V1",
+      type: "car",
+      latitude: -1.3,
+      longitude: 36.85,
+      speed: 30,
+      heading: 90,
+      metadata: { deviceId: "dev-1" },
+    });
+  });
+
+  it("pushes the device's samples, with the applied faults and its own timestamp", async () => {
+    const payload = await pushOnce(() => [sample()]);
+
+    expect(payload!.vehicles[0]).toEqual({
+      id: "v1",
+      name: "V1",
+      type: "car",
+      latitude: -1.3,
+      longitude: 36.85,
+      speed: 30,
+      heading: 90,
+      timestamp: 1_700_000_000_000,
+      metadata: { deviceId: "dev-1", faults: { active: ["clock_skew"], skewMs: 5000 } },
+    });
+  });
+
+  it("preserves duplicates and out-of-order samples instead of coalescing them", async () => {
+    const payload = await pushOnce(() => [
+      sample({ timestamp: 2000 }),
+      sample({ timestamp: 2000, faults: { active: ["duplicate"] } }),
+      sample({ timestamp: 1000, faults: { active: ["out_of_order"] } }),
+    ]);
+
+    expect(payload!.vehicles).toHaveLength(3);
+    expect(payload!.vehicles.map((v: any) => v.timestamp)).toEqual([2000, 2000, 1000]);
+  });
+
+  it("pushes nothing when every device was silent this window", async () => {
+    const payload = await pushOnce(() => []);
+
+    expect(payload).toBeUndefined();
+  });
+});

--- a/apps/simulator/src/__tests__/modules/DeviceFaultManager.test.ts
+++ b/apps/simulator/src/__tests__/modules/DeviceFaultManager.test.ts
@@ -1,0 +1,567 @@
+import { describe, it, expect, vi } from "vitest";
+import { DeviceFaultManager } from "../../modules/faults/DeviceFaultManager";
+import { parseFaultProfilesEnv } from "../../modules/faults/schema";
+import { calculateDistance } from "../../utils/helpers";
+import type { DeviceFaultProfile, VehicleDTO } from "../../types";
+
+const T0 = 1_700_000_000_000;
+
+function dto(overrides: Partial<VehicleDTO> = {}): VehicleDTO {
+  return {
+    id: "v1",
+    name: "V1",
+    type: "car",
+    position: [-1.3, 36.85],
+    speed: 40,
+    heading: 90,
+    ...overrides,
+  };
+}
+
+/** Manager with a fleet-wide profile armed and a fixed seed. */
+function armed(profile: DeviceFaultProfile, seed = 42): DeviceFaultManager {
+  return new DeviceFaultManager({ enabled: true, seed, default: profile });
+}
+
+describe("DeviceFaultManager", () => {
+  // ─── Off by default ───────────────────────────────────────────────
+
+  describe("inactive by default", () => {
+    it("passes the DTO through untouched when disabled", () => {
+      const manager = new DeviceFaultManager();
+      const input = dto();
+
+      const out = manager.report(input, T0);
+
+      expect(manager.isActive()).toBe(false);
+      expect(out).toEqual([input]);
+      // Same object: no allocation, no timestamp/faults fields on the wire.
+      expect(out[0]).toBe(input);
+    });
+
+    it("passes the DTO through when enabled but no profile is configured", () => {
+      const manager = new DeviceFaultManager({ enabled: true, seed: 1 });
+      const input = dto();
+
+      expect(manager.isActive()).toBe(false);
+      expect(manager.report(input, T0)[0]).toBe(input);
+      expect(manager.view(input, T0)).toBe(input);
+    });
+
+    it("is active once a profile exists and stays inactive while disabled", () => {
+      const profile: DeviceFaultProfile = { clockSkew: { offsetMs: 1 } };
+      expect(new DeviceFaultManager({ default: profile }).isActive()).toBe(false);
+      expect(new DeviceFaultManager({ enabled: true, default: profile }).isActive()).toBe(true);
+      expect(new DeviceFaultManager({ enabled: true, vehicles: { v1: profile } }).isActive()).toBe(
+        true
+      );
+    });
+  });
+
+  // ─── Frozen GPS ───────────────────────────────────────────────────
+
+  describe("frozen_gps", () => {
+    it("latches the fix and replays it for the frozen window", () => {
+      const manager = armed({
+        frozenGps: { probability: 1, minDurationMs: 5000, maxDurationMs: 5000 },
+      });
+
+      const first = manager.report(dto(), T0)[0]!;
+      expect(first.faults?.active).toContain("frozen_gps");
+      expect(first.position).toEqual([-1.3, 36.85]);
+
+      // The vehicle really moved, but the device keeps reporting the latched fix.
+      const moved = dto({ position: [-1.31, 36.86], speed: 55, heading: 180 });
+      const second = manager.report(moved, T0 + 1000)[0]!;
+      expect(second.position).toEqual([-1.3, 36.85]);
+      expect(second.speed).toBe(40);
+      expect(second.heading).toBe(90);
+      expect(second.faults?.active).toContain("frozen_gps");
+    });
+
+    it("re-latches on the current fix once the window expires", () => {
+      const manager = armed({
+        frozenGps: { probability: 1, minDurationMs: 5000, maxDurationMs: 5000 },
+      });
+      manager.report(dto(), T0);
+
+      const moved = dto({ position: [-1.31, 36.86] });
+      const after = manager.report(moved, T0 + 6000)[0]!;
+
+      expect(after.position).toEqual([-1.31, 36.86]);
+      expect(manager.getStatus().counts.frozen_gps).toBe(2);
+    });
+
+    it("never freezes at probability 0", () => {
+      const manager = armed({
+        frozenGps: { probability: 0, minDurationMs: 1000, maxDurationMs: 1000 },
+      });
+
+      const out = manager.report(dto(), T0)[0]!;
+
+      expect(out.faults?.active).toEqual([]);
+      expect(manager.getStatus().counts.frozen_gps).toBe(0);
+    });
+  });
+
+  // ─── Clock skew ───────────────────────────────────────────────────
+
+  describe("clock_skew", () => {
+    it("stamps the sample with the device's wrong clock", () => {
+      const manager = armed({ clockSkew: { offsetMs: 5000 } });
+
+      const out = manager.report(dto(), T0)[0]!;
+
+      expect(out.timestamp).toBe(T0 + 5000);
+      expect(out.faults).toMatchObject({ active: ["clock_skew"], skewMs: 5000 });
+    });
+
+    it("accumulates drift with device uptime", () => {
+      const manager = armed({ clockSkew: { offsetMs: 0, driftMsPerMinute: 60 } });
+      // First report sets the device's birth time; skew is 0 there.
+      const first = manager.report(dto(), T0)[0]!;
+      expect(first.timestamp).toBe(T0);
+      expect(first.faults?.active).toEqual([]);
+
+      const later = manager.report(dto(), T0 + 120_000)[0]!;
+
+      expect(later.faults?.skewMs).toBe(120);
+      expect(later.timestamp).toBe(T0 + 120_000 + 120);
+    });
+
+    it("carries the true emit time when no clock fault is armed", () => {
+      const manager = armed({ duplicate: { probability: 0, maxCopies: 1 } });
+
+      expect(manager.report(dto(), T0)[0]!.timestamp).toBe(T0);
+    });
+  });
+
+  // ─── Duplicate ────────────────────────────────────────────────────
+
+  describe("duplicate", () => {
+    it("retransmits the sample it just sent", () => {
+      const manager = armed({ duplicate: { probability: 1, maxCopies: 1 } });
+
+      const out = manager.report(dto(), T0);
+
+      expect(out).toHaveLength(2);
+      expect(out[1]!.position).toEqual(out[0]!.position);
+      expect(out[1]!.timestamp).toBe(out[0]!.timestamp);
+      expect(out[1]!.faults?.active).toContain("duplicate");
+      expect(out[0]!.faults?.active).not.toContain("duplicate");
+      expect(manager.getStatus().counts.duplicate).toBe(1);
+    });
+
+    it("emits at most maxCopies extra copies", () => {
+      const manager = armed({ duplicate: { probability: 1, maxCopies: 3 } });
+
+      for (let i = 0; i < 20; i++) {
+        const out = manager.report(dto(), T0 + i * 1000);
+        expect(out.length).toBeGreaterThanOrEqual(2);
+        expect(out.length).toBeLessThanOrEqual(4);
+      }
+    });
+  });
+
+  // ─── Out of order ─────────────────────────────────────────────────
+
+  describe("out_of_order", () => {
+    it("withholds a sample and releases it behind a newer one", () => {
+      const manager = armed({ outOfOrder: { probability: 1, holdMs: 1000 } });
+
+      // Nothing goes out: the device is sitting on this sample.
+      expect(manager.report(dto(), T0)).toEqual([]);
+      expect(manager.getStatus().held).toBe(1);
+
+      const released = manager.report(dto({ position: [-1.31, 36.86] }), T0 + 1000);
+
+      expect(released).toHaveLength(2);
+      // Newer sample first, older one behind it: out of order by timestamp.
+      expect(released[0]!.timestamp).toBe(T0 + 1000);
+      expect(released[1]!.timestamp).toBe(T0);
+      expect(released[1]!.faults?.active).toContain("out_of_order");
+      expect(manager.getStatus().held).toBe(0);
+    });
+
+    it("keeps emitting normally while a sample is still withheld", () => {
+      const manager = armed({ outOfOrder: { probability: 1, holdMs: 10_000 } });
+      manager.report(dto(), T0);
+
+      const out = manager.report(dto(), T0 + 1000);
+
+      expect(out).toHaveLength(1);
+      expect(out[0]!.timestamp).toBe(T0 + 1000);
+      expect(manager.getStatus().held).toBe(1);
+    });
+  });
+
+  // ─── Battery death ────────────────────────────────────────────────
+
+  describe("battery_dead", () => {
+    const battery = { initialPercent: 100, drainPercentPerHour: 100, dieAtPercent: 50 };
+
+    it("reports a draining battery while alive", () => {
+      const manager = armed({ battery });
+      manager.report(dto(), T0);
+
+      const out = manager.report(dto(), T0 + 900_000)[0]!;
+
+      expect(out.faults?.battery).toBe(75);
+      expect(out.faults?.active).toEqual([]);
+    });
+
+    it("goes silent once the battery dies", () => {
+      const manager = armed({ battery });
+      manager.report(dto(), T0);
+
+      expect(manager.report(dto(), T0 + 1_800_000)).toEqual([]);
+      const status = manager.getStatus();
+      expect(status.dead).toBe(1);
+      expect(status.counts.battery_dead).toBe(1);
+      // Death is counted once, not once per silent tick.
+      manager.report(dto(), T0 + 1_900_000);
+      expect(manager.getStatus().counts.battery_dead).toBe(1);
+    });
+
+    it("shows the last fix a dead device managed to send", () => {
+      const manager = armed({ battery });
+      manager.report(dto({ position: [-1.2, 36.8] }), T0);
+      manager.report(dto(), T0 + 1_800_000);
+
+      const view = manager.view(dto({ position: [-1.31, 36.86] }), T0 + 1_800_000);
+
+      expect(view.position).toEqual([-1.2, 36.8]);
+      expect(view.faults?.active).toContain("battery_dead");
+      expect(view.faults?.battery).toBe(0);
+    });
+  });
+
+  // ─── Teleport ─────────────────────────────────────────────────────
+
+  describe("teleport", () => {
+    it("moves the reported fix within the configured radius", () => {
+      const manager = armed({ teleport: { probability: 1, radiusMeters: 1000, holdMs: 0 } });
+
+      const out = manager.report(dto(), T0)[0]!;
+
+      expect(out.faults?.active).toContain("teleport");
+      const offsetKm = calculateDistance([-1.3, 36.85], out.position);
+      expect(offsetKm).toBeLessThanOrEqual(1.001);
+    });
+
+    it("holds the bogus offset for holdMs, then draws a new one", () => {
+      const manager = armed({ teleport: { probability: 1, radiusMeters: 1000, holdMs: 5000 } });
+
+      const first = manager.report(dto(), T0)[0]!;
+      const during = manager.report(dto(), T0 + 1000)[0]!;
+      expect(during.position).toEqual(first.position);
+
+      const after = manager.report(dto(), T0 + 6000)[0]!;
+      expect(after.position).not.toEqual(first.position);
+      expect(manager.getStatus().counts.teleport).toBe(2);
+    });
+  });
+
+  // ─── Reproducibility ──────────────────────────────────────────────
+
+  describe("reproducibility under a fixed seed", () => {
+    const noisy: DeviceFaultProfile = {
+      frozenGps: { probability: 0.4, minDurationMs: 500, maxDurationMs: 3000 },
+      teleport: { probability: 0.3, radiusMeters: 500, holdMs: 1000 },
+      duplicate: { probability: 0.3, maxCopies: 2 },
+      outOfOrder: { probability: 0.2, holdMs: 1500 },
+      clockSkew: { offsetMs: 250, driftMsPerMinute: 10 },
+    };
+
+    function run(seed: number, vehicleId = "v1"): string {
+      const manager = armed(noisy, seed);
+      const samples: VehicleDTO[] = [];
+      for (let i = 0; i < 100; i++) {
+        samples.push(
+          ...manager.report(
+            dto({ id: vehicleId, position: [-1.3 + i * 1e-4, 36.85] }),
+            T0 + i * 500
+          )
+        );
+      }
+      return JSON.stringify(samples);
+    }
+
+    it("produces an identical sample stream for the same seed", () => {
+      expect(run(7)).toBe(run(7));
+    });
+
+    it("produces a different stream for a different seed", () => {
+      expect(run(7)).not.toBe(run(8));
+    });
+
+    it("gives each device its own stream, so fleet order cannot matter", () => {
+      expect(run(7, "v1")).not.toBe(run(7, "v2").replaceAll('"v2"', '"v1"'));
+    });
+
+    it("is unseeded (and so not reproducible) when no seed is configured", () => {
+      const manager = new DeviceFaultManager({
+        enabled: true,
+        default: { teleport: { probability: 1, radiusMeters: 1000, holdMs: 0 } },
+      });
+      const randomSpy = vi.spyOn(Math, "random");
+
+      manager.report(dto(), T0);
+
+      expect(randomSpy).toHaveBeenCalled();
+      randomSpy.mockRestore();
+    });
+  });
+
+  // ─── view() ───────────────────────────────────────────────────────
+
+  describe("view", () => {
+    it("projects a frozen device without advancing fault state", () => {
+      const manager = armed({
+        frozenGps: { probability: 1, minDurationMs: 5000, maxDurationMs: 5000 },
+      });
+      manager.report(dto(), T0);
+
+      const moved = dto({ position: [-1.31, 36.86] });
+      expect(manager.view(moved, T0 + 1000).position).toEqual([-1.3, 36.85]);
+      // Still one frozen window, not two: view() drew no random numbers.
+      expect(manager.getStatus().counts.frozen_gps).toBe(1);
+    });
+
+    it("leaves an unknown device's DTO alone", () => {
+      const manager = armed({ clockSkew: { offsetMs: 100 } });
+      const input = dto();
+
+      expect(manager.view(input, T0)).toBe(input);
+    });
+
+    it("does not perturb the RNG stream the reports draw from", () => {
+      const profile: DeviceFaultProfile = {
+        teleport: { probability: 0.5, radiusMeters: 500, holdMs: 0 },
+      };
+      const withViews = armed(profile);
+      const withoutViews = armed(profile);
+
+      const a: VehicleDTO[] = [];
+      const b: VehicleDTO[] = [];
+      for (let i = 0; i < 20; i++) {
+        a.push(...withViews.report(dto(), T0 + i * 1000));
+        withViews.view(dto(), T0 + i * 1000);
+        withViews.view(dto(), T0 + i * 1000);
+        b.push(...withoutViews.report(dto(), T0 + i * 1000));
+      }
+
+      expect(a).toEqual(b);
+    });
+  });
+
+  // ─── Profiles & configuration ─────────────────────────────────────
+
+  describe("profiles", () => {
+    it("prefers a per-vehicle profile over the fleet-wide default", () => {
+      const manager = new DeviceFaultManager({
+        enabled: true,
+        seed: 1,
+        default: { clockSkew: { offsetMs: 1000 } },
+        vehicles: { v1: { clockSkew: { offsetMs: 9000 } } },
+      });
+
+      expect(manager.report(dto({ id: "v1" }), T0)[0]!.faults?.skewMs).toBe(9000);
+      expect(manager.report(dto({ id: "v2" }), T0)[0]!.faults?.skewMs).toBe(1000);
+    });
+
+    it("sets and clears a per-vehicle profile at runtime", () => {
+      const manager = new DeviceFaultManager({ enabled: true, seed: 1 });
+
+      manager.setVehicleProfile("v1", { clockSkew: { offsetMs: 3000 } });
+      expect(manager.isActive()).toBe(true);
+      expect(manager.report(dto(), T0)[0]!.faults?.skewMs).toBe(3000);
+
+      expect(manager.clearVehicleProfile("v1")).toBe(true);
+      expect(manager.clearVehicleProfile("v1")).toBe(false);
+      expect(manager.isActive()).toBe(false);
+    });
+
+    it("drops the device's latched state when its profile is replaced", () => {
+      const manager = armed({
+        frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 },
+      });
+      manager.report(dto(), T0);
+      expect(manager.getStatus().frozen).toBe(1);
+
+      manager.setVehicleProfile("v1", { clockSkew: { offsetMs: 1 } });
+
+      expect(manager.getStatus().devices).toBe(0);
+    });
+  });
+
+  describe("configure", () => {
+    it("flips enabled without restating the profiles", () => {
+      const manager = new DeviceFaultManager({ default: { clockSkew: { offsetMs: 100 } } });
+
+      const config = manager.configure({ enabled: true });
+
+      expect(config.enabled).toBe(true);
+      expect(config.default).toEqual({ clockSkew: { offsetMs: 100 } });
+      expect(manager.isActive()).toBe(true);
+    });
+
+    it("clears the fleet-wide default with an explicit null", () => {
+      const manager = armed({ clockSkew: { offsetMs: 100 } });
+
+      const config = manager.configure({ default: null });
+
+      expect(config.default).toBeUndefined();
+      expect(manager.isActive()).toBe(false);
+    });
+
+    it("discards device state when the seed changes", () => {
+      const manager = armed({
+        frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 },
+      });
+      manager.report(dto(), T0);
+      expect(manager.getStatus().devices).toBe(1);
+
+      manager.configure({ seed: 99 });
+
+      expect(manager.getStatus().devices).toBe(0);
+      expect(manager.getConfig().seed).toBe(99);
+    });
+
+    it("discards device state when disabled, so a re-enable starts clean", () => {
+      const manager = armed({
+        battery: { initialPercent: 10, drainPercentPerHour: 100, dieAtPercent: 5 },
+      });
+      manager.report(dto(), T0);
+
+      manager.configure({ enabled: false });
+      manager.configure({ enabled: true });
+
+      expect(manager.getStatus().devices).toBe(0);
+      expect(manager.report(dto(), T0)[0]!.faults?.battery).toBe(10);
+    });
+
+    it("emits faults:config on every configuration change", () => {
+      const manager = new DeviceFaultManager();
+      const listener = vi.fn();
+      manager.on("faults:config", listener);
+
+      manager.configure({ enabled: true, default: { clockSkew: { offsetMs: 1 } } });
+      manager.setVehicleProfile("v1", { clockSkew: { offsetMs: 2 } });
+      manager.clearVehicleProfile("v1");
+
+      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener.mock.calls[0]![0]).toMatchObject({ enabled: true });
+    });
+
+    it("merges per-vehicle profiles rather than replacing the whole map", () => {
+      const manager = new DeviceFaultManager({
+        enabled: true,
+        seed: 1,
+        vehicles: { v1: { clockSkew: { offsetMs: 1 } } },
+      });
+
+      const config = manager.configure({ vehicles: { v2: { clockSkew: { offsetMs: 2 } } } });
+
+      expect(Object.keys(config.vehicles).sort()).toEqual(["v1", "v2"]);
+    });
+  });
+
+  // ─── Egress queue ─────────────────────────────────────────────────
+
+  describe("drainTelemetry", () => {
+    it("hands over every emitted sample in order, then empties", () => {
+      const manager = armed({ duplicate: { probability: 1, maxCopies: 1 } });
+      manager.report(dto(), T0);
+      manager.report(dto(), T0 + 1000);
+
+      const drained = manager.drainTelemetry();
+
+      expect(drained).toHaveLength(4);
+      expect(drained.map((s) => s.timestamp)).toEqual([T0, T0, T0 + 1000, T0 + 1000]);
+      expect(manager.drainTelemetry()).toEqual([]);
+      expect(manager.getStatus().queued).toBe(0);
+    });
+
+    it("queues nothing for a silent device", () => {
+      const manager = armed({ outOfOrder: { probability: 1, holdMs: 60_000 } });
+
+      manager.report(dto(), T0);
+
+      expect(manager.drainTelemetry()).toEqual([]);
+    });
+
+    it("bounds the queue and drops the oldest samples on overflow", () => {
+      const manager = armed({ clockSkew: { offsetMs: 1 } });
+
+      for (let i = 0; i < 10_100; i++) manager.report(dto(), T0 + i);
+
+      expect(manager.getStatus().queued).toBe(10_000);
+      expect(manager.getDroppedCount()).toBe(100);
+      // The oldest 100 went; the queue starts at the 101st sample.
+      expect(manager.drainTelemetry()[0]!.timestamp).toBe(T0 + 100 + 1);
+    });
+  });
+
+  // ─── Reset ────────────────────────────────────────────────────────
+
+  describe("reset", () => {
+    it("clears device state and counters but keeps the configuration", () => {
+      const manager = armed({
+        frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 },
+      });
+      manager.report(dto(), T0);
+
+      manager.reset();
+
+      const status = manager.getStatus();
+      expect(status.devices).toBe(0);
+      expect(status.queued).toBe(0);
+      expect(status.counts.frozen_gps).toBe(0);
+      expect(manager.isActive()).toBe(true);
+      expect(manager.getConfig().default).toBeDefined();
+    });
+  });
+});
+
+// ─── FAULT_PROFILES env parsing ─────────────────────────────────────
+
+describe("parseFaultProfilesEnv", () => {
+  it("returns an empty config for an empty value", () => {
+    expect(parseFaultProfilesEnv("")).toEqual({});
+    expect(parseFaultProfilesEnv("   ")).toEqual({});
+  });
+
+  it("parses a default profile and per-vehicle overrides", () => {
+    const parsed = parseFaultProfilesEnv(
+      '{"default":{"clockSkew":{"offsetMs":500}},"vehicles":{"v1":{"duplicate":{"probability":0.5,"maxCopies":2}}}}'
+    );
+
+    expect(parsed.default).toEqual({ clockSkew: { offsetMs: 500 } });
+    expect(parsed.vehicles?.v1).toEqual({ duplicate: { probability: 0.5, maxCopies: 2 } });
+  });
+
+  it("throws on malformed JSON", () => {
+    expect(() => parseFaultProfilesEnv("{nope")).toThrow(/not valid JSON/);
+  });
+
+  it("throws on an unknown key, rather than silently arming nothing", () => {
+    expect(() => parseFaultProfilesEnv('{"default":{"frozenGPS":{"probability":1}}}')).toThrow(
+      /Invalid FAULT_PROFILES/
+    );
+  });
+
+  it("rejects an out-of-range probability", () => {
+    expect(() =>
+      parseFaultProfilesEnv('{"default":{"duplicate":{"probability":2,"maxCopies":1}}}')
+    ).toThrow(/Invalid FAULT_PROFILES/);
+  });
+
+  it("rejects a frozen window whose max is below its min", () => {
+    expect(() =>
+      parseFaultProfilesEnv(
+        '{"default":{"frozenGps":{"probability":1,"minDurationMs":5000,"maxDurationMs":1000}}}'
+      )
+    ).toThrow(/maxDurationMs must be >= minDurationMs/);
+  });
+});

--- a/apps/simulator/src/__tests__/routes/faults.test.ts
+++ b/apps/simulator/src/__tests__/routes/faults.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createFaultRoutes } from "../../routes/faults";
+import { DeviceFaultManager } from "../../modules/faults/DeviceFaultManager";
+import type { RouteContext } from "../../routes/types";
+
+describe("fault routes", () => {
+  let faults: DeviceFaultManager;
+  let app: express.Express;
+
+  beforeEach(() => {
+    faults = new DeviceFaultManager();
+    const ctx = { vehicleManager: { faults } } as unknown as RouteContext;
+    app = express();
+    app.use(express.json());
+    app.use(createFaultRoutes(ctx));
+  });
+
+  describe("GET /faults", () => {
+    it("returns the configuration and a live status snapshot", async () => {
+      const res = await request(app).get("/faults");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ enabled: false, vehicles: {} });
+      expect(res.body.status).toMatchObject({ enabled: false, devices: 0, queued: 0 });
+      expect(res.body.status.counts).toMatchObject({ frozen_gps: 0, battery_dead: 0 });
+    });
+  });
+
+  describe("POST /faults", () => {
+    it("arms the layer and echoes the resolved configuration", async () => {
+      const res = await request(app)
+        .post("/faults")
+        .send({ enabled: true, seed: 7, default: { clockSkew: { offsetMs: 2500 } } });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        enabled: true,
+        seed: 7,
+        default: { clockSkew: { offsetMs: 2500 } },
+        vehicles: {},
+      });
+      expect(faults.isActive()).toBe(true);
+    });
+
+    it("clears the fleet-wide default with an explicit null", async () => {
+      await request(app)
+        .post("/faults")
+        .send({ enabled: true, default: { clockSkew: { offsetMs: 1 } } });
+
+      const res = await request(app).post("/faults").send({ default: null });
+
+      expect(res.status).toBe(200);
+      expect(res.body.default).toBeUndefined();
+    });
+
+    it("rejects an unknown key so a typo cannot silently arm nothing", async () => {
+      const res = await request(app)
+        .post("/faults")
+        .send({ default: { frozenGPS: { probability: 1 } } });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Validation failed");
+      expect(res.body.details.join(" ")).toMatch(/frozenGPS/);
+    });
+
+    it("rejects an out-of-range probability", async () => {
+      const res = await request(app)
+        .post("/faults")
+        .send({ default: { duplicate: { probability: 5, maxCopies: 1 } } });
+
+      expect(res.status).toBe(400);
+      expect(res.body.details.join(" ")).toMatch(/probability/);
+    });
+
+    it("rejects a frozen window whose max is below its min", async () => {
+      const res = await request(app)
+        .post("/faults")
+        .send({
+          default: { frozenGps: { probability: 1, minDurationMs: 9000, maxDurationMs: 1000 } },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.details.join(" ")).toMatch(/maxDurationMs must be >= minDurationMs/);
+    });
+  });
+
+  describe("PUT /faults/vehicles/:id", () => {
+    it("sets one vehicle's profile", async () => {
+      const res = await request(app)
+        .put("/faults/vehicles/v1")
+        .send({ teleport: { probability: 0.2, radiusMeters: 800, holdMs: 0 } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.vehicles.v1).toEqual({
+        teleport: { probability: 0.2, radiusMeters: 800, holdMs: 0 },
+      });
+    });
+
+    it("validates the profile body", async () => {
+      const res = await request(app).put("/faults/vehicles/v1").send({ battery: {} });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("DELETE /faults/vehicles/:id", () => {
+    it("removes an existing profile", async () => {
+      await request(app)
+        .put("/faults/vehicles/v1")
+        .send({ clockSkew: { offsetMs: 10 } });
+
+      const res = await request(app).delete("/faults/vehicles/v1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.vehicles).toEqual({});
+    });
+
+    it("404s for a vehicle with no profile", async () => {
+      const res = await request(app).delete("/faults/vehicles/ghost");
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toMatch(/No fault profile/);
+    });
+  });
+
+  describe("GET /faults/status and POST /faults/reset", () => {
+    it("reports live device state and clears it on reset", async () => {
+      faults.configure({
+        enabled: true,
+        seed: 1,
+        default: { frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 } },
+      });
+      faults.report(
+        { id: "v1", name: "V1", type: "car", position: [-1.3, 36.85], speed: 30, heading: 0 },
+        Date.now()
+      );
+
+      const before = await request(app).get("/faults/status");
+      expect(before.body).toMatchObject({ devices: 1, frozen: 1, queued: 1 });
+      expect(before.body.counts.frozen_gps).toBe(1);
+
+      const after = await request(app).post("/faults/reset");
+      expect(after.status).toBe(200);
+      expect(after.body).toMatchObject({ devices: 0, frozen: 0, queued: 0 });
+      expect(after.body.counts.frozen_gps).toBe(0);
+      // Reset clears device state, not the configuration.
+      expect(faults.isActive()).toBe(true);
+    });
+  });
+});

--- a/apps/simulator/src/__tests__/setup/eventWiring.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiring.test.ts
@@ -51,6 +51,7 @@ describe("wireEvents", () => {
       network: network as unknown as EventWiringContext["network"],
       vehicleManager: Object.assign(vehicleManager, {
         getTrafficSnapshot: vi.fn().mockReturnValue({ edges: {} }),
+        faults: createMockEmitter(),
       }) as unknown as EventWiringContext["vehicleManager"],
       fleetManager: fleetManager as unknown as EventWiringContext["fleetManager"],
       jobManager: Object.assign(createMockEmitter(), {

--- a/apps/simulator/src/__tests__/setup/eventWiringHeatZoneTime.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiringHeatZoneTime.test.ts
@@ -86,6 +86,7 @@ describe("wireEvents — heat-zone time-of-day scaling", () => {
       getTrafficProfile: vi.fn(() => DEFAULT_TRAFFIC_PROFILE),
       getTrafficSnapshot: vi.fn().mockReturnValue({ edges: {} }),
       analytics: { getSnapshot: vi.fn().mockReturnValue({}) },
+      faults: new EventEmitter(),
     });
 
     const ctx = {

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -29,6 +29,7 @@ import {
   createReplayRoutes,
   createFleetRoutes,
   createJobRoutes,
+  createFaultRoutes,
   createAnalyticsRoutes,
   createScenarioRoutes,
   createStateRoutes,
@@ -129,6 +130,7 @@ app.use(createRecordingRoutes(ctx));
 app.use(createReplayRoutes(ctx));
 app.use(createFleetRoutes(ctx));
 app.use(createJobRoutes(ctx));
+app.use(createFaultRoutes(ctx));
 app.use(createAnalyticsRoutes(ctx));
 app.use(createScenarioRoutes(ctx));
 app.use(createGeofenceRoutes(geoFenceManager));

--- a/apps/simulator/src/modules/Adapter.ts
+++ b/apps/simulator/src/modules/Adapter.ts
@@ -2,7 +2,7 @@ import type { DataVehicle } from "../types";
 import { config } from "../utils/config";
 import logger from "../utils/logger";
 
-interface SyncVehicle {
+export interface SyncVehicle {
   id: string;
   name: string;
   latitude: number;
@@ -12,6 +12,11 @@ interface SyncVehicle {
   speed?: number;
   /** Heading / course over ground in degrees. */
   heading?: number;
+  /**
+   * Device fix timestamp (epoch ms), distinct from the batch timestamp. Sent
+   * only by a simulated device with a fault profile, whose clock may be skewed.
+   */
+  timestamp?: number;
   /** Arbitrary source-provided metadata, carried opaquely through to the sinks. */
   metadata?: Record<string, unknown>;
 }

--- a/apps/simulator/src/modules/AdapterSyncManager.ts
+++ b/apps/simulator/src/modules/AdapterSyncManager.ts
@@ -1,11 +1,58 @@
-import type { DataVehicle, Vehicle, VehicleType } from "../types";
+import type { DataVehicle, Vehicle, VehicleDTO, VehicleType } from "../types";
 import { config } from "../utils/config";
-import Adapter from "./Adapter";
+import Adapter, { type SyncVehicle } from "./Adapter";
 import { recordAdapterSync } from "../metrics";
 import logger from "../utils/logger";
 
 /** Consecutive-failure count at which a persistent-failure error is logged. */
 const PERSISTENT_FAILURE_THRESHOLD = 5;
+
+/** One update per vehicle, from the vehicle's true current state. */
+function buildSnapshotPayload(vehicles: Vehicle[]): SyncVehicle[] {
+  return vehicles.map((v) => ({
+    id: v.id,
+    name: v.name,
+    type: v.type,
+    latitude: v.position[0],
+    longitude: v.position[1],
+    speed: v.speed, // km/h
+    heading: v.bearing, // degrees
+    // Carry source-provided metadata opaquely back to the adapter/sinks.
+    ...(v.sourceMetadata !== undefined ? { metadata: v.sourceMetadata } : {}),
+  }));
+}
+
+/**
+ * The simulated devices' own samples, in emission order. There may be several
+ * (or zero) per vehicle, so this is not a snapshot: it is the device telemetry
+ * stream, with the injected faults intact. The applied faults ride along under
+ * `metadata.faults` so a downstream consumer can tell an injected fault from a
+ * real one while testing against it.
+ */
+function buildFaultedPayload(samples: VehicleDTO[], vehicles: Vehicle[]): SyncVehicle[] {
+  const sourceMetadata = new Map<string, Record<string, unknown>>();
+  for (const v of vehicles) {
+    if (v.sourceMetadata !== undefined) sourceMetadata.set(v.id, v.sourceMetadata);
+  }
+  return samples.map((s) => {
+    const source = sourceMetadata.get(s.id);
+    const metadata =
+      source !== undefined || s.faults !== undefined
+        ? { ...(source ?? {}), ...(s.faults !== undefined ? { faults: s.faults } : {}) }
+        : undefined;
+    return {
+      id: s.id,
+      name: s.name,
+      type: s.type,
+      latitude: s.position[0],
+      longitude: s.position[1],
+      speed: s.speed,
+      heading: s.heading,
+      ...(s.timestamp !== undefined ? { timestamp: s.timestamp } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
+    };
+  });
+}
 
 /**
  * Manages adapter integration: fetching vehicles from external adapter
@@ -113,8 +160,20 @@ export class AdapterSyncManager {
    * failures back off exponentially (with jitter, capped at config.maxSyncBackoffMs)
    * instead of hammering an unhealthy adapter at the fixed cadence. The delay
    * resets to `intervalMs` on the first successful sync.
+   *
+   * @param getFaultedTelemetry - Optional device-fault egress. When it returns
+   * an array, THAT is pushed: the simulated devices' own samples in emission
+   * order, so duplicates and reordering reach the downstream sinks instead of
+   * being coalesced into one position per vehicle. An empty array means every
+   * device was silent this window (dead battery, withheld sample) and nothing
+   * is pushed at all. Returning `null` — or omitting the callback — keeps the
+   * original "snapshot of current true positions" behavior.
    */
-  startLocationUpdates(intervalMs: number, getVehicles: () => IterableIterator<Vehicle>): void {
+  startLocationUpdates(
+    intervalMs: number,
+    getVehicles: () => IterableIterator<Vehicle>,
+    getFaultedTelemetry?: () => VehicleDTO[] | null
+  ): void {
     this.stopLocationUpdates();
     const session = this.syncSession;
     // Consecutive-failure counter scoped to this session so a stale sync
@@ -124,6 +183,12 @@ export class AdapterSyncManager {
 
     const syncOnce = async (): Promise<void> => {
       const vehicles = Array.from(getVehicles());
+      const faulted = getFaultedTelemetry?.() ?? null;
+      // Every device silent this window: emitting nothing is the correct
+      // behavior, not an error, so skip the push entirely.
+      if (faulted !== null && faulted.length === 0) return;
+      const payload =
+        faulted !== null ? buildFaultedPayload(faulted, vehicles) : buildSnapshotPayload(vehicles);
       // The periodic sync runs outside any HTTP request, so generate a fresh
       // correlation id per push cycle and forward it as x-request-id so the
       // adapter can thread it into its telemetry envelope.
@@ -132,17 +197,7 @@ export class AdapterSyncManager {
       try {
         await this.adapter.sync(
           {
-            vehicles: vehicles.map((v) => ({
-              id: v.id,
-              name: v.name,
-              type: v.type,
-              latitude: v.position[0],
-              longitude: v.position[1],
-              speed: v.speed, // km/h
-              heading: v.bearing, // degrees
-              // Carry source-provided metadata opaquely back to the adapter/sinks.
-              ...(v.sourceMetadata !== undefined ? { metadata: v.sourceMetadata } : {}),
-            })),
+            vehicles: payload,
             timestamp: Date.now(),
           },
           correlationId

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -22,6 +22,7 @@ import { RouteManager } from "./RouteManager";
 import { GameLoop, FAILURE_LOG_SAMPLE_RATE } from "./GameLoop";
 import { AdapterSyncManager } from "./AdapterSyncManager";
 import { AnalyticsAccumulator } from "./AnalyticsAccumulator";
+import { DeviceFaultManager, parseFaultProfilesEnv } from "./faults";
 import logger from "../utils/logger";
 
 /**
@@ -30,6 +31,7 @@ import logger from "../utils/logger";
  * - RouteManager: route/waypoint tracking, pathfinding, movement physics
  * - GameLoop: tick/timing logic
  * - AdapterSyncManager: adapter integration
+ * - DeviceFaultManager: per-vehicle device fault injection at telemetry egress
  *
  * Maintains the same public API as the original monolithic class for backward compatibility.
  */
@@ -40,6 +42,7 @@ export class VehicleManager extends EventEmitter {
   public readonly gameLoop: GameLoop;
   public readonly adapterSync: AdapterSyncManager;
   public readonly analytics: AnalyticsAccumulator;
+  public readonly faults: DeviceFaultManager;
 
   public readonly clock = new SimulationClock({
     startHour: 7,
@@ -88,6 +91,13 @@ export class VehicleManager extends EventEmitter {
     );
     this.adapterSync = new AdapterSyncManager();
     this.analytics = new AnalyticsAccumulator(this.registry, fleetManager);
+    // Throws on a malformed FAULT_PROFILES, aborting startup: a fault layer
+    // that armed nothing because of a typo is worse than a boot failure.
+    this.faults = new DeviceFaultManager({
+      enabled: config.faultsEnabled,
+      seed: config.faultSeed,
+      ...parseFaultProfilesEnv(config.faultProfiles),
+    });
 
     // Attach analytics accumulator to game loop so stats update each tick
     this.gameLoop.analyticsAccumulator = this.analytics;
@@ -109,7 +119,20 @@ export class VehicleManager extends EventEmitter {
     });
     this.routeManager.on("route:completed", (data) => this.emit("route:completed", data));
     this.routeManager.on("vehicle:rerouted", (data) => this.emit("vehicle:rerouted", data));
-    this.gameLoop.on("update", (data) => this.emit("update", data));
+    // The game-loop tick IS the device's report, so it is the one place device
+    // faults are injected: a report can become several samples (duplicate, or
+    // a withheld sample released after a newer one) or none at all (dead
+    // battery). With no fault profile armed the DTO is forwarded untouched.
+    this.gameLoop.on("update", (data: VehicleDTO) => {
+      if (!this.faults.isActive()) {
+        this.emit("update", data);
+        return;
+      }
+      const now = Date.now();
+      for (const sample of this.faults.report(data, now)) {
+        this.emit("update", sample);
+      }
+    });
 
     this.init();
   }
@@ -195,6 +218,9 @@ export class VehicleManager extends EventEmitter {
     this.gameLoop.reset();
     this.adapterSync.stopLocationUpdates();
     this.advanceFailureCounts.clear();
+    // Device state (drained batteries, open frozen windows, queued samples) is
+    // tied to the previous vehicle roster; the fault CONFIG survives the reset.
+    this.faults.reset();
   }
 
   // ─── Game loop delegation ─────────────────────────────────────────
@@ -248,7 +274,14 @@ export class VehicleManager extends EventEmitter {
   // ─── Adapter sync delegation ──────────────────────────────────────
 
   public startLocationUpdates(intervalMs: number): void {
-    this.adapterSync.startLocationUpdates(intervalMs, () => this.registry.getAll().values());
+    this.adapterSync.startLocationUpdates(
+      intervalMs,
+      () => this.registry.getAll().values(),
+      // With faults armed the push carries the DEVICE's samples (in emission
+      // order, duplicates and reordering intact) instead of a snapshot of true
+      // positions. Returning null keeps the original snapshot behavior.
+      () => (this.faults.isActive() ? this.faults.drainTelemetry() : null)
+    );
   }
 
   public stopLocationUpdates(): void {
@@ -301,7 +334,12 @@ export class VehicleManager extends EventEmitter {
   }
 
   public getVehicles(): VehicleDTO[] {
-    return this.registry.getAllSerialized();
+    const vehicles = this.registry.getAllSerialized();
+    if (!this.faults.isActive()) return vehicles;
+    // Project each device's currently-reported fix so a polling reader sees the
+    // frozen/teleported/stale position the stream is reporting, not the truth.
+    const now = Date.now();
+    return vehicles.map((vehicle) => this.faults.view(vehicle, now));
   }
 
   /**
@@ -356,7 +394,7 @@ export class VehicleManager extends EventEmitter {
     try {
       this.fleets.assignVehicles(fleetId, [vehicleId]);
       vehicle.fleetId = fleetId;
-      this.emit("update", serializeVehicle(vehicle));
+      this.emit("update", this.reportedFix(vehicle));
       return true;
     } catch {
       return false;
@@ -371,7 +409,7 @@ export class VehicleManager extends EventEmitter {
     try {
       this.fleets.unassignVehicles(fleetId, [vehicleId]);
       vehicle.fleetId = undefined;
-      this.emit("update", serializeVehicle(vehicle));
+      this.emit("update", this.reportedFix(vehicle));
       return true;
     } catch {
       return false;
@@ -407,6 +445,17 @@ export class VehicleManager extends EventEmitter {
   }
 
   // ─── Internal helpers ─────────────────────────────────────────────
+
+  /**
+   * DTO for an out-of-band `update` frame (e.g. a fleet reassignment), carrying
+   * the device's currently-reported fix rather than the true one. Without this
+   * a frozen or dead device would appear to jump back to reality whenever
+   * something other than the game loop emitted a frame for it.
+   */
+  private reportedFix(vehicle: Vehicle): VehicleDTO {
+    const dto = serializeVehicle(vehicle);
+    return this.faults.isActive() ? this.faults.view(dto, Date.now()) : dto;
+  }
 
   private setRandomDestination(vehicleId: string): void {
     this.routeManager.setRandomDestination(vehicleId);

--- a/apps/simulator/src/modules/faults/DeviceFaultManager.ts
+++ b/apps/simulator/src/modules/faults/DeviceFaultManager.ts
@@ -1,0 +1,512 @@
+import { EventEmitter } from "events";
+import type {
+  DeviceFaultConfig,
+  DeviceFaultInfo,
+  DeviceFaultKind,
+  DeviceFaultProfile,
+  DeviceFaultStatus,
+  Position,
+  VehicleDTO,
+} from "../../types";
+import { defaultRng, mulberry32, type Rng } from "../../utils/rng";
+import type { FaultConfigPatch } from "./schema";
+
+/**
+ * Device-level fault injection.
+ *
+ * The adapter's realism engine degrades telemetry at egress — it models the
+ * TRANSPORT (correlated GPS noise, connectivity dropouts, jittered cadence).
+ * This module models the DEVICE: a tracker whose GPS freezes, whose clock is
+ * wrong, that retransmits, that reorders, that teleports, that runs out of
+ * battery. Faults are therefore properties of a simulated device rather than
+ * of the outbound pipe, and they are injected before the telemetry ever leaves
+ * the simulator, so a consumer sees them on the WebSocket feed AND in the
+ * adapter push. The two layers compose; neither replaces the other.
+ *
+ * Cardinal rule: with no profile configured (the default), {@link report}
+ * returns the DTO it was handed, untouched, and no `timestamp`/`faults` fields
+ * appear on the wire. The fault layer is invisible until it is armed.
+ *
+ * Determinism: each device draws from its OWN `mulberry32` stream, seeded from
+ * `(seed, vehicleId)`. That is what makes a fault reproducible under a fixed
+ * seed regardless of how many other vehicles exist or in what order they tick.
+ * With no seed the streams are `Math.random` and nothing is reproducible.
+ */
+
+/** Metres per degree of latitude (spherical approximation). */
+const METERS_PER_DEG_LAT = 111_320;
+
+/**
+ * Hard cap on faulted samples awaiting an adapter push. The queue exists so
+ * stream-shaped faults (duplicates, reordering) survive to the adapter instead
+ * of being coalesced into one position per vehicle; it is bounded drop-oldest
+ * so a run with no adapter attached cannot grow it without limit. Every device
+ * reports on the same game tick, so drop-oldest is uniform across devices.
+ */
+const MAX_TELEMETRY_QUEUE = 10_000;
+
+export const FAULT_KINDS: readonly DeviceFaultKind[] = [
+  "frozen_gps",
+  "clock_skew",
+  "duplicate",
+  "out_of_order",
+  "battery_dead",
+  "teleport",
+] as const;
+
+/** Live per-device state. Rebuilt from scratch on reset or a seed change. */
+interface DeviceState {
+  /** This device's own stream, so faults don't depend on fleet iteration order. */
+  rng: Rng;
+  /** First-seen time: the origin for battery drain and clock drift. */
+  bornAt: number;
+  /** Wall-clock end of the current frozen-GPS window; 0 = not frozen. */
+  frozenUntil: number;
+  frozenFix: { position: Position; speed: number; heading: number } | null;
+  /** Wall-clock end of the current teleport window; 0 = not teleporting. */
+  teleportUntil: number;
+  teleportOffset: { dLat: number; dLon: number } | null;
+  /** Sample withheld by the out-of-order fault, and when it may be released. */
+  held: { sample: VehicleDTO; releaseAt: number } | null;
+  batteryPercent: number;
+  dead: boolean;
+  /** Last shaped sample — the device's "current" fix for polling readers. */
+  lastSample: VehicleDTO | null;
+}
+
+export interface DeviceFaultManagerOptions {
+  enabled?: boolean;
+  seed?: number;
+  default?: DeviceFaultProfile;
+  vehicles?: Record<string, DeviceFaultProfile>;
+}
+
+/** FNV-1a over the vehicle id, mixed with the configured seed. */
+function deviceSeed(seed: number, vehicleId: string): number {
+  let h = (2166136261 ^ seed) >>> 0;
+  for (let i = 0; i < vehicleId.length; i++) {
+    h ^= vehicleId.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** Converts a metric offset at `latitude` into a lat/lon delta. */
+function metersToOffset(
+  distanceM: number,
+  bearingRad: number,
+  latitude: number
+): { dLat: number; dLon: number } {
+  const north = Math.cos(bearingRad) * distanceM;
+  const east = Math.sin(bearingRad) * distanceM;
+  const cosLat = Math.max(Math.cos((latitude * Math.PI) / 180), 0.01);
+  return { dLat: north / METERS_PER_DEG_LAT, dLon: east / (METERS_PER_DEG_LAT * cosLat) };
+}
+
+/** Copy of `sample` with one more fault kind recorded on it. */
+function withFault(sample: VehicleDTO, kind: DeviceFaultKind): VehicleDTO {
+  const faults: DeviceFaultInfo = {
+    ...(sample.faults ?? { active: [] }),
+    active: [...(sample.faults?.active ?? []), kind],
+  };
+  return { ...sample, faults };
+}
+
+function zeroCounts(): Record<DeviceFaultKind, number> {
+  return {
+    frozen_gps: 0,
+    clock_skew: 0,
+    duplicate: 0,
+    out_of_order: 0,
+    battery_dead: 0,
+    teleport: 0,
+  };
+}
+
+/**
+ * Injects per-vehicle device faults into outgoing telemetry.
+ *
+ * Emits: `faults:config` (the whole {@link DeviceFaultConfig}) whenever the
+ * configuration changes, so the UI can follow a runtime edit over WebSocket.
+ */
+export class DeviceFaultManager extends EventEmitter {
+  private enabled: boolean;
+  private seed: number | undefined;
+  private defaultProfile: DeviceFaultProfile | undefined;
+  private profiles = new Map<string, DeviceFaultProfile>();
+  private devices = new Map<string, DeviceState>();
+  private queue: VehicleDTO[] = [];
+  private counts = zeroCounts();
+  /** Samples dropped from the egress queue on overflow, for status reporting. */
+  private droppedFromQueue = 0;
+
+  constructor(options: DeviceFaultManagerOptions = {}) {
+    super();
+    this.enabled = options.enabled ?? false;
+    this.seed = options.seed;
+    this.defaultProfile = options.default;
+    for (const [id, profile] of Object.entries(options.vehicles ?? {})) {
+      this.profiles.set(id, profile);
+    }
+  }
+
+  // ─── Queries ──────────────────────────────────────────────────────
+
+  /**
+   * True when fault injection is enabled AND at least one profile exists.
+   * Callers use this to skip the fault path entirely, keeping the unfaulted
+   * hot path exactly what it was before this module existed.
+   */
+  isActive(): boolean {
+    return this.enabled && (this.defaultProfile !== undefined || this.profiles.size > 0);
+  }
+
+  getConfig(): DeviceFaultConfig {
+    return {
+      enabled: this.enabled,
+      ...(this.seed !== undefined ? { seed: this.seed } : {}),
+      ...(this.defaultProfile !== undefined ? { default: this.defaultProfile } : {}),
+      vehicles: Object.fromEntries(this.profiles),
+    };
+  }
+
+  getStatus(): DeviceFaultStatus {
+    let frozen = 0;
+    let teleporting = 0;
+    let dead = 0;
+    let held = 0;
+    for (const device of this.devices.values()) {
+      if (device.dead) dead++;
+      if (device.frozenFix) frozen++;
+      if (device.teleportOffset) teleporting++;
+      if (device.held) held++;
+    }
+    return {
+      enabled: this.enabled,
+      devices: this.devices.size,
+      frozen,
+      teleporting,
+      dead,
+      held,
+      queued: this.queue.length,
+      counts: { ...this.counts },
+    };
+  }
+
+  /** Profile governing a vehicle: its override, else the fleet-wide default. */
+  private profileFor(vehicleId: string): DeviceFaultProfile | undefined {
+    return this.profiles.get(vehicleId) ?? this.defaultProfile;
+  }
+
+  // ─── Configuration ────────────────────────────────────────────────
+
+  /**
+   * Applies a validated partial configuration and returns the resolved config.
+   *
+   * Toggling `enabled` or changing `seed` discards all per-device state: a
+   * re-enable that resumed a half-drained battery, or a reseed that kept the
+   * old RNG streams, would break the reproducibility guarantee this module
+   * exists to provide.
+   */
+  configure(patch: FaultConfigPatch): DeviceFaultConfig {
+    let stateInvalidated = false;
+
+    if (patch.enabled !== undefined && patch.enabled !== this.enabled) {
+      this.enabled = patch.enabled;
+      stateInvalidated = true;
+    }
+    if (patch.seed !== undefined && patch.seed !== this.seed) {
+      this.seed = patch.seed;
+      stateInvalidated = true;
+    }
+    if (patch.default !== undefined) {
+      this.defaultProfile = patch.default ?? undefined;
+    }
+    if (patch.vehicles !== undefined) {
+      for (const [id, profile] of Object.entries(patch.vehicles)) {
+        this.profiles.set(id, profile);
+      }
+    }
+
+    if (stateInvalidated) this.resetDevices();
+    return this.publishConfig();
+  }
+
+  setVehicleProfile(vehicleId: string, profile: DeviceFaultProfile): DeviceFaultConfig {
+    this.profiles.set(vehicleId, profile);
+    // Drop this device's latched state so the new profile starts from a clean
+    // device rather than inheriting a frozen window from the old one.
+    this.devices.delete(vehicleId);
+    return this.publishConfig();
+  }
+
+  /** Removes a per-vehicle override. Returns false when there was none. */
+  clearVehicleProfile(vehicleId: string): boolean {
+    if (!this.profiles.delete(vehicleId)) return false;
+    this.devices.delete(vehicleId);
+    this.publishConfig();
+    return true;
+  }
+
+  private publishConfig(): DeviceFaultConfig {
+    const config = this.getConfig();
+    this.emit("faults:config", config);
+    return config;
+  }
+
+  // ─── Reset ────────────────────────────────────────────────────────
+
+  /** Clears all device state and counters. Configuration is preserved. */
+  reset(): void {
+    this.resetDevices();
+    this.counts = zeroCounts();
+    this.droppedFromQueue = 0;
+  }
+
+  private resetDevices(): void {
+    this.devices.clear();
+    this.queue = [];
+  }
+
+  // ─── Telemetry ────────────────────────────────────────────────────
+
+  /**
+   * Shapes one device report. Returns the samples the device actually emits:
+   * usually one, none when the device is silent (dead battery, or a sample
+   * withheld by the out-of-order fault), several when it duplicates or
+   * releases a withheld sample after a newer one.
+   *
+   * The returned samples are also queued for the next adapter push, so the
+   * stream-shaped faults survive to the downstream sinks rather than being
+   * coalesced into one position per vehicle.
+   */
+  report(dto: VehicleDTO, now: number): VehicleDTO[] {
+    const profile = this.profileFor(dto.id);
+    if (!this.enabled || !profile) return [dto];
+
+    const device = this.device(dto.id, now);
+    const sample = this.shape(dto, device, profile, now, true);
+    if (sample === null) return [];
+    device.lastSample = sample;
+
+    const out: VehicleDTO[] = [];
+
+    // ── Out-of-order: withhold this sample so a newer one overtakes it ──
+    if (profile.outOfOrder) {
+      if (device.held && now >= device.held.releaseAt) {
+        // Newer sample first, then the older withheld one: the stream is now
+        // genuinely out of order by timestamp, which is the point.
+        out.push(sample, device.held.sample);
+        device.held = null;
+      } else if (!device.held && device.rng.next() < profile.outOfOrder.probability) {
+        device.held = {
+          sample: withFault(sample, "out_of_order"),
+          releaseAt: now + profile.outOfOrder.holdMs,
+        };
+        this.counts.out_of_order++;
+      } else {
+        out.push(sample);
+      }
+    } else {
+      out.push(sample);
+    }
+
+    // ── Duplicate: the device retransmits what it just sent ──
+    // Only when the fresh sample actually went out; there is nothing to
+    // retransmit in the tick where it was withheld.
+    if (
+      profile.duplicate &&
+      out[0] === sample &&
+      device.rng.next() < profile.duplicate.probability
+    ) {
+      const copies = 1 + Math.floor(device.rng.next() * profile.duplicate.maxCopies);
+      for (let i = 0; i < copies; i++) out.push(withFault(sample, "duplicate"));
+      this.counts.duplicate++;
+    }
+
+    this.enqueue(out);
+    return out;
+  }
+
+  /**
+   * The device's currently-reported fix, WITHOUT advancing any fault state.
+   *
+   * Used by the pollable surfaces (`GET /vehicles`, out-of-band `update`
+   * frames such as a fleet reassignment) so a frozen device does not appear to
+   * un-freeze whenever something other than the game loop reads it. Draws no
+   * random numbers, so it cannot perturb reproducibility.
+   */
+  view(dto: VehicleDTO, now: number): VehicleDTO {
+    const profile = this.profileFor(dto.id);
+    if (!this.enabled || !profile) return dto;
+    const device = this.devices.get(dto.id);
+    // Nothing reported yet: there is no device state to project.
+    if (!device) return dto;
+
+    const sample = this.shape(dto, device, profile, now, false);
+    if (sample !== null) return sample;
+    // Dead device: show the last fix it managed to send, flagged as dead, so a
+    // reader sees a stale position rather than a live one.
+    const last = device.lastSample ?? dto;
+    return withFault(
+      { ...last, faults: { ...(last.faults ?? { active: [] }), battery: 0 } },
+      "battery_dead"
+    );
+  }
+
+  /** Takes every queued faulted sample, in emission order, and clears the queue. */
+  drainTelemetry(): VehicleDTO[] {
+    if (this.queue.length === 0) return [];
+    const drained = this.queue;
+    this.queue = [];
+    return drained;
+  }
+
+  private enqueue(samples: VehicleDTO[]): void {
+    if (samples.length === 0) return;
+    this.queue.push(...samples);
+    const overflow = this.queue.length - MAX_TELEMETRY_QUEUE;
+    if (overflow > 0) {
+      // Drop-oldest: for position telemetry the newest fix supersedes stale ones.
+      this.queue.splice(0, overflow);
+      this.droppedFromQueue += overflow;
+    }
+  }
+
+  /** Number of samples dropped from the egress queue on overflow. */
+  getDroppedCount(): number {
+    return this.droppedFromQueue;
+  }
+
+  private device(vehicleId: string, now: number): DeviceState {
+    let device = this.devices.get(vehicleId);
+    if (device) return device;
+    device = {
+      rng: this.seed === undefined ? defaultRng : mulberry32(deviceSeed(this.seed, vehicleId)),
+      bornAt: now,
+      frozenUntil: 0,
+      frozenFix: null,
+      teleportUntil: 0,
+      teleportOffset: null,
+      held: null,
+      batteryPercent: 100,
+      dead: false,
+      lastSample: null,
+    };
+    this.devices.set(vehicleId, device);
+    return device;
+  }
+
+  /**
+   * Applies the position/time faults to one report.
+   *
+   * With `advance` true this is the device reporting: fault windows may open
+   * and RNG is drawn. With `advance` false it only projects state that is
+   * already latched, which is what {@link view} needs. Returns `null` when the
+   * device is silent (dead battery).
+   */
+  private shape(
+    dto: VehicleDTO,
+    device: DeviceState,
+    profile: DeviceFaultProfile,
+    now: number,
+    advance: boolean
+  ): VehicleDTO | null {
+    const active: DeviceFaultKind[] = [];
+
+    // ── Battery: a dead device emits nothing at all ──
+    let battery: number | undefined;
+    if (profile.battery) {
+      const hours = Math.max(0, now - device.bornAt) / 3_600_000;
+      battery = Math.max(
+        0,
+        profile.battery.initialPercent - profile.battery.drainPercentPerHour * hours
+      );
+      device.batteryPercent = battery;
+      if (battery <= profile.battery.dieAtPercent) {
+        if (advance && !device.dead) {
+          device.dead = true;
+          this.counts.battery_dead++;
+        }
+        return null;
+      }
+      device.dead = false;
+    } else {
+      device.batteryPercent = 100;
+      device.dead = false;
+    }
+
+    let position: Position = dto.position;
+    let speed = dto.speed;
+    let heading = dto.heading;
+
+    // ── Frozen GPS: the device replays its latched fix ──
+    if (profile.frozenGps) {
+      if (now < device.frozenUntil && device.frozenFix) {
+        position = device.frozenFix.position;
+        speed = device.frozenFix.speed;
+        heading = device.frozenFix.heading;
+        active.push("frozen_gps");
+      } else if (advance) {
+        device.frozenUntil = 0;
+        device.frozenFix = null;
+        if (device.rng.next() < profile.frozenGps.probability) {
+          const { minDurationMs, maxDurationMs } = profile.frozenGps;
+          const duration = minDurationMs + device.rng.next() * (maxDurationMs - minDurationMs);
+          device.frozenUntil = now + duration;
+          device.frozenFix = { position, speed, heading };
+          active.push("frozen_gps");
+          this.counts.frozen_gps++;
+        }
+      }
+    }
+
+    // ── Teleport / spoofing: the fix jumps somewhere it cannot be ──
+    if (profile.teleport) {
+      if (now < device.teleportUntil && device.teleportOffset) {
+        position = [
+          position[0] + device.teleportOffset.dLat,
+          position[1] + device.teleportOffset.dLon,
+        ];
+        active.push("teleport");
+      } else if (advance) {
+        device.teleportUntil = 0;
+        device.teleportOffset = null;
+        if (device.rng.next() < profile.teleport.probability) {
+          const bearing = device.rng.next() * 2 * Math.PI;
+          const distance = device.rng.next() * profile.teleport.radiusMeters;
+          const offset = metersToOffset(distance, bearing, position[0]);
+          device.teleportOffset = offset;
+          // holdMs 0 leaves `teleportUntil === now`, so the jump lasts exactly
+          // this one sample — a glitch rather than a spoofing session.
+          device.teleportUntil = now + profile.teleport.holdMs;
+          position = [position[0] + offset.dLat, position[1] + offset.dLon];
+          active.push("teleport");
+          this.counts.teleport++;
+        }
+      }
+    }
+
+    // ── Clock skew: the device stamps its fix with the wrong time ──
+    let timestamp = now;
+    let skewMs: number | undefined;
+    if (profile.clockSkew) {
+      const minutes = Math.max(0, now - device.bornAt) / 60_000;
+      const skew = profile.clockSkew.offsetMs + (profile.clockSkew.driftMsPerMinute ?? 0) * minutes;
+      if (skew !== 0) {
+        skewMs = Math.round(skew);
+        timestamp = now + skewMs;
+        active.push("clock_skew");
+        if (advance) this.counts.clock_skew++;
+      }
+    }
+
+    const faults: DeviceFaultInfo = {
+      active,
+      ...(battery !== undefined ? { battery: Math.round(battery * 10) / 10 } : {}),
+      ...(skewMs !== undefined ? { skewMs } : {}),
+    };
+
+    return { ...dto, position, speed, heading, timestamp, faults };
+  }
+}

--- a/apps/simulator/src/modules/faults/index.ts
+++ b/apps/simulator/src/modules/faults/index.ts
@@ -1,0 +1,9 @@
+export { DeviceFaultManager, FAULT_KINDS } from "./DeviceFaultManager";
+export type { DeviceFaultManagerOptions } from "./DeviceFaultManager";
+export {
+  faultConfigSchema,
+  faultProfileSchema,
+  faultProfilesEnvSchema,
+  parseFaultProfilesEnv,
+} from "./schema";
+export type { FaultConfigPatch, FaultProfilesEnv } from "./schema";

--- a/apps/simulator/src/modules/faults/schema.ts
+++ b/apps/simulator/src/modules/faults/schema.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import type { DeviceFaultProfile } from "../../types";
+
+/**
+ * Zod schemas for device fault profiles.
+ *
+ * ONE validation story: the same schemas validate the `FAULT_PROFILES` env var
+ * at startup and every runtime `POST /faults` / `PUT /faults/vehicles/:id`
+ * body. Objects are `.strict()` on purpose — a mistyped key in a fault profile
+ * would otherwise be silently ignored, and an operator would be left believing
+ * a fault was armed when it was not.
+ */
+
+const probability = z.number().min(0).max(1);
+const durationMs = z.number().int().min(0);
+
+export const faultProfileSchema = z
+  .object({
+    frozenGps: z
+      .object({
+        probability,
+        minDurationMs: durationMs,
+        maxDurationMs: durationMs,
+      })
+      .strict()
+      .refine((v) => v.maxDurationMs >= v.minDurationMs, {
+        message: "maxDurationMs must be >= minDurationMs",
+        path: ["maxDurationMs"],
+      })
+      .optional(),
+    clockSkew: z
+      .object({
+        offsetMs: z.number().int(),
+        driftMsPerMinute: z.number().optional(),
+      })
+      .strict()
+      .optional(),
+    duplicate: z
+      .object({
+        probability,
+        maxCopies: z.number().int().min(1).max(10),
+      })
+      .strict()
+      .optional(),
+    outOfOrder: z
+      .object({
+        probability,
+        holdMs: durationMs,
+      })
+      .strict()
+      .optional(),
+    battery: z
+      .object({
+        initialPercent: z.number().min(0).max(100),
+        drainPercentPerHour: z.number().min(0),
+        dieAtPercent: z.number().min(0).max(100),
+      })
+      .strict()
+      .optional(),
+    teleport: z
+      .object({
+        probability,
+        radiusMeters: z.number().min(0),
+        holdMs: durationMs,
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+/**
+ * Runtime reconfiguration body. Every field is optional so a caller can flip
+ * `enabled` without restating the profiles. `default: null` clears the
+ * fleet-wide profile (there is no other way to express "remove it").
+ */
+export const faultConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    seed: z.number().int().optional(),
+    default: faultProfileSchema.nullable().optional(),
+    vehicles: z.record(z.string().min(1), faultProfileSchema).optional(),
+  })
+  .strict();
+
+/** Shape of the `FAULT_PROFILES` env var: profiles only, no engine flags. */
+export const faultProfilesEnvSchema = z
+  .object({
+    default: faultProfileSchema.optional(),
+    vehicles: z.record(z.string().min(1), faultProfileSchema).optional(),
+  })
+  .strict();
+
+export type FaultConfigPatch = z.infer<typeof faultConfigSchema>;
+
+export interface FaultProfilesEnv {
+  default?: DeviceFaultProfile;
+  vehicles?: Record<string, DeviceFaultProfile>;
+}
+
+/**
+ * Parses and validates the `FAULT_PROFILES` env var. Throws (aborting startup)
+ * on malformed JSON or a schema violation: a fault layer that silently armed
+ * nothing because of a typo is worse than a boot failure.
+ */
+export function parseFaultProfilesEnv(raw: string): FaultProfilesEnv {
+  if (!raw.trim()) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`FAULT_PROFILES is not valid JSON: ${message}`);
+  }
+
+  const result = faultProfilesEnvSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  - ${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("\n");
+    throw new Error(`Invalid FAULT_PROFILES:\n${issues}`);
+  }
+  return result.data;
+}

--- a/apps/simulator/src/routes/faults.ts
+++ b/apps/simulator/src/routes/faults.ts
@@ -1,0 +1,55 @@
+import { Router } from "express";
+import type { RouteContext } from "./types";
+import { validateBody } from "../middleware/validate";
+import { faultConfigSchema, faultProfileSchema } from "../modules/faults";
+
+/**
+ * Routes for device-level fault injection: read and edit the fault layer's
+ * configuration at runtime, inspect live per-device state, and clear that state
+ * without touching the configuration.
+ *
+ * The bodies go through the SAME zod schemas that validate `FAULT_PROFILES` at
+ * startup, so there is one validation story rather than two.
+ */
+export function createFaultRoutes(ctx: RouteContext): Router {
+  const router = Router();
+  const { faults } = ctx.vehicleManager;
+
+  router.get("/faults", (_req, res) => {
+    res.json({ ...faults.getConfig(), status: faults.getStatus() });
+  });
+
+  router.post("/faults", validateBody(faultConfigSchema), (req, res) => {
+    res.json(faults.configure(req.body));
+  });
+
+  router.get("/faults/status", (_req, res) => {
+    res.json(faults.getStatus());
+  });
+
+  /**
+   * Clears every device's latched state (drained batteries, open frozen
+   * windows, withheld samples, queued telemetry) and the trigger counters,
+   * keeping the configuration. This is how a repeatable run is started over
+   * from a known device state.
+   */
+  router.post("/faults/reset", (_req, res) => {
+    faults.reset();
+    res.json(faults.getStatus());
+  });
+
+  router.put("/faults/vehicles/:id", validateBody(faultProfileSchema), (req, res) => {
+    res.json(faults.setVehicleProfile(req.params.id as string, req.body));
+  });
+
+  router.delete("/faults/vehicles/:id", (req, res) => {
+    const vehicleId = req.params.id as string;
+    if (!faults.clearVehicleProfile(vehicleId)) {
+      res.status(404).json({ error: `No fault profile for vehicle "${vehicleId}"` });
+      return;
+    }
+    res.json(faults.getConfig());
+  });
+
+  return router;
+}

--- a/apps/simulator/src/routes/index.ts
+++ b/apps/simulator/src/routes/index.ts
@@ -6,6 +6,7 @@ export { createRecordingRoutes } from "./recording";
 export { createReplayRoutes } from "./replay";
 export { createFleetRoutes } from "./fleets";
 export { createJobRoutes } from "./jobs";
+export { createFaultRoutes } from "./faults";
 export { createAnalyticsRoutes } from "./analytics";
 export { createScenarioRoutes } from "./scenarios";
 export { createStateRoutes } from "./state";

--- a/apps/simulator/src/setup/eventWiring.ts
+++ b/apps/simulator/src/setup/eventWiring.ts
@@ -135,6 +135,9 @@ export function wireEvents(ctx: EventWiringContext): {
   incidentManager.on("incident:created", (data) => broadcaster.broadcast("incident:created", data));
   incidentManager.on("incident:cleared", (data) => broadcaster.broadcast("incident:cleared", data));
   vehicleManager.on("vehicle:rerouted", (data) => broadcaster.broadcast("vehicle:rerouted", data));
+  // Device fault config changed (a runtime edit through /faults) — push it so an
+  // operator UI does not have to poll to learn which faults are armed.
+  vehicleManager.faults.on("faults:config", (data) => broadcaster.broadcast("faults:config", data));
 
   // ─── Traffic congestion snapshot + geofence checks every 2 seconds ──
   const trafficBroadcastInterval = setInterval(() => {

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -27,6 +27,11 @@ export type {
   FleetAnalytics,
   AnalyticsSnapshot,
   SubscribeFilter,
+  DeviceFaultKind,
+  DeviceFaultInfo,
+  DeviceFaultProfile,
+  DeviceFaultConfig,
+  DeviceFaultStatus,
 } from "@moveet/shared-types";
 
 // Re-export ExportVehicle under its old name for backwards compatibility

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -165,6 +165,32 @@ const envObjectSchema = z.object({
    * more (smaller) sector buckets.
    */
   SECTORS_N: z.coerce.number().int().min(1).default(10),
+
+  /**
+   * Device-level fault injection (frozen GPS, clock skew, duplicates,
+   * reordering, battery death, teleport/spoofing). Opt-in: with this off, or
+   * with no profile configured, telemetry is byte-for-byte what it was.
+   */
+  FAULTS_ENABLED: z
+    .enum(["true", "false", "1", "0", ""])
+    .default("false")
+    .transform((v) => v === "true" || v === "1"),
+
+  /**
+   * Seed for the per-device fault RNG streams. Every fault type is reproducible
+   * only when this is set; unset means `Math.random` per device.
+   */
+  FAULT_SEED: z.preprocess(
+    (v) => (v === "" || v === undefined ? undefined : v),
+    z.coerce.number().int().optional()
+  ),
+
+  /**
+   * Fault profiles as a JSON string: `{"default":{...},"vehicles":{"id":{...}}}`.
+   * Validated by `modules/faults/schema.ts` (the same schema the REST API uses);
+   * a malformed value aborts startup rather than silently arming nothing.
+   */
+  FAULT_PROFILES: z.string().default(""),
 });
 
 export const envSchema = envObjectSchema
@@ -224,6 +250,9 @@ function buildConfig(env: EnvConfig) {
     pathfindCooldownMs: env.PATHFIND_COOLDOWN_MS,
     maxSyncBackoffMs: env.MAX_SYNC_BACKOFF_MS,
     sectorsN: env.SECTORS_N,
+    faultsEnabled: env.FAULTS_ENABLED,
+    faultSeed: env.FAULT_SEED,
+    faultProfiles: env.FAULT_PROFILES,
   } as const;
 }
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -22,6 +22,117 @@ export interface VehicleDTO {
   speed: number;
   heading: number;
   fleetId?: string;
+  /**
+   * Device fix timestamp (epoch ms), as reported by the simulated device.
+   * Present only for a vehicle whose device has a fault profile — a skewed
+   * device clock is only observable if the sample carries its own timestamp.
+   */
+  timestamp?: number;
+  /**
+   * Device faults that shaped this sample. Present only for a vehicle whose
+   * device has a fault profile, so the default (fault-free) wire shape is
+   * unchanged.
+   */
+  faults?: DeviceFaultInfo;
+}
+
+// ─── Device fault injection ─────────────────────────────────────────
+// Faults are properties of the simulated DEVICE (a GPS tracker that freezes,
+// skews its clock, retransmits, or runs out of battery). This is a different
+// concern from the adapter's realism engine, which models the TRANSPORT
+// (correlated GPS noise, connectivity dropouts, jittered cadence). The two
+// compose: a device fault is injected before the telemetry ever leaves the
+// simulator, so it is visible on the WebSocket feed and in the adapter push.
+
+export type DeviceFaultKind =
+  | "frozen_gps"
+  | "clock_skew"
+  | "duplicate"
+  | "out_of_order"
+  | "battery_dead"
+  | "teleport";
+
+/** Fault annotation carried by a single telemetry sample. */
+export interface DeviceFaultInfo {
+  /** Fault kinds that shaped this sample. Empty when the device reported clean. */
+  active: DeviceFaultKind[];
+  /** Remaining battery (%), when the profile models a battery. */
+  battery?: number;
+  /** Applied clock offset (ms): sample timestamp minus true emit time. */
+  skewMs?: number;
+}
+
+/** Per-fault tuning for one simulated device. Every fault group is opt-in. */
+export interface DeviceFaultProfile {
+  /** The device latches its last fix and keeps reporting it while frozen. */
+  frozenGps?: {
+    /** Chance per report of entering a frozen window, 0-1. */
+    probability: number;
+    minDurationMs: number;
+    maxDurationMs: number;
+  };
+  /** The device's clock is wrong, and optionally drifts as it runs. */
+  clockSkew?: {
+    offsetMs: number;
+    /** Extra skew accumulated per minute of device uptime. */
+    driftMsPerMinute?: number;
+  };
+  /** The device retransmits a sample it has already sent. */
+  duplicate?: {
+    probability: number;
+    /** Maximum extra copies emitted alongside the original. */
+    maxCopies: number;
+  };
+  /** The device withholds a sample so a newer one overtakes it on the wire. */
+  outOfOrder?: {
+    probability: number;
+    /** How long the withheld sample is held before it is released. */
+    holdMs: number;
+  };
+  /** The device runs on a battery and goes silent when it dies. */
+  battery?: {
+    initialPercent: number;
+    drainPercentPerHour: number;
+    /** Level at or below which the device stops reporting entirely. */
+    dieAtPercent: number;
+  };
+  /** The reported position jumps somewhere it cannot be (bad fix / spoofing). */
+  teleport?: {
+    probability: number;
+    radiusMeters: number;
+    /** How long the bogus offset persists. 0 = a single-sample glitch. */
+    holdMs: number;
+  };
+}
+
+/** The fault layer's whole configuration, as read and written over REST/WS. */
+export interface DeviceFaultConfig {
+  enabled: boolean;
+  /**
+   * Seed for the per-device RNG streams. Omitted = unseeded (`Math.random`);
+   * every fault type is reproducible only when a seed is set.
+   */
+  seed?: number;
+  /** Applied to every vehicle without an explicit profile. */
+  default?: DeviceFaultProfile;
+  /** Per-vehicle overrides keyed by vehicle id. Replaces the default outright. */
+  vehicles: Record<string, DeviceFaultProfile>;
+}
+
+/** Live per-device fault state, for observability. */
+export interface DeviceFaultStatus {
+  enabled: boolean;
+  /** Devices the fault layer currently holds state for. */
+  devices: number;
+  frozen: number;
+  teleporting: number;
+  dead: number;
+  /** Samples withheld by the out-of-order fault, awaiting release. */
+  held: number;
+  /** Faulted samples queued for the next adapter push. */
+  queued: number;
+  /** Cumulative per-kind trigger counts since the last fault-layer reset. */
+  counts: Record<DeviceFaultKind, number>;
 }
 
 /**

--- a/packages/shared-types/src/ws.ts
+++ b/packages/shared-types/src/ws.ts
@@ -20,6 +20,7 @@ import type {
   Waypoint,
   SubscribeFilter,
   BoundingBox,
+  DeviceFaultConfig,
 } from "./index";
 
 // ─── UI/producer-shared payload shapes ──────────────────────────────
@@ -212,6 +213,8 @@ export interface WsMessageMap {
   "scenario:resumed": ScenarioEventPayload;
   "scenario:completed": ScenarioEventPayload;
   "scenario:stopped": ScenarioEventPayload;
+  /** Device fault-injection configuration changed (startup or runtime edit). */
+  "faults:config": DeviceFaultConfig;
 }
 
 /** Every data-carrying WS message type. */
@@ -269,6 +272,7 @@ const DATA_MESSAGE_TYPES: ReadonlySet<string> = new Set<WsDataMessageType>([
   "scenario:resumed",
   "scenario:completed",
   "scenario:stopped",
+  "faults:config",
 ]);
 
 /**


### PR DESCRIPTION
Closes `fleetsim-all-mxzc.3`.

## What

Faults are now properties of a **simulated device** rather than of the outbound pipe. The adapter's realism engine degrades telemetry at egress and models the **transport** (correlated GPS noise, connectivity dropouts, jittered cadence); this layer models the **device** and injects faults before telemetry ever leaves the simulator, so a consumer sees them on the WebSocket feed *and* in the adapter push. The two compose; neither replaces the other.

Six fault kinds, each opt-in per profile:

| Fault | What the device does |
|---|---|
| `frozen_gps` | Latches its last fix and replays it for a window while the vehicle moves on |
| `clock_skew` | Stamps fixes with a wrong (and optionally drifting) clock |
| `duplicate` | Retransmits a sample it already sent, timestamp and all |
| `out_of_order` | Withholds a sample so a newer one overtakes it on the wire |
| `battery_dead` | Drains a battery and goes completely silent when it dies |
| `teleport` | Reports a position it cannot be at, as a glitch or a sustained spoofing window |

## Acceptance criteria

- **Per-vehicle profiles configurable at runtime** — `POST /faults` (partial patch; `default: null` clears the fleet-wide profile), `PUT`/`DELETE /faults/vehicles/:id`, plus `GET /faults`, `GET /faults/status`, `POST /faults/reset` and a `faults:config` WS frame. Bodies go through the same zod schemas that validate `FAULT_PROFILES` at startup.
- **Reproducible under a fixed seed** — each device draws from its *own* `mulberry32` stream seeded from `(seed, vehicleId)`, so a fault sequence does not depend on fleet size or tick order. Toggling `enabled` or changing `seed` discards per-device state so a reseeded run starts from a clean device.
- **Observable in the outgoing telemetry stream** — the `update` frames carry the device's sample (one report can become several frames, or none); `GET /vehicles` serves each device's currently-reported fix; the adapter push carries the samples **in emission order** with duplicates and reordering intact, each with its own device `timestamp` and the applied faults under `metadata.faults`.

## Notes

- **Off by default** (`FAULTS_ENABLED`, `FAULT_SEED`, `FAULT_PROFILES`). With no profile armed the DTO is forwarded untouched and no `timestamp`/`faults` fields appear on the wire.
- Unknown keys in a profile are **rejected** rather than ignored — a mistyped fault name would otherwise leave an operator believing a fault was armed when it was not. A malformed `FAULT_PROFILES` aborts startup for the same reason.
- The adapter egress queue is bounded drop-oldest (10k samples), so a run with no adapter attached cannot grow it without limit.
- The broadcaster still coalesces to the latest frame per vehicle per 100 ms flush, so duplicates and reordering are best observed on the adapter push. Documented in the simulator README.
- No UI surface in this PR; the WS `faults:config` frame and the shared types are in place for one.

## Verification

- `apps/simulator`: 87 test files / 1834 tests pass; coverage gate passes (new `modules/faults` at 100% lines, 96% branches).
- Repo-wide `turbo type-check` green; adapter, ui, shared-types, network, server-kit suites green.
- `biome lint` and `biome format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)