### PR TITLE
feat: wire jobs + device faults into the UI, and fix the job lifecycle they ride on

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ SLA breach along the way.
 | `POST`   | `/jobs/:id/cancel`   | Cancel a live job and release its vehicle         |
 | `DELETE` | `/jobs/:id`          | Remove a finished job from the board              |
 
+Naming a `vehicleId` that is not in the fleet answers `404`; one that is already
+carrying another job answers `409` naming that job. A vehicle taken off its job by
+something else (an operator dispatch, a scenario) re-queues the job if the load was
+not yet collected, and fails it — rather than reporting a delivery — if it was.
+
+In the UI the board is the Fleet dock panel's **Jobs** tab: place a pickup/dropoff
+with two map clicks, watch the SLA countdown, reassign a job that has not been
+picked up, and see which unit is carrying what in the vehicle list and inspector.
+
 ### Device faults
 
 Faults injected as properties of the simulated **device** (frozen GPS, clock skew,
@@ -259,6 +268,12 @@ shape and per-fault semantics.
 | `POST`   | `/faults/reset`          | Clear latched device state, keeping the config      |
 | `PUT`    | `/faults/vehicles/:id`   | Set one vehicle's fault profile                     |
 | `DELETE` | `/faults/vehicles/:id`   | Remove one vehicle's fault profile                  |
+
+The UI surfaces this as **Monitor → Faults**: arm the layer, set a seed, apply a
+profile preset fleet-wide or to one device, watch the live device counters, and
+clear latched state. Vehicles whose device is misbehaving carry a fault badge in
+the vehicle list, and the inspector shows the active faults, remaining battery and
+clock skew for the selected one.
 
 ### Incidents
 
@@ -314,7 +329,7 @@ Connect to `ws://localhost:5010`. On connect the server sends a `status` and `op
 | `status`           | server → client | `SimulationStatus` (running, ready, interval)             |
 | `options`          | server → client | Current `StartOptions`                                    |
 | `heatzones`        | server → client | `HeatZoneFeature[]`                                       |
-| `direction`        | server → client | Active dispatch assignment                                |
+| `direction`        | server → client | Active route + ETA, with a `reason` (`dispatch`/`waypoints`/`random`/`reroute`) |
 | `waypoint:reached` | server → client | Vehicle reached a waypoint                                |
 | `route:completed`  | server → client | Vehicle completed its full route                          |
 | `reset`            | server → client | Simulation was reset                                      |

--- a/apps/simulator/openapi.yaml
+++ b/apps/simulator/openapi.yaml
@@ -1536,6 +1536,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "404":
+          description: The named `vehicleId` is not in the fleet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: The named `vehicleId` is already carrying another job
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VehicleJobConflict"
 
   /jobs/{id}/assign:
     post:
@@ -1572,6 +1584,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "404":
+          description: The named `vehicleId` is not in the fleet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: >
+            The named `vehicleId` is already carrying a DIFFERENT job (naming the
+            vehicle that already holds this one is accepted).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VehicleJobConflict"
 
   /jobs/{id}/cancel:
     post:
@@ -2317,6 +2343,25 @@ components:
       properties:
         error:
           type: string
+
+    VehicleJobConflict:
+      type: object
+      required: [error, job]
+      description: A vehicle was named for a job while it is already carrying another one.
+      properties:
+        error:
+          type: string
+        job:
+          type: object
+          description: The job that currently holds the vehicle.
+          required: [id, reference, status]
+          properties:
+            id:
+              type: string
+            reference:
+              type: string
+            status:
+              $ref: "#/components/schemas/JobStatus"
 
     ValidationError:
       type: object

--- a/apps/simulator/src/__tests__/JobManager.test.ts
+++ b/apps/simulator/src/__tests__/JobManager.test.ts
@@ -32,6 +32,14 @@ class FakeVehicles extends EventEmitter implements JobVehicleGateway {
     if (this.unroutable.has(vehicleId)) {
       return { vehicleId, status: "error", error: "No route found for leg 0" };
     }
+    // RouteManager emits the direction from inside this call, before returning.
+    this.emit("direction", {
+      vehicleId,
+      route: { edges: [], distance: 12 },
+      waypoints,
+      currentWaypointIndex: 0,
+      reason: "waypoints",
+    });
     return {
       vehicleId,
       status: "ok",
@@ -55,6 +63,24 @@ class FakeVehicles extends EventEmitter implements JobVehicleGateway {
 
   finishRoute(vehicleId: string): void {
     this.emit("route:completed", { vehicleId });
+  }
+
+  /** Someone else (operator dispatch, scenario) points the vehicle elsewhere. */
+  redispatch(vehicleId: string): void {
+    this.emit("direction", {
+      vehicleId,
+      route: { edges: [], distance: 3 },
+      reason: "dispatch",
+    });
+  }
+
+  /** Same trip, new path around an incident. */
+  reroute(vehicleId: string): void {
+    this.emit("direction", {
+      vehicleId,
+      route: { edges: [], distance: 9 },
+      reason: "reroute",
+    });
   }
 }
 
@@ -150,6 +176,42 @@ describe("JobManager", () => {
 
       expect(job.strategy).toBe("manual");
       expect(job.vehicleId).toBe("far");
+    });
+
+    it("names the vehicle and the job a manual assignment is queued behind", async () => {
+      const first = await manager.createJob({
+        pickup: PICKUP,
+        dropoff: DROPOFF,
+        vehicleId: "near",
+      });
+      const queued = await manager.createJob({
+        pickup: PICKUP,
+        dropoff: DROPOFF,
+        vehicleId: "near",
+      });
+
+      expect(queued.status).toBe("pending");
+      expect(queued.error).toBe(`Waiting for Unit near to finish ${first.reference}`);
+    });
+
+    it("fails a manual job whose vehicle has left the fleet", async () => {
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF, vehicleId: "ghost" });
+
+      expect(job.status).toBe("failed");
+      expect(job.error).toBe("Vehicle ghost is no longer in the fleet");
+    });
+
+    it("fails a manual job whose named vehicle cannot reach the pickup", async () => {
+      vehicles.unroutable.add("far");
+
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF, vehicleId: "far" });
+      expect(job.status).toBe("pending");
+
+      // No fallback candidate exists under `manual`, so the retry is terminal.
+      await manager.sweep();
+
+      expect(manager.getJob(job.id)?.status).toBe("failed");
+      expect(manager.getJob(job.id)?.error).toBe("Unit far could not reach this pickup");
     });
 
     it("never assigns a vehicle that already holds a job", async () => {
@@ -292,6 +354,84 @@ describe("JobManager", () => {
       expect(requeued?.status).toBe("pending");
       expect(requeued?.vehicleId).toBeUndefined();
       expect(requeued?.error).toBe("Vehicle was re-dispatched before pickup; job re-queued");
+    });
+  });
+
+  /**
+   * A job's vehicle can be taken off it at any moment by something that isn't
+   * the job board: an operator dispatch, a scenario, a re-route. The job must
+   * say so rather than sitting en_route behind a vehicle that is driving
+   * somewhere else — or, worse, reporting a delivery that never happened.
+   */
+  describe("vehicle taken off a job", () => {
+    it("re-queues a job whose vehicle is dispatched away before the pickup", async () => {
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+      expect(job.status).toBe("en_route");
+
+      vehicles.redispatch("near");
+
+      const requeued = manager.getJob(job.id);
+      expect(requeued?.status).toBe("pending");
+      expect(requeued?.vehicleId).toBeUndefined();
+      expect(requeued?.error).toBe("Vehicle was re-dispatched before pickup; job re-queued");
+    });
+
+    it("fails a job whose vehicle is dispatched away with the load on board", async () => {
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+      vehicles.arriveAtPickup("near");
+      expect(manager.getJob(job.id)?.status).toBe("on_scene");
+
+      vehicles.redispatch("near");
+
+      const failed = manager.getJob(job.id);
+      expect(failed?.status).toBe("failed");
+      expect(failed?.error).toBe("Vehicle was re-dispatched mid-trip; the load was not delivered");
+      // The unit that had it stays on the record, but is free for new work.
+      expect(failed?.vehicleId).toBe("near");
+      expect(manager.jobForVehicleId("near")).toBeUndefined();
+    });
+
+    it("does not mistake the job's own assignment for a re-dispatch", async () => {
+      // The assignment route emits a `waypoints` direction from inside
+      // findAndSetWaypointRoutes; that is the job's own doing.
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+      expect(manager.getJob(job.id)?.status).toBe("en_route");
+      expect(manager.jobForVehicleId("near")?.id).toBe(job.id);
+    });
+
+    it("treats an incident re-route as the same trip", async () => {
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+
+      vehicles.reroute("near");
+
+      expect(manager.getJob(job.id)?.status).toBe("en_route");
+      expect(manager.jobForVehicleId("near")?.id).toBe(job.id);
+    });
+
+    it("ignores route changes for vehicles that hold no job", async () => {
+      await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+      const before = updates.length;
+
+      vehicles.redispatch("far");
+
+      expect(updates).toHaveLength(before);
+    });
+  });
+
+  describe("jobForVehicleId", () => {
+    it("reports the job a vehicle is currently holding", async () => {
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+
+      expect(manager.jobForVehicleId("near")?.id).toBe(job.id);
+      expect(manager.jobForVehicleId("far")).toBeUndefined();
+      expect(manager.jobForVehicleId("nobody")).toBeUndefined();
+    });
+
+    it("stops reporting a vehicle once its job is cancelled", async () => {
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+      manager.cancelJob(job.id);
+
+      expect(manager.jobForVehicleId("near")).toBeUndefined();
     });
   });
 

--- a/apps/simulator/src/__tests__/RouteManagerWaypointHandover.test.ts
+++ b/apps/simulator/src/__tests__/RouteManagerWaypointHandover.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { RouteManager } from "../modules/RouteManager";
+import { VehicleRegistry } from "../modules/VehicleRegistry";
+import { TrafficManager } from "../modules/TrafficManager";
+import { FleetManager } from "../modules/FleetManager";
+import { RoadNetwork } from "../modules/RoadNetwork";
+import { config } from "../utils/config";
+import type { Vehicle, StartOptions } from "../types";
+import path from "path";
+
+vi.mock("../utils/logger", () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
+
+const DEFAULT_OPTIONS: StartOptions = {
+  updateInterval: 500,
+  minSpeed: 20,
+  maxSpeed: 60,
+  speedVariation: 0,
+  acceleration: 5,
+  deceleration: 7,
+  turnThreshold: 45,
+  heatZoneSpeedFactor: 0.5,
+  adapterSyncInterval: 1000,
+};
+
+/**
+ * Handover between the legs of a multi-stop route, and between a multi-stop
+ * route and whatever replaces it.
+ *
+ * These are the seams the job lifecycle rides on: `JobManager` reads
+ * `waypoint:reached` as "the load was collected" and `route:completed` as "the
+ * load was delivered", so a leg handover that loses the remaining stops — or a
+ * replaced route that still emits the old route's waypoint events — makes the
+ * job board describe a trip that never happened.
+ */
+describe("RouteManager multi-stop handover", () => {
+  let network: RoadNetwork;
+  let registry: VehicleRegistry;
+  let routeManager: RouteManager;
+  let origVehicleCount: number;
+  let origAdapterURL: string;
+
+  beforeEach(() => {
+    origVehicleCount = config.vehicleCount;
+    origAdapterURL = config.adapterURL;
+    (config as any).vehicleCount = 2;
+    (config as any).adapterURL = "";
+
+    network = new RoadNetwork(FIXTURE_PATH);
+    registry = new VehicleRegistry(network, new FleetManager());
+    routeManager = new RouteManager(network, registry, new TrafficManager());
+    routeManager.getClockHour = () => 12;
+    registry.loadFromData();
+  });
+
+  afterEach(async () => {
+    await network.shutdownWorkers();
+    (config as any).vehicleCount = origVehicleCount;
+    (config as any).adapterURL = origAdapterURL;
+  });
+
+  function firstVehicle(): Vehicle {
+    return registry.getAll().values().next().value!;
+  }
+
+  /** Puts a vehicle somewhere both fixture destinations are routable from. */
+  function placeOnRoutableEdge(vehicle: Vehicle): void {
+    const startNode = network.findNearestNode([45.502, -73.567]);
+    vehicle.currentEdge = startNode.connections[0];
+    vehicle.position = vehicle.currentEdge.start.coordinates;
+    vehicle.progress = 0;
+  }
+
+  describe("dwell at an intermediate stop", () => {
+    it("resumes the remaining legs instead of wandering off", async () => {
+      const vehicle = firstVehicle();
+      placeOnRoutableEdge(vehicle);
+
+      const result = await routeManager.findAndSetWaypointRoutes(vehicle.id, [
+        { position: [45.5029, -73.5661], label: "pickup", dwellTime: 5 },
+        { position: [45.5026, -73.5664], label: "dropoff", dwellTime: 0 },
+      ]);
+      expect(result.status).toBe("ok");
+
+      // Mid-route state after the first stop: the next leg is already loaded and
+      // the vehicle is holding at the stop for its dwell.
+      const legRoute = routeManager.getRoute(vehicle.id);
+      expect(legRoute).toBeDefined();
+      vehicle.dwellUntil = Date.now() - 1;
+
+      const random = vi.spyOn(routeManager, "setRandomDestination");
+      routeManager.updateVehicle(vehicle, 500, DEFAULT_OPTIONS);
+
+      expect(random).not.toHaveBeenCalled();
+      expect(vehicle.dwellUntil).toBeUndefined();
+      // The remaining leg — and the waypoints that describe it — survive.
+      expect(routeManager.getRoute(vehicle.id)).toBe(legRoute);
+      expect(vehicle.waypoints).toHaveLength(2);
+    });
+
+    it("still wanders when the dwell ends with no route left", () => {
+      const vehicle = firstVehicle();
+      placeOnRoutableEdge(vehicle);
+      routeManager.deleteRoute(vehicle.id);
+      vehicle.dwellUntil = Date.now() - 1;
+
+      const random = vi.spyOn(routeManager, "setRandomDestination").mockImplementation(() => {});
+      routeManager.updateVehicle(vehicle, 500, DEFAULT_OPTIONS);
+
+      expect(random).toHaveBeenCalledWith(vehicle.id);
+    });
+  });
+
+  describe("a single-destination dispatch replaces a multi-stop route", () => {
+    it("drops the abandoned stops so their events can never fire", async () => {
+      const vehicle = firstVehicle();
+      placeOnRoutableEdge(vehicle);
+
+      await routeManager.findAndSetWaypointRoutes(vehicle.id, [
+        { position: [45.5029, -73.5661], label: "pickup", dwellTime: 0 },
+        { position: [45.5026, -73.5664], label: "dropoff", dwellTime: 0 },
+      ]);
+      expect(vehicle.waypoints).toHaveLength(2);
+
+      const dispatched = await routeManager.findAndSetRoutes(vehicle.id, [45.5026, -73.5664]);
+      expect(dispatched.status).toBe("ok");
+
+      expect(vehicle.waypoints).toBeUndefined();
+      expect(vehicle.currentWaypointIndex).toBeUndefined();
+
+      // Completing the dispatched route must not replay the old trip's stops.
+      const events: string[] = [];
+      routeManager.on("waypoint:reached", () => events.push("waypoint:reached"));
+      routeManager.on("route:completed", () => events.push("route:completed"));
+      (routeManager as any).handleRouteCompleted(vehicle);
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe("direction reason", () => {
+    it("labels a job/multi-stop route, a dispatch and a wander differently", async () => {
+      const vehicle = firstVehicle();
+      placeOnRoutableEdge(vehicle);
+
+      const reasons: (string | undefined)[] = [];
+      routeManager.on("direction", (payload) => reasons.push(payload.reason));
+
+      await routeManager.findAndSetWaypointRoutes(vehicle.id, [
+        { position: [45.5029, -73.5661], label: "pickup", dwellTime: 0 },
+      ]);
+      await routeManager.findAndSetRoutes(vehicle.id, [45.5026, -73.5664]);
+
+      expect(reasons).toEqual(["waypoints", "dispatch"]);
+    });
+  });
+});

--- a/apps/simulator/src/__tests__/routes/jobs.test.ts
+++ b/apps/simulator/src/__tests__/routes/jobs.test.ts
@@ -32,7 +32,9 @@ function createMockContext(): RouteContext {
     network: {
       getBoundingBox: vi.fn().mockReturnValue(BBOX),
     } as unknown as RouteContext["network"],
-    vehicleManager: {} as RouteContext["vehicleManager"],
+    vehicleManager: {
+      hasVehicle: vi.fn().mockReturnValue(true),
+    } as unknown as RouteContext["vehicleManager"],
     fleetManager: {} as RouteContext["fleetManager"],
     jobManager: {
       getJobs: vi.fn().mockReturnValue([job()]),
@@ -40,6 +42,7 @@ function createMockContext(): RouteContext {
       reassignJob: vi.fn().mockResolvedValue(job({ vehicleId: "v2" })),
       cancelJob: vi.fn().mockReturnValue(job({ status: "cancelled" })),
       deleteJob: vi.fn(),
+      jobForVehicleId: vi.fn().mockReturnValue(undefined),
     } as unknown as RouteContext["jobManager"],
     incidentManager: {} as RouteContext["incidentManager"],
     recordingManager: {} as RouteContext["recordingManager"],
@@ -152,6 +155,39 @@ describe("Job routes", () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBe("Validation failed");
     });
+
+    it("404s a manual job naming a vehicle that does not exist", async () => {
+      vi.mocked(ctx.vehicleManager.hasVehicle).mockReturnValue(false);
+
+      const res = await request(app)
+        .post("/jobs")
+        .send({ pickup: IN_BOUNDS, dropoff: { lat: -1.31, lng: 36.9 }, vehicleId: "ghost" });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Vehicle "ghost" not found');
+      expect(ctx.jobManager.createJob).not.toHaveBeenCalled();
+    });
+
+    it("409s a manual job naming a vehicle that is already on a job", async () => {
+      vi.mocked(ctx.jobManager.jobForVehicleId).mockReturnValue(job({ id: "job-9" }));
+
+      const res = await request(app)
+        .post("/jobs")
+        .send({ pickup: IN_BOUNDS, dropoff: { lat: -1.31, lng: 36.9 }, vehicleId: "v2" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('Vehicle "v2" is already on JOB-0001');
+      expect(res.body.job).toEqual({ id: "job-9", reference: "JOB-0001", status: "en_route" });
+      expect(ctx.jobManager.createJob).not.toHaveBeenCalled();
+    });
+
+    it("does not look up a vehicle when none was named", async () => {
+      await request(app)
+        .post("/jobs")
+        .send({ pickup: IN_BOUNDS, dropoff: { lat: -1.31, lng: 36.9 } });
+
+      expect(ctx.vehicleManager.hasVehicle).not.toHaveBeenCalled();
+    });
   });
 
   describe("POST /jobs/:id/assign", () => {
@@ -179,6 +215,33 @@ describe("Job routes", () => {
 
       expect(res.status).toBe(400);
       expect(ctx.jobManager.reassignJob).not.toHaveBeenCalled();
+    });
+
+    it("404s an unknown vehicle", async () => {
+      vi.mocked(ctx.vehicleManager.hasVehicle).mockReturnValue(false);
+
+      const res = await request(app).post("/jobs/job-1/assign").send({ vehicleId: "ghost" });
+
+      expect(res.status).toBe(404);
+      expect(ctx.jobManager.reassignJob).not.toHaveBeenCalled();
+    });
+
+    it("409s a vehicle already on a DIFFERENT job", async () => {
+      vi.mocked(ctx.jobManager.jobForVehicleId).mockReturnValue(job({ id: "job-9" }));
+
+      const res = await request(app).post("/jobs/job-1/assign").send({ vehicleId: "v2" });
+
+      expect(res.status).toBe(409);
+      expect(ctx.jobManager.reassignJob).not.toHaveBeenCalled();
+    });
+
+    it("allows re-assigning to the vehicle already on THIS job", async () => {
+      vi.mocked(ctx.jobManager.jobForVehicleId).mockReturnValue(job({ id: "job-1" }));
+
+      const res = await request(app).post("/jobs/job-1/assign").send({ vehicleId: "v2" });
+
+      expect(res.status).toBe(200);
+      expect(ctx.jobManager.reassignJob).toHaveBeenCalledWith("job-1", { vehicleId: "v2" });
     });
   });
 

--- a/apps/simulator/src/modules/JobManager.ts
+++ b/apps/simulator/src/modules/JobManager.ts
@@ -8,6 +8,7 @@ import type {
   JobStatus,
   Position,
   RouteCompletedPayload,
+  VehicleDirection,
   VehicleDTO,
   Waypoint,
   WaypointReachedPayload,
@@ -33,6 +34,7 @@ export interface JobVehicleGateway {
   ): Promise<{ etaSeconds: number; distanceKm: number } | null>;
   on(event: "waypoint:reached", listener: (payload: WaypointReachedPayload) => void): unknown;
   on(event: "route:completed", listener: (payload: RouteCompletedPayload) => void): unknown;
+  on(event: "direction", listener: (payload: VehicleDirection) => void): unknown;
 }
 
 /**
@@ -102,6 +104,7 @@ export class JobManager extends EventEmitter {
     super();
     this.vehicles.on("waypoint:reached", (payload) => this.onWaypointReached(payload));
     this.vehicles.on("route:completed", (payload) => this.onRouteCompleted(payload));
+    this.vehicles.on("direction", (payload) => this.onDirection(payload));
   }
 
   // ─── Public API ───────────────────────────────────────────────────
@@ -112,6 +115,16 @@ export class JobManager extends EventEmitter {
 
   getJob(id: string): JobDTO | undefined {
     return this.jobs.get(id);
+  }
+
+  /**
+   * The job a vehicle is currently holding, if any. This is the "is this unit
+   * busy" question the REST layer asks before accepting a manual assignment,
+   * and the UI asks to label a vehicle with the job it is carrying.
+   */
+  jobForVehicleId(vehicleId: string): JobDTO | undefined {
+    const job = this.jobForVehicle(vehicleId);
+    return job ? { ...job } : undefined;
   }
 
   /**
@@ -261,9 +274,19 @@ export class JobManager extends EventEmitter {
 
     try {
       const state = this.requireRuntime(id);
-      const { vehicle, rosterSize } = await this.pickVehicle(job, state);
+      const { vehicle, rosterSize, blocked } = await this.pickVehicle(job, state);
 
       if (!vehicle) {
+        // A named vehicle that has left the fleet is never coming back, and the
+        // manual path never grows `attempted` — so without this the job would
+        // pend forever behind a unit that no longer exists.
+        if (blocked?.fatal) {
+          job.status = "failed";
+          job.error = blocked.message;
+          this.publish(job);
+          this.maybeStopSweep();
+          return;
+        }
         // A small fleet exhausts its candidates before MAX_ASSIGN_ATTEMPTS, so
         // the give-up point is whichever comes first — otherwise a two-vehicle
         // fleet that both fail to route would retry the same pair forever.
@@ -277,7 +300,7 @@ export class JobManager extends EventEmitter {
         }
         // Nothing free yet. Say so once — the sweep retries every second and
         // re-emitting the same message each time is pure noise.
-        const message = "Waiting for an available vehicle";
+        const message = blocked?.message ?? "Waiting for an available vehicle";
         if (job.error !== message) {
           job.error = message;
           this.publish(job);
@@ -340,7 +363,12 @@ export class JobManager extends EventEmitter {
   private async pickVehicle(
     job: JobDTO,
     state: JobRuntime
-  ): Promise<{ vehicle: VehicleDTO | null; rosterSize: number }> {
+  ): Promise<{
+    vehicle: VehicleDTO | null;
+    rosterSize: number;
+    /** Why no vehicle came back, when the reason is specific enough to say. */
+    blocked?: { message: string; fatal: boolean };
+  }> {
     const roster = this.vehicles.getVehicles();
     const available = roster.filter((v) => {
       if (this.busyVehicles.has(v.id)) return false;
@@ -352,7 +380,33 @@ export class JobManager extends EventEmitter {
 
     if (job.strategy === "manual") {
       const wanted = state.manualVehicleId;
-      return { vehicle: available.find((v) => v.id === wanted) ?? null, rosterSize };
+      const picked = available.find((v) => v.id === wanted) ?? null;
+      if (picked || !wanted) return { vehicle: picked, rosterSize };
+
+      // Say WHICH vehicle the job is waiting for, and distinguish "busy" (worth
+      // waiting for) from "gone" (never resolving).
+      const inRoster = roster.find((v) => v.id === wanted);
+      if (!inRoster) {
+        return {
+          vehicle: null,
+          rosterSize,
+          blocked: { message: `Vehicle ${wanted} is no longer in the fleet`, fatal: true },
+        };
+      }
+      if (state.attempted.has(wanted)) {
+        // The operator named this unit and it could not route to the pickup.
+        // There is no second candidate to fall back to under `manual`.
+        return {
+          vehicle: null,
+          rosterSize,
+          blocked: { message: `${inRoster.name} could not reach this pickup`, fatal: true },
+        };
+      }
+      const holder = this.jobForVehicle(wanted);
+      const message = holder
+        ? `Waiting for ${inRoster.name} to finish ${holder.reference}`
+        : `Waiting for ${inRoster.name}`;
+      return { vehicle: null, rosterSize, blocked: { message, fatal: false } };
     }
 
     if (available.length === 0) return { vehicle: null, rosterSize };
@@ -406,6 +460,55 @@ export class JobManager extends EventEmitter {
     }, this.options.pickupDwellSeconds * 1000);
     timer.unref?.();
     state.dwellTimer = timer;
+  }
+
+  /**
+   * A route change for a vehicle that is holding a job.
+   *
+   * `JobManager` sets exactly one route per assignment, labelled with the job's
+   * reference; any other route change means something else — an operator
+   * dispatch, a scenario, a replay — has taken the unit off its job. Waiting for
+   * `route:completed` to notice is not enough: that fires wherever the new route
+   * happens to end, which for a job past its pickup would read as a delivery.
+   */
+  private onDirection(payload: VehicleDirection): void {
+    // A reroute is the same trip on a new path; a payload with no reason is a
+    // snapshot of an existing route (reset), not a change.
+    if (!payload.reason || payload.reason === "reroute") return;
+
+    const job = this.jobForVehicle(payload.vehicleId);
+    if (!job) return;
+    if (payload.reason === "waypoints" && this.ownsWaypoints(job, payload.waypoints)) return;
+
+    const state = this.runtime.get(job.id);
+    if (state) this.clearDwell(state);
+
+    if (job.status === "on_scene" || job.status === "transporting") {
+      // The load is on board and the unit is no longer taking it anywhere. This
+      // is a failure, not a re-queue: re-running the pickup leg would collect a
+      // load that has already been collected.
+      job.status = "failed";
+      job.error = "Vehicle was re-dispatched mid-trip; the load was not delivered";
+      this.releaseVehicle(job);
+      this.publish(job);
+      this.maybeStopSweep();
+      return;
+    }
+
+    this.releaseVehicle(job);
+    job.status = "pending";
+    job.assignedAt = undefined;
+    job.etaToPickupSeconds = undefined;
+    job.etaToDropoffSeconds = undefined;
+    job.routeDistanceKm = undefined;
+    job.error = "Vehicle was re-dispatched before pickup; job re-queued";
+    this.publish(job);
+    this.ensureSweep();
+  }
+
+  /** Whether a multi-stop route is the one this job asked for. */
+  private ownsWaypoints(job: JobDTO, waypoints?: Waypoint[]): boolean {
+    return waypoints?.[0]?.label === `${job.reference} pickup`;
   }
 
   private onRouteCompleted(payload: RouteCompletedPayload): void {

--- a/apps/simulator/src/modules/RouteManager.ts
+++ b/apps/simulator/src/modules/RouteManager.ts
@@ -192,6 +192,9 @@ export class RouteManager extends EventEmitter {
         if (!this.registry.has(vehicleId)) return;
 
         if (route) {
+          // Same reasoning as findAndSetRoutes: a wander destination replaces a
+          // multi-stop route, so its legs must not outlive it.
+          this.clearWaypointState(vehicle);
           this.setRouteFor(vehicleId, route);
           vehicle.edgeIndex = -1;
           if (this.unroutedAttempts.delete(vehicleId)) {
@@ -201,6 +204,7 @@ export class RouteManager extends EventEmitter {
             vehicleId,
             route: this.getSerializedRoute(vehicleId, route),
             eta: utils.estimateRouteDuration(route, vehicle.speed),
+            reason: "random",
           });
         }
       })
@@ -413,7 +417,12 @@ export class RouteManager extends EventEmitter {
     if (vehicle.dwellUntil) {
       if (Date.now() < vehicle.dwellUntil) return;
       vehicle.dwellUntil = undefined;
-      this.setRandomDestination(vehicle.id);
+      // A dwell at an INTERMEDIATE stop already has the next leg loaded (see
+      // handleRouteCompleted), so the vehicle resumes its trip. Only a dwell
+      // with nothing left to drive — the end of a route, where the route was
+      // deleted — means the vehicle needs somewhere new to go. Wandering off
+      // here regardless is what used to strand a job's dropoff leg.
+      if (!this.routes.has(vehicle.id)) this.setRandomDestination(vehicle.id);
       return;
     }
 
@@ -639,11 +648,17 @@ export class RouteManager extends EventEmitter {
 
     const eta = utils.estimateRouteDuration(route, vehicle.speed);
 
+    // A single-destination route replaces any multi-stop one outright. Without
+    // this the stale legs survive: `handleRouteCompleted` would take the
+    // multi-stop branch when THIS route finishes, emit a `waypoint:reached` for
+    // the abandoned trip, and put the vehicle back onto its next leg.
+    this.clearWaypointState(vehicle);
     this.setRouteFor(vehicleId, route);
     this.emit("direction", {
       vehicleId,
       route: this.getSerializedRoute(vehicleId, route),
       eta,
+      reason: "dispatch",
     });
     const previousEdgeId = vehicle.currentEdge.id;
     this.traffic.leave(previousEdgeId);
@@ -766,6 +781,7 @@ export class RouteManager extends EventEmitter {
       eta,
       waypoints,
       currentWaypointIndex: 0,
+      reason: "waypoints",
     });
 
     return {
@@ -865,6 +881,7 @@ export class RouteManager extends EventEmitter {
             vehicleId,
             route: serialized,
             eta: utils.estimateRouteDuration(newRoute, vehicle.speed),
+            reason: "reroute",
           });
         }
       })

--- a/apps/simulator/src/routes/faults.ts
+++ b/apps/simulator/src/routes/faults.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import type { DeviceFaultState } from "@moveet/shared-types";
 import type { RouteContext } from "./types";
 import { validateBody } from "../middleware/validate";
 import { faultConfigSchema, faultProfileSchema } from "../modules/faults";
@@ -16,7 +17,8 @@ export function createFaultRoutes(ctx: RouteContext): Router {
   const { faults } = ctx.vehicleManager;
 
   router.get("/faults", (_req, res) => {
-    res.json({ ...faults.getConfig(), status: faults.getStatus() });
+    const state: DeviceFaultState = { ...faults.getConfig(), status: faults.getStatus() };
+    res.json(state);
   });
 
   router.post("/faults", validateBody(faultConfigSchema), (req, res) => {

--- a/apps/simulator/src/routes/jobs.ts
+++ b/apps/simulator/src/routes/jobs.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, type Response } from "express";
 import type { RouteContext } from "./types";
 import { asyncHandler } from "./helpers";
 import { validateBody } from "../middleware/validate";
@@ -10,7 +10,38 @@ import { assignJobSchema, createJobSchema } from "../middleware/schemas";
  */
 export function createJobRoutes(ctx: RouteContext): Router {
   const router = Router();
-  const { jobManager, network } = ctx;
+  const { jobManager, network, vehicleManager } = ctx;
+
+  /**
+   * Rejects a named vehicle that cannot take the job.
+   *
+   * The zod schemas check the shape of `vehicleId`, not that it refers to a
+   * vehicle that exists and is free. Without this the job is accepted and then
+   * sits pending forever behind a unit that will never become available, which
+   * reads to an operator as the simulator quietly ignoring their dispatch.
+   */
+  function rejectUnassignableVehicle(
+    vehicleId: string,
+    res: Response,
+    /** Job being (re)assigned — a vehicle already on THIS job is not a conflict. */
+    forJobId?: string
+  ): boolean {
+    if (!vehicleManager.hasVehicle(vehicleId)) {
+      res.status(404).json({ error: `Vehicle "${vehicleId}" not found` });
+      return true;
+    }
+    const holder = jobManager.jobForVehicleId(vehicleId);
+    if (holder && holder.id !== forJobId) {
+      // The conflicting job goes under its own key rather than `details`, which
+      // everywhere else in this API is an array of validation strings.
+      res.status(409).json({
+        error: `Vehicle "${vehicleId}" is already on ${holder.reference}`,
+        job: { id: holder.id, reference: holder.reference, status: holder.status },
+      });
+      return true;
+    }
+    return false;
+  }
 
   /** Stops outside the loaded road network can never be routed to. */
   function stopOutOfBounds(lat: number, lng: number): boolean {
@@ -46,6 +77,7 @@ export function createJobRoutes(ctx: RouteContext): Router {
         res.status(400).json({ error: "Validation failed", details: errors });
         return;
       }
+      if (req.body.vehicleId && rejectUnassignableVehicle(req.body.vehicleId, res)) return;
 
       const job = await jobManager.createJob(req.body);
       res.status(201).json(job);
@@ -56,8 +88,10 @@ export function createJobRoutes(ctx: RouteContext): Router {
     "/jobs/:id/assign",
     validateBody(assignJobSchema),
     asyncHandler(async (req, res) => {
+      const jobId = req.params.id as string;
+      if (req.body.vehicleId && rejectUnassignableVehicle(req.body.vehicleId, res, jobId)) return;
       try {
-        const job = await jobManager.reassignJob(req.params.id as string, req.body);
+        const job = await jobManager.reassignJob(jobId, req.body);
         res.json(job);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -24,6 +24,7 @@ import { useIncidents } from "./hooks/useIncidents";
 import { useJobs } from "./hooks/useJobs";
 import { useJobDraft } from "./hooks/useJobDraft";
 import { useJobsAutoReveal } from "./hooks/useJobsAutoReveal";
+import { useFaults } from "./hooks/useFaults";
 import { useRecording } from "./hooks/useRecording";
 import { useReplay } from "./hooks/useReplay";
 import { useDispatchFlow } from "./hooks/useDispatchFlow";
@@ -125,6 +126,18 @@ export default function App() {
 
   const recording = useRecording();
   const analytics = useAnalytics();
+
+  // ─── Device faults ──────────────────────────────────────────────
+  // Status counters are polled only while the Monitor drawer is open; the
+  // configuration itself arrives on `faults:config` either way, so the dock
+  // badge stays honest with the panel closed.
+  const faults = useFaults(dockNavigation.openCluster === "monitor");
+  const faultsEnabled = faults.config?.enabled ?? false;
+  const toggleFaults = useCallback(
+    () => void faults.configure({ enabled: !faultsEnabled }),
+    [faults, faultsEnabled]
+  );
+  const clearFaultState = useCallback(() => void faults.reset(), [faults]);
 
   // ─── Geofencing ─────────────────────────────────────────────────
   const geofences = useGeofenceManager({
@@ -316,6 +329,9 @@ export default function App() {
         jobPlacementActive: jobDraft.active,
         onStartJob: jobDraft.start,
         onCancelJobPlacement: jobDraft.cancel,
+        faultsArmed: faultsEnabled,
+        onToggleFaults: toggleFaults,
+        onClearFaultState: clearFaultState,
         onCreateRandomIncident: incidents.createRandom,
         onStartGeofenceDrawing: geofences.startDrawing,
         heatzones: heatzoneEditor,
@@ -345,6 +361,9 @@ export default function App() {
       jobDraft.active,
       jobDraft.start,
       jobDraft.cancel,
+      faultsEnabled,
+      toggleFaults,
+      clearFaultState,
       incidents.createRandom,
       geofences.startDrawing,
       heatzoneEditor,
@@ -411,6 +430,7 @@ export default function App() {
             )}
             <ModeBanner
               mode={interaction.mode}
+              jobPlacementStage={jobDraft.stage}
               dispatchState={dispatch.dispatchState}
               selectedCount={dispatch.selectedForDispatch.length}
               stopCount={dispatch.assignments.reduce((sum, a) => sum + a.waypoints.length, 0)}
@@ -464,6 +484,9 @@ export default function App() {
                 draft: jobDraft,
                 onCancelJob: jobs.cancelJob,
                 onDeleteJob: jobs.deleteJob,
+                onAssignJob: jobs.assignJob,
+                vehicles,
+                jobByVehicleId: jobs.jobByVehicleId,
                 error: jobs.error,
               }}
               incidents={{
@@ -471,6 +494,11 @@ export default function App() {
                 createRandom: incidents.createRandom,
                 remove: incidents.remove,
                 error: incidents.error,
+              }}
+              faults={{
+                faults,
+                vehicles,
+                selectedVehicleId: filters.selected,
               }}
               geofences={{
                 fences: geofences.fences,
@@ -501,6 +529,7 @@ export default function App() {
               vehicle={selectedVehicle}
               poi={selectedPoi ?? undefined}
               fleet={selectedVehicle ? vehicleFleetMap.get(selectedVehicle.id) : undefined}
+              job={selectedVehicle ? jobs.jobByVehicleId.get(selectedVehicle.id) : undefined}
               onClose={closeInspector}
             />
             <CreateZoneDialog

--- a/apps/ui/src/Controls/Adapter/adapterPanelSwitch.test.tsx
+++ b/apps/ui/src/Controls/Adapter/adapterPanelSwitch.test.tsx
@@ -128,6 +128,9 @@ function dockProps(): Omit<DockProps, "navigation"> {
       draft: { active: false } as unknown as JobsPanelProps["draft"],
       onCancelJob: async () => {},
       onDeleteJob: async () => {},
+      onAssignJob: async () => {},
+      vehicles: [],
+      jobByVehicleId: new Map(),
       error: null,
     },
 
@@ -136,6 +139,21 @@ function dockProps(): Omit<DockProps, "navigation"> {
       createRandom: async () => {},
       remove: async () => {},
       error: null,
+    },
+    // The dock bar reads only the fault status counters (the Monitor badge);
+    // the panel itself is opened in one test, where an unarmed layer is enough.
+    faults: {
+      faults: {
+        config: null,
+        status: null,
+        loading: false,
+        error: null,
+        configure: async () => {},
+        setVehicleProfile: async () => {},
+        clearVehicleProfile: async () => {},
+        reset: async () => {},
+      },
+      vehicles: [],
     },
     geofences: {
       fences: [],

--- a/apps/ui/src/Controls/FaultsPanel.test.tsx
+++ b/apps/ui/src/Controls/FaultsPanel.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FaultsPanel from "./FaultsPanel";
+import type { UseFaults } from "@/hooks/useFaults";
+import type { DeviceFaultConfig, DeviceFaultStatus } from "@/types";
+import { FAULT_PRESETS } from "@/lib/faultPresets";
+
+function status(overrides: Partial<DeviceFaultStatus> = {}): DeviceFaultStatus {
+  return {
+    enabled: true,
+    devices: 2,
+    frozen: 0,
+    teleporting: 0,
+    dead: 0,
+    held: 0,
+    queued: 0,
+    counts: {
+      frozen_gps: 0,
+      clock_skew: 0,
+      duplicate: 0,
+      out_of_order: 0,
+      battery_dead: 0,
+      teleport: 0,
+    },
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<DeviceFaultConfig> = {}): DeviceFaultConfig {
+  return { enabled: false, vehicles: {}, ...overrides };
+}
+
+function faultsApi(overrides: Partial<UseFaults> = {}): UseFaults {
+  return {
+    config: config(),
+    status: status(),
+    loading: false,
+    error: null,
+    configure: vi.fn().mockResolvedValue(undefined),
+    setVehicleProfile: vi.fn().mockResolvedValue(undefined),
+    clearVehicleProfile: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const VEHICLES = [
+  { id: "v1", name: "Unit 1" },
+  { id: "v2", name: "Unit 2" },
+];
+
+function renderPanel(overrides: Partial<UseFaults> = {}) {
+  const faults = faultsApi(overrides);
+  render(<FaultsPanel faults={faults} vehicles={VEHICLES} />);
+  return faults;
+}
+
+describe("FaultsPanel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows a loading state before the first snapshot", () => {
+    render(
+      <FaultsPanel
+        faults={faultsApi({ config: null, status: null, loading: true })}
+        vehicles={VEHICLES}
+      />
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(/Reading fault configuration/i);
+  });
+
+  it("arms and disarms the layer through the switch", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel();
+
+    await user.click(screen.getByRole("switch", { name: /enable device fault injection/i }));
+
+    expect(faults.configure).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it("reads as armed when the layer is enabled", () => {
+    renderPanel({ config: config({ enabled: true }) });
+
+    expect(screen.getByRole("switch", { name: /enable device fault injection/i })).toBeChecked();
+    expect(screen.getByText("Armed")).toBeInTheDocument();
+  });
+
+  it("warns when armed with nothing to inject", () => {
+    renderPanel({ config: config({ enabled: true }) });
+
+    expect(screen.getByText(/no profile is set/i)).toBeInTheDocument();
+  });
+
+  it("does not warn when a profile is armed", () => {
+    renderPanel({
+      config: config({ enabled: true, default: { duplicate: { probability: 0.2, maxCopies: 2 } } }),
+    });
+
+    expect(screen.queryByText(/no profile is set/i)).not.toBeInTheDocument();
+  });
+
+  it("commits a seed on blur, not on every keystroke", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel();
+
+    const seed = screen.getByLabelText(/fault rng seed/i);
+    await user.type(seed, "77");
+    expect(faults.configure).not.toHaveBeenCalled();
+
+    await user.tab();
+    expect(faults.configure).toHaveBeenCalledWith({ seed: 77 });
+  });
+
+  it("does not re-send a seed that has not changed", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel({ config: config({ seed: 42 }) });
+
+    const seed = screen.getByLabelText(/fault rng seed/i);
+    await user.click(seed);
+    await user.tab();
+
+    expect(faults.configure).not.toHaveBeenCalled();
+  });
+
+  it("applies a fleet-wide preset", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel();
+    const preset = FAULT_PRESETS[0];
+
+    await user.click(screen.getByRole("button", { name: preset.label }));
+
+    expect(faults.configure).toHaveBeenCalledWith({ default: preset.profile });
+  });
+
+  it("marks the fleet-wide preset currently in force", () => {
+    const preset = FAULT_PRESETS[1];
+    renderPanel({ config: config({ default: preset.profile }) });
+
+    expect(screen.getByRole("button", { name: preset.label })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("clears the fleet-wide profile with an explicit null", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel({ config: config({ default: FAULT_PRESETS[0].profile }) });
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(faults.configure).toHaveBeenCalledWith({ default: null });
+  });
+
+  it("arms a preset on one device", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel();
+
+    await user.selectOptions(screen.getByLabelText(/vehicle to arm/i), "v2");
+    await user.selectOptions(screen.getByLabelText(/fault preset to arm/i), FAULT_PRESETS[2].id);
+
+    expect(faults.setVehicleProfile).toHaveBeenCalledWith("v2", FAULT_PRESETS[2].profile);
+  });
+
+  it("pre-selects the inspected vehicle", () => {
+    render(<FaultsPanel faults={faultsApi()} vehicles={VEHICLES} selectedVehicleId="v2" />);
+
+    expect(screen.getByLabelText(/vehicle to arm/i)).toHaveValue("v2");
+  });
+
+  it("lists per-device profiles by vehicle name and clears one", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel({
+      config: config({ vehicles: { v1: { clockSkew: { offsetMs: -45_000 } } } }),
+    });
+
+    // "Unit 1" also appears as an option in the arming select, so identify the
+    // profile row by the description only it carries.
+    expect(screen.getByText(/skew -45s/)).toBeInTheDocument();
+    expect(screen.getAllByText("Unit 1").length).toBeGreaterThan(1);
+
+    await user.click(screen.getByRole("button", { name: /clear fault profile for Unit 1/i }));
+    expect(faults.clearVehicleProfile).toHaveBeenCalledWith("v1");
+  });
+
+  it("falls back to the vehicle id when the roster does not know it", () => {
+    renderPanel({
+      config: config({ vehicles: { ghost: { duplicate: { probability: 0.5, maxCopies: 2 } } } }),
+    });
+
+    expect(screen.getByText("ghost")).toBeInTheDocument();
+  });
+
+  it("clears latched device state without touching the config", async () => {
+    const user = userEvent.setup();
+    const faults = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /clear state/i }));
+
+    expect(faults.reset).toHaveBeenCalled();
+    expect(faults.configure).not.toHaveBeenCalled();
+  });
+
+  it("shows live device counters", () => {
+    renderPanel({ status: status({ devices: 5, frozen: 2, dead: 1 }) });
+
+    const frozen = screen.getByText("frozen").closest("div") as HTMLElement;
+    expect(within(frozen).getByText("2")).toBeInTheDocument();
+    const dead = screen.getByText("dead").closest("div") as HTMLElement;
+    expect(within(dead).getByText("1")).toBeInTheDocument();
+  });
+
+  it("summarises per-kind trigger counts once faults have fired", () => {
+    renderPanel({
+      status: status({ counts: { ...status().counts, frozen_gps: 4, teleport: 1 } }),
+    });
+
+    expect(screen.getByText(/frozen 4/)).toBeInTheDocument();
+    expect(screen.getByText(/spoofed 1/)).toBeInTheDocument();
+    expect(screen.queryByText(/No faults injected yet/)).not.toBeInTheDocument();
+  });
+
+  it("says so when nothing has fired yet", () => {
+    renderPanel();
+
+    expect(screen.getByText(/No faults injected yet/)).toBeInTheDocument();
+  });
+
+  it("surfaces a hook error", () => {
+    renderPanel({ error: "simulator unreachable" });
+
+    expect(screen.getByText("simulator unreachable")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/Controls/FaultsPanel.tsx
+++ b/apps/ui/src/Controls/FaultsPanel.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Button, Switch, SquaredButton } from "@/components/Inputs";
+import { Input } from "@/components/ui/input";
+import { Eyebrow, LList, LRow, Tag, mono, type SevTone } from "@/Dock/DockPanelKit";
+import { PanelEmptyState, PanelErrorState, PanelLoadingState } from "./PanelPrimitives";
+import { WarningTriangle } from "@/components/Icons";
+import { FAULT_KIND_LABEL, FAULT_PRESETS, describeProfile, matchPreset } from "@/lib/faultPresets";
+import type { UseFaults } from "@/hooks/useFaults";
+import type { DeviceFaultKind, DeviceFaultStatus } from "@/types";
+
+/** The counters worth a headline; the rest read as per-kind trigger totals. */
+const LIVE_METRICS: { key: keyof DeviceFaultStatus; label: string; tone: SevTone }[] = [
+  { key: "devices", label: "devices", tone: "idle" },
+  { key: "frozen", label: "frozen", tone: "warn" },
+  { key: "teleporting", label: "spoofing", tone: "warn" },
+  { key: "dead", label: "dead", tone: "error" },
+  { key: "held", label: "held", tone: "idle" },
+  { key: "queued", label: "queued", tone: "idle" },
+];
+
+export interface FaultsPanelProps {
+  faults: UseFaults;
+  /** Roster used to name profile rows and to arm a specific device. */
+  vehicles: { id: string; name: string }[];
+  /** Currently selected vehicle, pre-selected in the per-device arming control. */
+  selectedVehicleId?: string;
+}
+
+/**
+ * Device fault injection, as an operator surface.
+ *
+ * Faults are properties of the simulated DEVICE — a tracker that freezes, skews
+ * its clock, retransmits, or dies — so this panel is about arming misbehaviour
+ * and watching it happen, not about the vehicles themselves.
+ *
+ * Profiles are authored from presets rather than a form over all six fault
+ * groups: the useful operator question is "make this device flaky", and a
+ * 15-field nested form answers a question nobody asked. The REST API stays open
+ * for the arbitrary case.
+ */
+export default function FaultsPanel({ faults, vehicles, selectedVehicleId }: FaultsPanelProps) {
+  const { config, status, loading, error } = faults;
+  const [targetId, setTargetId] = useState<string>("");
+  const [seedDraft, setSeedDraft] = useState<string | null>(null);
+
+  const target = targetId || selectedVehicleId || vehicles[0]?.id || "";
+
+  const nameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const v of vehicles) map.set(v.id, v.name);
+    return map;
+  }, [vehicles]);
+
+  const vehicleProfiles = Object.entries(config?.vehicles ?? {});
+  const activePreset = matchPreset(config?.default);
+  const enabled = config?.enabled ?? false;
+  // Armed but with nothing to inject: worth saying, since the counters will sit
+  // at zero and look like a broken feature.
+  const nothingArmed = enabled && !config?.default && vehicleProfiles.length === 0;
+
+  if (loading && !config)
+    return <PanelLoadingState>Reading fault configuration…</PanelLoadingState>;
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-col gap-2.5 px-[15px] pb-3 pt-1">
+        <div className="flex items-center justify-between gap-2">
+          <Eyebrow>Fault layer</Eyebrow>
+          <label className="flex items-center gap-2 text-[10.5px] text-muted-foreground">
+            <span>{enabled ? "Armed" : "Off"}</span>
+            <Switch
+              isSelected={enabled}
+              onChange={(next) => void faults.configure({ enabled: next })}
+              aria-label="Enable device fault injection"
+            />
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label className="flex flex-1 items-center gap-2 text-[10.5px] text-muted-foreground">
+            <span className="whitespace-nowrap" title="Seeded runs are reproducible">
+              Seed
+            </span>
+            <Input
+              type="number"
+              value={seedDraft ?? (config?.seed != null ? String(config.seed) : "")}
+              placeholder="unseeded"
+              aria-label="Fault RNG seed"
+              onChange={(e) => setSeedDraft(e.target.value)}
+              onBlur={() => {
+                if (seedDraft === null) return;
+                const parsed = Number(seedDraft);
+                setSeedDraft(null);
+                if (!Number.isInteger(parsed)) return;
+                if (parsed === config?.seed) return;
+                void faults.configure({ seed: parsed });
+              }}
+              className={cn(mono, "h-7 w-24 text-[11px]")}
+            />
+          </label>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void faults.reset()}
+            title="Clear dead batteries, frozen windows and withheld samples — keeps the configuration"
+          >
+            Clear state
+          </Button>
+        </div>
+
+        {nothingArmed && (
+          <p className="rounded-md border border-status-warn/35 bg-status-warn/[0.07] px-2.5 py-1.5 text-[11px] text-foreground">
+            Armed, but no profile is set — pick a fleet-wide preset or arm one device below.
+          </p>
+        )}
+      </div>
+
+      {error ? (
+        <div className="px-[15px] pb-2">
+          <PanelErrorState>{error}</PanelErrorState>
+        </div>
+      ) : null}
+
+      {/* ── Live device state ─────────────────────────────────────── */}
+      <div className="flex flex-col gap-2 px-[15px] pb-3">
+        <Eyebrow>Live</Eyebrow>
+        <div className="grid grid-cols-3 gap-1.5">
+          {LIVE_METRICS.map(({ key, label, tone }) => {
+            const value = (status?.[key] as number | undefined) ?? 0;
+            return (
+              <div
+                key={key}
+                className={cn(
+                  "flex flex-col rounded-md border border-border-soft px-2 py-1.5",
+                  value > 0 && tone === "error" && "border-status-error/40",
+                  value > 0 && tone === "warn" && "border-status-warn/40"
+                )}
+              >
+                <span
+                  className={cn(
+                    mono,
+                    "text-[13px] font-semibold",
+                    value === 0
+                      ? "text-muted-foreground"
+                      : tone === "error"
+                        ? "text-status-error"
+                        : tone === "warn"
+                          ? "text-status-warn"
+                          : "text-foreground"
+                  )}
+                >
+                  {value}
+                </span>
+                <span className="text-[9.5px] uppercase tracking-wider text-muted-foreground">
+                  {label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        {status && <TriggerCounts counts={status.counts} />}
+      </div>
+
+      {/* ── Fleet-wide profile ────────────────────────────────────── */}
+      <div className="flex flex-col gap-2 px-[15px] pb-3">
+        <div className="flex items-center justify-between gap-2">
+          <Eyebrow>Fleet default</Eyebrow>
+          {config?.default && (
+            <button
+              type="button"
+              className="text-[10.5px] text-muted-foreground underline-offset-2 hover:text-status-error hover:underline"
+              onClick={() => void faults.configure({ default: null })}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {FAULT_PRESETS.map((preset) => {
+            const active = activePreset?.id === preset.id;
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                title={preset.hint}
+                aria-pressed={active}
+                onClick={() => void faults.configure({ default: preset.profile })}
+                className={cn(
+                  "rounded-md px-2 py-[3px] text-[10.5px] font-medium",
+                  "transition-[color,background-color] duration-fast ease-standard",
+                  active
+                    ? "bg-foreground/[0.06] text-foreground shadow-[inset_0_0_0_1px_var(--color-border-soft)]"
+                    : "text-muted-foreground hover:bg-foreground/[0.035] hover:text-foreground"
+                )}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className={cn(mono, "text-[10.5px] text-muted-foreground/60")}>
+          {config?.default ? describeProfile(config.default) : "No fleet-wide profile"}
+        </p>
+      </div>
+
+      {/* ── Per-device profiles ───────────────────────────────────── */}
+      <div className="flex flex-col gap-2 px-[15px] pb-2">
+        <Eyebrow>Per device</Eyebrow>
+        <div className="flex items-center gap-1.5">
+          <select
+            value={target}
+            aria-label="Vehicle to arm"
+            onChange={(e) => setTargetId(e.target.value)}
+            className={cn(
+              "h-7 min-w-0 flex-1 rounded-md border border-border bg-transparent px-1.5 text-[11px] text-foreground",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            )}
+          >
+            {vehicles.length === 0 && <option value="">No vehicles</option>}
+            {vehicles.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+          <select
+            defaultValue=""
+            aria-label="Fault preset to arm"
+            disabled={!target}
+            onChange={(e) => {
+              const preset = FAULT_PRESETS.find((p) => p.id === e.target.value);
+              if (!preset || !target) return;
+              void faults.setVehicleProfile(target, preset.profile);
+              e.target.value = "";
+            }}
+            className={cn(
+              "h-7 rounded-md border border-border bg-transparent px-1.5 text-[11px] text-foreground",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              "disabled:cursor-not-allowed disabled:opacity-40"
+            )}
+          >
+            <option value="">Arm preset…</option>
+            {FAULT_PRESETS.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {vehicleProfiles.length === 0 ? (
+        <div className="px-[15px] pb-3">
+          <PanelEmptyState icon={<WarningTriangle />}>
+            No device has its own profile — every vehicle uses the fleet default
+          </PanelEmptyState>
+        </div>
+      ) : (
+        <LList className="px-2 pb-2.5 pt-0">
+          {vehicleProfiles.map(([vehicleId, profile]) => (
+            <LRow
+              key={vehicleId}
+              tone="warn"
+              primary={nameById.get(vehicleId) ?? vehicleId}
+              secondary={describeProfile(profile)}
+              meta={
+                <SquaredButton
+                  className="flex-shrink-0"
+                  icon={<span aria-hidden="true">×</span>}
+                  variant="ghost"
+                  tone="danger"
+                  aria-label={`Clear fault profile for ${nameById.get(vehicleId) ?? vehicleId}`}
+                  title="Clear this device's profile"
+                  onClick={() => void faults.clearVehicleProfile(vehicleId)}
+                />
+              }
+            />
+          ))}
+        </LList>
+      )}
+    </div>
+  );
+}
+
+/** Cumulative per-kind trigger totals since the last state clear. */
+function TriggerCounts({ counts }: { counts: Record<DeviceFaultKind, number> }) {
+  const fired = (Object.entries(counts) as [DeviceFaultKind, number][]).filter(([, n]) => n > 0);
+  if (fired.length === 0) {
+    return (
+      <p className={cn(mono, "text-[10.5px] text-muted-foreground/60")}>No faults injected yet</p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {fired.map(([kind, n]) => (
+        <Tag key={kind} tone="warn">
+          {FAULT_KIND_LABEL[kind]} {n}
+        </Tag>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/Controls/JobsPanel.reassign.test.tsx
+++ b/apps/ui/src/Controls/JobsPanel.reassign.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import JobsPanel, { type JobsPanelProps } from "./JobsPanel";
+import type { JobDTO, JobStatus } from "@/types";
+
+function job(overrides: Partial<JobDTO> = {}): JobDTO {
+  const createdAt = 1_000_000;
+  return {
+    id: "job-1",
+    reference: "JOB-0001",
+    status: "en_route" as JobStatus,
+    pickup: { position: [-1.29, 36.82] },
+    dropoff: { position: [-1.3, 36.84] },
+    strategy: "nearest",
+    vehicleId: "v1",
+    vehicleName: "Unit 1",
+    createdAt,
+    slaSeconds: 900,
+    slaDeadline: createdAt + 900_000,
+    slaBreached: false,
+    ...overrides,
+  };
+}
+
+const VEHICLES = [
+  { id: "v1", name: "Unit 1" },
+  { id: "v2", name: "Unit 2" },
+  { id: "v3", name: "Unit 3" },
+];
+
+function renderPanel(overrides: Partial<JobsPanelProps> = {}) {
+  const jobs = overrides.jobs ?? [job()];
+  const onAssignJob = vi.fn().mockResolvedValue(undefined);
+  const props: JobsPanelProps = {
+    jobs,
+    counts: { total: jobs.length, live: jobs.length, queued: 0, breached: 0 },
+    draft: {
+      stage: "idle",
+      active: false,
+      pickup: null,
+      strategy: "nearest",
+      slaMinutes: 15,
+      submitting: false,
+      setStrategy: vi.fn(),
+      setSlaMinutes: vi.fn(),
+      start: vi.fn(),
+      cancel: vi.fn(),
+      handleMapClick: vi.fn(),
+    },
+    onCancelJob: vi.fn().mockResolvedValue(undefined),
+    onDeleteJob: vi.fn().mockResolvedValue(undefined),
+    onAssignJob,
+    vehicles: VEHICLES,
+    jobByVehicleId: new Map([["v1", jobs[0]]]),
+    error: null,
+    ...overrides,
+  };
+  render(<JobsPanel {...props} />);
+  return { onAssignJob, props };
+}
+
+describe("JobsPanel reassignment", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("offers reassignment for a job that has not been picked up", () => {
+    renderPanel();
+
+    expect(screen.getByRole("button", { name: /reassign job JOB-0001/i })).toBeInTheDocument();
+  });
+
+  it("does not offer reassignment once the load is on board", () => {
+    renderPanel({ jobs: [job({ status: "transporting" })] });
+
+    expect(screen.queryByRole("button", { name: /reassign/i })).not.toBeInTheDocument();
+  });
+
+  it("does not offer reassignment for a finished job", () => {
+    renderPanel({ jobs: [job({ status: "complete" })] });
+
+    expect(screen.queryByRole("button", { name: /reassign/i })).not.toBeInTheDocument();
+  });
+
+  it("re-runs a strategy without naming a vehicle", async () => {
+    const user = userEvent.setup();
+    const { onAssignJob } = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /reassign job JOB-0001/i }));
+    await user.selectOptions(screen.getByLabelText(/reassign JOB-0001/i), "best_eta");
+
+    expect(onAssignJob).toHaveBeenCalledWith("job-1", { strategy: "best_eta" });
+  });
+
+  it("assigns a named vehicle as a manual assignment", async () => {
+    const user = userEvent.setup();
+    const { onAssignJob } = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /reassign job JOB-0001/i }));
+    await user.selectOptions(screen.getByLabelText(/reassign JOB-0001/i), "v2");
+
+    expect(onAssignJob).toHaveBeenCalledWith("job-1", { vehicleId: "v2" });
+  });
+
+  it("leaves out vehicles already carrying a different job", async () => {
+    const user = userEvent.setup();
+    const other = job({ id: "job-2", reference: "JOB-0002", vehicleId: "v3" });
+    renderPanel({
+      jobs: [job()],
+      jobByVehicleId: new Map([
+        ["v1", job()],
+        ["v3", other],
+      ]),
+    });
+
+    await user.click(screen.getByRole("button", { name: /reassign job JOB-0001/i }));
+    const select = screen.getByLabelText(/reassign JOB-0001/i);
+
+    // v1 holds THIS job, so it stays selectable; v3 holds another one.
+    expect(within(select).getByRole("option", { name: "Unit 1" })).toBeInTheDocument();
+    expect(within(select).queryByRole("option", { name: "Unit 3" })).not.toBeInTheDocument();
+  });
+
+  it("collapses the control after a choice", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /reassign job JOB-0001/i }));
+    await user.selectOptions(screen.getByLabelText(/reassign JOB-0001/i), "v2");
+
+    expect(screen.queryByLabelText(/reassign JOB-0001/i)).not.toBeInTheDocument();
+  });
+
+  it("toggles the control closed again", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    const toggle = screen.getByRole("button", { name: /reassign job JOB-0001/i });
+    await user.click(toggle);
+    expect(screen.getByLabelText(/reassign JOB-0001/i)).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.queryByLabelText(/reassign JOB-0001/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/Controls/JobsPanel.tsx
+++ b/apps/ui/src/Controls/JobsPanel.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button, SquaredButton } from "@/components/Inputs";
 import { Input } from "@/components/ui/input";
 import { Eyebrow, LList, LRow, Tag, mono, type SevTone } from "@/Dock/DockPanelKit";
 import { PanelEmptyState, PanelErrorState } from "./PanelPrimitives";
-import { JobIcon } from "@/components/Icons";
+import { JobIcon, Reset } from "@/components/Icons";
 import type { JobAssignmentStrategy, JobDTO, JobStatus } from "@/types";
 import type { JobDraft } from "@/hooks/useJobDraft";
 import type { JobCounts } from "@/hooks/useJobs";
@@ -91,8 +91,27 @@ export interface JobsPanelProps {
   draft: JobDraft;
   onCancelJob: (id: string) => Promise<void>;
   onDeleteJob: (id: string) => Promise<void>;
+  /** Re-target a job: re-run a strategy, or name a vehicle (manual). */
+  onAssignJob: (
+    id: string,
+    body: { vehicleId?: string; strategy?: JobAssignmentStrategy }
+  ) => Promise<void>;
+  /** Roster used to offer a specific vehicle when reassigning. */
+  vehicles: { id: string; name: string }[];
+  /** vehicleId → the live job it is carrying, so busy units aren't offered. */
+  jobByVehicleId: Map<string, JobDTO>;
   error?: string | null;
 }
+
+/**
+ * Statuses that can still be re-targeted. Once the load is on board, swapping
+ * units would be a different job — the simulator rejects it, so don't offer it.
+ */
+const REASSIGNABLE: ReadonlySet<JobStatus> = new Set<JobStatus>([
+  "pending",
+  "assigned",
+  "en_route",
+]);
 
 /**
  * The job board: create a pickup/dropoff job by clicking the map twice, then
@@ -108,9 +127,14 @@ export default function JobsPanel({
   draft,
   onCancelJob,
   onDeleteJob,
+  onAssignJob,
+  vehicles,
+  jobByVehicleId,
   error,
 }: JobsPanelProps) {
   const [now, setNow] = useState(() => Date.now());
+  /** Job whose reassign control is expanded, if any. */
+  const [reassigningId, setReassigningId] = useState<string | null>(null);
 
   // One shared 1 Hz tick drives every countdown; no timer per row.
   useEffect(() => {
@@ -218,58 +242,142 @@ export default function JobsPanel({
         {ordered.map((job) => {
           const live = isJobLive(job);
           const tone: SevTone = job.slaBreached && live ? "error" : STATUS_TONE[job.status];
+          const reassignable = REASSIGNABLE.has(job.status);
           return (
-            <LRow
-              key={job.id}
-              tone={tone}
-              primary={
-                <span className="flex items-center gap-1.5">
-                  <span className={mono}>{job.reference}</span>
-                  {job.slaBreached && <Tag tone="error">Late</Tag>}
-                </span>
-              }
-              secondary={jobSecondary(job)}
-              meta={
-                <>
-                  <Tag tone={tone}>{STATUS_LABEL[job.status]}</Tag>
-                  {live && (
-                    <span
-                      className={cn(
-                        mono,
-                        "whitespace-nowrap text-[11px]",
-                        job.slaBreached ? "text-status-error" : "text-muted-foreground"
-                      )}
-                      title="Time remaining against the SLA deadline"
-                    >
-                      {formatCountdown(job.slaDeadline, now)}
-                    </span>
-                  )}
-                  {live ? (
-                    <SquaredButton
-                      className="flex-shrink-0"
-                      icon={<span aria-hidden="true">×</span>}
-                      variant="ghost"
-                      tone="danger"
-                      aria-label={`Cancel job ${job.reference}`}
-                      title="Cancel job"
-                      onClick={() => onCancelJob(job.id)}
-                    />
-                  ) : (
-                    <SquaredButton
-                      className="flex-shrink-0"
-                      icon={<span aria-hidden="true">×</span>}
-                      variant="ghost"
-                      aria-label={`Remove job ${job.reference}`}
-                      title="Remove from board"
-                      onClick={() => onDeleteJob(job.id)}
-                    />
-                  )}
-                </>
-              }
-            />
+            <Fragment key={job.id}>
+              <LRow
+                tone={tone}
+                primary={
+                  <span className="flex items-center gap-1.5">
+                    <span className={mono}>{job.reference}</span>
+                    {job.slaBreached && <Tag tone="error">Late</Tag>}
+                  </span>
+                }
+                secondary={jobSecondary(job)}
+                meta={
+                  <>
+                    <Tag tone={tone}>{STATUS_LABEL[job.status]}</Tag>
+                    {live && (
+                      <span
+                        className={cn(
+                          mono,
+                          "whitespace-nowrap text-[11px]",
+                          job.slaBreached ? "text-status-error" : "text-muted-foreground"
+                        )}
+                        title="Time remaining against the SLA deadline"
+                      >
+                        {formatCountdown(job.slaDeadline, now)}
+                      </span>
+                    )}
+                    {reassignable && (
+                      <SquaredButton
+                        className="flex-shrink-0"
+                        icon={<Reset />}
+                        variant="ghost"
+                        active={reassigningId === job.id}
+                        aria-label={`Reassign job ${job.reference}`}
+                        aria-expanded={reassigningId === job.id}
+                        title="Reassign to another vehicle or re-run the search"
+                        onClick={() =>
+                          setReassigningId((prev) => (prev === job.id ? null : job.id))
+                        }
+                      />
+                    )}
+                    {live ? (
+                      <SquaredButton
+                        className="flex-shrink-0"
+                        icon={<span aria-hidden="true">×</span>}
+                        variant="ghost"
+                        tone="danger"
+                        aria-label={`Cancel job ${job.reference}`}
+                        title="Cancel job"
+                        onClick={() => onCancelJob(job.id)}
+                      />
+                    ) : (
+                      <SquaredButton
+                        className="flex-shrink-0"
+                        icon={<span aria-hidden="true">×</span>}
+                        variant="ghost"
+                        aria-label={`Remove job ${job.reference}`}
+                        title="Remove from board"
+                        onClick={() => onDeleteJob(job.id)}
+                      />
+                    )}
+                  </>
+                }
+              />
+              {reassigningId === job.id && (
+                <ReassignRow
+                  job={job}
+                  vehicles={vehicles}
+                  jobByVehicleId={jobByVehicleId}
+                  onAssign={async (body) => {
+                    setReassigningId(null);
+                    await onAssignJob(job.id, body);
+                  }}
+                />
+              )}
+            </Fragment>
           );
         })}
       </LList>
+    </div>
+  );
+}
+
+/**
+ * Inline reassign control for a job that hasn't been picked up yet.
+ *
+ * Offers both shapes the API accepts: re-run a strategy (the simulator picks),
+ * or name a vehicle (`manual`). Vehicles already carrying another job are left
+ * out — the simulator answers those with a 409, and offering a choice that is
+ * guaranteed to fail is worse than not offering it.
+ */
+function ReassignRow({
+  job,
+  vehicles,
+  jobByVehicleId,
+  onAssign,
+}: {
+  job: JobDTO;
+  vehicles: { id: string; name: string }[];
+  jobByVehicleId: Map<string, JobDTO>;
+  onAssign: (body: { vehicleId?: string; strategy?: JobAssignmentStrategy }) => Promise<void>;
+}) {
+  const free = vehicles.filter((v) => {
+    const holder = jobByVehicleId.get(v.id);
+    return !holder || holder.id === job.id;
+  });
+
+  return (
+    <div className="flex items-center gap-1.5 border-t border-border-soft px-2 py-2 pl-[13px]">
+      <span className="text-[10.5px] text-muted-foreground">Reassign</span>
+      <select
+        defaultValue=""
+        aria-label={`Reassign ${job.reference}`}
+        onChange={(e) => {
+          const value = e.target.value;
+          if (!value) return;
+          const strategy = STRATEGIES.find((s) => s.value === value);
+          void onAssign(strategy ? { strategy: strategy.value } : { vehicleId: value });
+        }}
+        className={cn(
+          "h-7 min-w-0 flex-1 rounded-md border border-border bg-transparent px-1.5 text-[11px] text-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        )}
+      >
+        <option value="">Choose…</option>
+        {STRATEGIES.map((option) => (
+          <option key={option.value} value={option.value}>
+            Re-run {option.label}
+          </option>
+        ))}
+        {free.map((v) => (
+          <option key={v.id} value={v.id}>
+            {v.name}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/apps/ui/src/Controls/Vehicles.jobsFaults.test.tsx
+++ b/apps/ui/src/Controls/Vehicles.jobsFaults.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import VehicleList from "./Vehicles";
+import { createVehicle } from "@/test/mocks/types";
+import type { JobDTO } from "@/types";
+
+/**
+ * What a vehicle row says about the job it is carrying and the device reporting
+ * it. Both exist so an operator can see, without opening anything, that a unit
+ * is busy (don't re-dispatch it) or that its telemetry is not to be trusted.
+ */
+function job(overrides: Partial<JobDTO> = {}): JobDTO {
+  return {
+    id: "job-1",
+    reference: "JOB-4F2A",
+    status: "en_route",
+    pickup: { position: [-1.29, 36.82] },
+    dropoff: { position: [-1.3, 36.84] },
+    strategy: "nearest",
+    vehicleId: "v1",
+    vehicleName: "Truck Alpha",
+    createdAt: 0,
+    slaSeconds: 900,
+    slaDeadline: 900_000,
+    slaBreached: false,
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  filter: "",
+  maxSpeed: 100,
+  vehicleFleetMap: new Map(),
+  onFilterChange: vi.fn(),
+  onSelectVehicle: vi.fn(),
+  onHoverVehicle: vi.fn(),
+  onUnhoverVehicle: vi.fn(),
+};
+
+describe("VehicleList job + device annotations", () => {
+  it("shows the job reference a unit is carrying instead of its motion state", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[createVehicle({ id: "v1", name: "Truck Alpha", visible: true, speed: 40 })]}
+        jobByVehicleId={new Map([["v1", job()]])}
+      />
+    );
+
+    expect(screen.getByText("JOB-4F2A")).toBeInTheDocument();
+    expect(screen.queryByText("enroute")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the motion state for a free unit", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[createVehicle({ id: "v1", name: "Truck Alpha", visible: true, speed: 40 })]}
+        jobByVehicleId={new Map()}
+      />
+    );
+
+    expect(screen.getByText("enroute")).toBeInTheDocument();
+  });
+
+  it("reads as idle when stopped and unassigned", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[createVehicle({ id: "v1", name: "Truck Alpha", visible: true, speed: 0 })]}
+      />
+    );
+
+    expect(screen.getByText("idle")).toBeInTheDocument();
+  });
+
+  it("badges the fault kind shaping the last sample", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[
+          createVehicle({
+            id: "v1",
+            name: "Truck Alpha",
+            visible: true,
+            faults: { active: ["frozen_gps"] },
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("frozen")).toBeInTheDocument();
+  });
+
+  it("collapses several concurrent faults into one badge", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[
+          createVehicle({
+            id: "v1",
+            name: "Truck Alpha",
+            visible: true,
+            faults: { active: ["frozen_gps", "clock_skew", "duplicate"] },
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("frozen +2")).toBeInTheDocument();
+  });
+
+  it("says nothing for a device reporting clean", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[
+          createVehicle({ id: "v1", name: "Truck Alpha", visible: true, faults: { active: [] } }),
+        ]}
+      />
+    );
+
+    expect(screen.queryByText(/frozen|clock|duplicate/)).not.toBeInTheDocument();
+  });
+
+  it("says nothing for a device with no fault profile at all", () => {
+    render(
+      <VehicleList
+        {...baseProps}
+        vehicles={[createVehicle({ id: "v1", name: "Truck Alpha", visible: true })]}
+      />
+    );
+
+    expect(screen.queryByText(/frozen/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/Controls/Vehicles.tsx
+++ b/apps/ui/src/Controls/Vehicles.tsx
@@ -1,13 +1,21 @@
 import { cn } from "@/lib/utils";
 import { memo, useCallback, useMemo } from "react";
 import { FixedSizeList, type ListChildComponentProps } from "react-window";
-import type { Fleet, Vehicle, DispatchAssignment, DirectionResult } from "@/types";
+import type {
+  Fleet,
+  Vehicle,
+  DispatchAssignment,
+  DirectionResult,
+  DeviceFaultInfo,
+  JobDTO,
+} from "@/types";
 import { DispatchState } from "@/hooks/useDispatchState";
 import { useDirectionContext } from "@/data/useData";
 import { useResizeObserver } from "@/hooks/useResizeObserver";
 import { PanelBadge, PanelBody, PanelEmptyState, PanelHeader } from "./PanelPrimitives";
 import { StatusDot, mono } from "@/Dock/DockPanelKit";
 import { Search } from "@/components/Icons";
+import { FAULT_KIND_LABEL } from "@/lib/faultPresets";
 import { Input } from "@/components/ui/input";
 
 // Row height (px) for the virtualized list — must match the rendered row's
@@ -45,6 +53,8 @@ interface VehicleListProps {
   onToggleVehicleForDispatch?: (id: string) => void;
   assignments?: DispatchAssignment[];
   results?: DirectionResult[];
+  /** vehicleId → the live job it is carrying (from `useJobs`). */
+  jobByVehicleId?: Map<string, JobDTO>;
 }
 
 function formatRouteDistance(distance?: number) {
@@ -101,6 +111,17 @@ function ResultBadge({ result }: { result: DirectionResult }) {
 }
 
 /**
+ * Compact label for the fault kinds shaping a vehicle's last sample, or
+ * `undefined` when the device reported clean (or has no fault profile at all).
+ */
+function summarizeFaults(faults: DeviceFaultInfo | undefined): string | undefined {
+  const active = faults?.active;
+  if (!active || active.length === 0) return undefined;
+  if (active.length === 1) return FAULT_KIND_LABEL[active[0]];
+  return `${FAULT_KIND_LABEL[active[0]]} +${active.length - 1}`;
+}
+
+/**
  * A single vehicle row. Kept as a leaf `React.memo` component with a narrow,
  * mostly-primitive prop shape so a position/heading tick on ONE vehicle
  * (which changes `vehicles` array identity in the parent) does not force
@@ -122,6 +143,10 @@ interface VehicleRowProps {
   isRouteState: boolean;
   assignment: DispatchAssignment | undefined;
   result: DirectionResult | undefined;
+  /** Reference of the job this unit is carrying, if any. */
+  jobReference: string | undefined;
+  /** Device faults shaping this vehicle's last sample, if its device has a profile. */
+  faults: DeviceFaultInfo | undefined;
   style: React.CSSProperties;
   onSelect: (id: string) => void;
   onToggleForDispatch: ((id: string) => void) | undefined;
@@ -144,6 +169,8 @@ const VehicleRow = memo(function VehicleRow({
   isRouteState,
   assignment,
   result,
+  jobReference,
+  faults,
   style,
   onSelect,
   onToggleForDispatch,
@@ -153,6 +180,7 @@ const VehicleRow = memo(function VehicleRow({
   const isSelected = !showCheckbox && !isResults && isRowSelected;
   const isDispatchSelected = showCheckbox && isChecked;
   const moving = speed > 0;
+  const faultSummary = summarizeFaults(faults);
 
   const handleClick = () => {
     if (showCheckbox && onToggleForDispatch) {
@@ -227,13 +255,31 @@ const VehicleRow = memo(function VehicleRow({
               {VEHICLE_TYPE_LABELS[type] ?? type}
             </span>
           )}
+          {faultSummary && (
+            <span
+              className="flex-shrink-0 rounded-sm bg-status-warn/15 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-status-warn"
+              title={`Device fault: ${faultSummary}`}
+            >
+              {faultSummary}
+            </span>
+          )}
         </span>
 
-        {/* Status: dot + label */}
-        <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-          <StatusDot tone={moving ? "ok" : "idle"} />
-          {moving ? "enroute" : "idle"}
-        </span>
+        {/* Status: what this unit is doing — its job, if it has one, else motion */}
+        {jobReference ? (
+          <span
+            className={cn(mono, "flex items-center gap-1.5 text-[11px] text-accent")}
+            title={`Carrying ${jobReference}`}
+          >
+            <StatusDot tone="accent" />
+            {jobReference}
+          </span>
+        ) : (
+          <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+            <StatusDot tone={moving ? "ok" : "idle"} />
+            {moving ? "enroute" : "idle"}
+          </span>
+        )}
 
         {/* km/h (unit lives in the header) */}
         <span
@@ -260,6 +306,7 @@ interface RowData {
   selectedForDispatchSet: Set<string>;
   assignments: DispatchAssignment[] | undefined;
   results: DirectionResult[] | undefined;
+  jobByVehicleId: Map<string, JobDTO> | undefined;
   selectedId: string | undefined;
   maxSpeed: number;
   showCheckbox: boolean;
@@ -285,6 +332,7 @@ function Row({ index, style, data }: ListChildComponentProps<RowData>) {
     selectedForDispatchSet,
     assignments,
     results,
+    jobByVehicleId,
     selectedId,
     showCheckbox,
     isDispatch,
@@ -327,6 +375,8 @@ function Row({ index, style, data }: ListChildComponentProps<RowData>) {
       isRouteState={isRouteState}
       assignment={assignment}
       result={result}
+      jobReference={jobByVehicleId?.get(vehicle.id)?.reference}
+      faults={vehicle.faults}
       style={insetStyle}
       onSelect={onSelectVehicle}
       onToggleForDispatch={onToggleVehicleForDispatch}
@@ -351,6 +401,7 @@ export default function VehicleList({
   onToggleVehicleForDispatch,
   assignments,
   results,
+  jobByVehicleId,
 }: VehicleListProps) {
   const { directions } = useDirectionContext();
   const visibleVehicles = useMemo(() => vehicles.filter((v) => v.visible), [vehicles]);
@@ -381,6 +432,7 @@ export default function VehicleList({
       selectedForDispatchSet,
       assignments,
       results,
+      jobByVehicleId,
       selectedId,
       maxSpeed,
       showCheckbox,
@@ -399,6 +451,7 @@ export default function VehicleList({
       selectedForDispatchSet,
       assignments,
       results,
+      jobByVehicleId,
       selectedId,
       maxSpeed,
       showCheckbox,

--- a/apps/ui/src/Dock/Dock.tsx
+++ b/apps/ui/src/Dock/Dock.tsx
@@ -17,6 +17,7 @@ import FleetPanel from "./FleetPanel";
 import TempoPanel from "./TempoPanel";
 import SinksPanel from "./SinksPanel";
 import MonitorPanel from "./MonitorPanel";
+import { countMisbehavingDevices } from "@/lib/faultPresets";
 import SettingsPanel from "./SettingsPanel";
 import type { StatusTone } from "./DockPanelKit";
 import type Incidents from "@/Controls/Incidents";
@@ -84,6 +85,7 @@ export interface DockProps {
 
   // Monitor
   incidents: ComponentProps<typeof Incidents>;
+  faults: ComponentProps<typeof MonitorPanel>["faults"];
   geofences: ComponentProps<typeof GeofencePanel>;
   analytics: ComponentProps<typeof AnalyticsPanel>;
   toggles: ComponentProps<typeof TogglesPanel>;
@@ -140,6 +142,7 @@ export default function Dock({
   dispatch,
   jobs,
   incidents,
+  faults,
   geofences,
   analytics,
   toggles,
@@ -150,6 +153,7 @@ export default function Dock({
   const { openCluster, panelOpen, toggle, close, isOpen } = navigation;
   const { clock, setSpeedMultiplier } = useClock();
   const adapter = useAdapterConfig(openCluster === "sinks-source");
+  const faultyDevices = countMisbehavingDevices(faults.faults.config, faults.faults.status);
   const dockRef = useRef<HTMLDivElement>(null);
   const tempoBtnRef = useRef<HTMLButtonElement>(null);
 
@@ -226,7 +230,12 @@ export default function Dock({
         )}
         {openCluster === "sinks-source" && <SinksPanel adapter={adapter} />}
         {openCluster === "monitor" && (
-          <MonitorPanel incidents={incidents} analytics={analytics} geofences={geofences} />
+          <MonitorPanel
+            incidents={incidents}
+            analytics={analytics}
+            geofences={geofences}
+            faults={faults}
+          />
         )}
         {openCluster === "settings" && (
           <SettingsPanel toggles={toggles} recordings={recordings} advanced={advanced} />
@@ -286,7 +295,13 @@ export default function Dock({
             icon={<ChartIcon />}
             label="Monitor"
             active={isOpen("monitor")}
-            badge={countBadge(incidentCount, "err")}
+            // Incidents are the louder signal; a silently misbehaving device is
+            // still worth a badge when there are no incidents to report.
+            badge={
+              incidentCount > 0
+                ? countBadge(incidentCount, "err")
+                : countBadge(faultyDevices, "err")
+            }
             aria-label="Monitor"
             onClick={() => toggle("monitor")}
           />

--- a/apps/ui/src/Dock/FleetPanel.tsx
+++ b/apps/ui/src/Dock/FleetPanel.tsx
@@ -362,6 +362,7 @@ export default function FleetPanel({
               onToggleVehicleForDispatch={dispatch.onToggleVehicleForDispatch}
               assignments={dispatch.assignments}
               results={dispatch.results}
+              jobByVehicleId={jobs.jobByVehicleId}
             />
           </SuppressPanelHeader>
         </div>

--- a/apps/ui/src/Dock/MonitorPanel.faults.test.tsx
+++ b/apps/ui/src/Dock/MonitorPanel.faults.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MonitorPanel, { type MonitorPanelProps } from "./MonitorPanel";
+import type { UseFaults } from "@/hooks/useFaults";
+import type { DeviceFaultStatus } from "@/types";
+
+function status(overrides: Partial<DeviceFaultStatus> = {}): DeviceFaultStatus {
+  return {
+    enabled: true,
+    devices: 3,
+    frozen: 0,
+    teleporting: 0,
+    dead: 0,
+    held: 0,
+    queued: 0,
+    counts: {
+      frozen_gps: 0,
+      clock_skew: 0,
+      duplicate: 0,
+      out_of_order: 0,
+      battery_dead: 0,
+      teleport: 0,
+    },
+    ...overrides,
+  };
+}
+
+function faultsApi(overrides: Partial<UseFaults> = {}): UseFaults {
+  return {
+    config: { enabled: true, vehicles: {} },
+    status: status(),
+    loading: false,
+    error: null,
+    configure: vi.fn().mockResolvedValue(undefined),
+    setVehicleProfile: vi.fn().mockResolvedValue(undefined),
+    clearVehicleProfile: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function props(faults: UseFaults): MonitorPanelProps {
+  return {
+    incidents: {
+      incidents: [],
+      createRandom: vi.fn(),
+      remove: vi.fn(),
+      error: null,
+    } as unknown as MonitorPanelProps["incidents"],
+    analytics: { summary: null, fleetHistory: new Map(), summaryHistory: [] },
+    geofences: {
+      fences: [],
+      onFenceToggle: vi.fn(),
+      onFenceDelete: vi.fn(),
+      alerts: [],
+      drawingActive: false,
+      vertexCount: 0,
+      onStartDrawing: vi.fn(),
+      onCancelDrawing: vi.fn(),
+      onConfirmDrawing: vi.fn(),
+    } as unknown as MonitorPanelProps["geofences"],
+    faults: { faults, vehicles: [{ id: "v1", name: "Unit 1" }] },
+  };
+}
+
+describe("MonitorPanel faults tab", () => {
+  it("offers Faults as a tab and opens the panel", async () => {
+    const user = userEvent.setup();
+    render(<MonitorPanel {...props(faultsApi())} />);
+
+    const tab = screen.getByRole("tab", { name: /faults/i });
+    await user.click(tab);
+
+    expect(screen.getByRole("switch", { name: /enable device fault injection/i })).toBeVisible();
+  });
+
+  it("badges the tab with the number of misbehaving devices", () => {
+    render(<MonitorPanel {...props(faultsApi({ status: status({ frozen: 2, dead: 1 }) }))} />);
+
+    expect(screen.getByRole("tab", { name: /faults/i })).toHaveTextContent("3");
+  });
+
+  it("does not badge a disarmed layer, even with latched counters", () => {
+    render(
+      <MonitorPanel
+        {...props(
+          faultsApi({
+            config: { enabled: false, vehicles: {} },
+            status: status({ frozen: 4, enabled: false }),
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByRole("tab", { name: /faults/i })).not.toHaveTextContent("4");
+  });
+
+  it("starts on Incidents so the default view is unchanged", () => {
+    render(<MonitorPanel {...props(faultsApi())} />);
+
+    expect(screen.getByRole("tab", { name: /incidents/i })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+  });
+});

--- a/apps/ui/src/Dock/MonitorPanel.tsx
+++ b/apps/ui/src/Dock/MonitorPanel.tsx
@@ -3,34 +3,50 @@ import Incidents from "@/Controls/Incidents";
 import AnalyticsPanel from "@/Controls/AnalyticsPanel";
 import GeofencePanel from "@/Controls/GeofencePanel";
 import HeatzonePanel from "@/Controls/HeatzonePanel";
+import FaultsPanel from "@/Controls/FaultsPanel";
 import { SuppressPanelHeader } from "@/Controls/PanelPrimitives";
 import { PanelHead, PanelScroll, PanelTabStrip, type PanelTab } from "./DockPanelKit";
+import { countMisbehavingDevices } from "@/lib/faultPresets";
 
 export interface MonitorPanelProps {
   incidents: ComponentProps<typeof Incidents>;
   analytics: ComponentProps<typeof AnalyticsPanel>;
   geofences: ComponentProps<typeof GeofencePanel>;
+  faults: ComponentProps<typeof FaultsPanel>;
 }
 
-type MonitorTabId = "incidents" | "analytics" | "geofences" | "heatzones";
+type MonitorTabId = "incidents" | "analytics" | "geofences" | "heatzones" | "faults";
 
 /**
- * Monitor panel — observe-only. Everything here is something you *watch*:
- * live incidents, fleet analytics, and geofences (which raise enter/exit
- * alerts). View filters, session, and vehicle tuning moved to `SettingsPanel`
- * so this cluster stays a coherent "what's happening" surface.
+ * Monitor panel — everything here is something you *watch*: live incidents,
+ * fleet analytics, geofences (which raise enter/exit alerts), heat zones, and
+ * device faults. Each tab also carries the controls that produce what it
+ * watches (draw a zone, arm a fault profile), because the thing being observed
+ * and the knob that causes it belong side by side. View filters, session, and
+ * vehicle tuning moved to `SettingsPanel` so this cluster stays a coherent
+ * "what's happening" surface.
  *
  * Leaves render their own `PanelHeader`; we already own the title, so
  * `SuppressPanelHeader` collapses the duplicate while keeping in-body controls.
  */
-export default function MonitorPanel({ incidents, analytics, geofences }: MonitorPanelProps) {
+export default function MonitorPanel({
+  incidents,
+  analytics,
+  geofences,
+  faults,
+}: MonitorPanelProps) {
   const [tab, setTab] = useState<MonitorTabId>("incidents");
+
+  // Devices currently misbehaving — the number worth seeing without opening
+  // the tab.
+  const faultyDevices = countMisbehavingDevices(faults.faults.config, faults.faults.status);
 
   const tabs: PanelTab<MonitorTabId>[] = [
     { id: "incidents", label: "Incidents", badge: incidents.incidents.length },
     { id: "analytics", label: "Analytics" },
     { id: "geofences", label: "Geofences" },
     { id: "heatzones", label: "Heat Zones" },
+    { id: "faults", label: "Faults", badge: faultyDevices },
   ];
   const activeLabel = tabs.find((t) => t.id === tab)?.label ?? "Incidents";
 
@@ -44,6 +60,7 @@ export default function MonitorPanel({ incidents, analytics, geofences }: Monito
           {tab === "analytics" && <AnalyticsPanel {...analytics} />}
           {tab === "geofences" && <GeofencePanel {...geofences} />}
           {tab === "heatzones" && <HeatzonePanel />}
+          {tab === "faults" && <FaultsPanel {...faults} />}
         </SuppressPanelHeader>
       </PanelScroll>
     </>

--- a/apps/ui/src/Inspector/Inspector.device.test.tsx
+++ b/apps/ui/src/Inspector/Inspector.device.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Inspector from "./Inspector";
+import { createVehicle } from "@/test/mocks/types";
+import { vehicleEventStore } from "./vehicleEventStore";
+import type { JobDTO } from "@/types";
+
+beforeEach(() => vehicleEventStore.clear());
+
+function job(overrides: Partial<JobDTO> = {}): JobDTO {
+  return {
+    id: "job-1",
+    reference: "JOB-4F2A",
+    status: "transporting",
+    pickup: { position: [-1.29, 36.82] },
+    dropoff: { position: [-1.3, 36.84] },
+    strategy: "nearest",
+    vehicleId: "v1",
+    vehicleName: "Unit 1",
+    createdAt: 0,
+    slaSeconds: 900,
+    slaDeadline: 900_000,
+    slaBreached: false,
+    ...overrides,
+  };
+}
+
+describe("Inspector job field", () => {
+  it("names the job a vehicle is carrying", () => {
+    render(<Inspector vehicle={createVehicle({ id: "v1" })} job={job()} onClose={vi.fn()} />);
+
+    expect(screen.getByText("JOB-4F2A")).toBeInTheDocument();
+  });
+
+  it("flags a job past its SLA", () => {
+    render(
+      <Inspector
+        vehicle={createVehicle({ id: "v1" })}
+        job={job({ slaBreached: true })}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Late")).toBeInTheDocument();
+  });
+
+  it("omits the field for a free vehicle", () => {
+    render(<Inspector vehicle={createVehicle({ id: "v1" })} onClose={vi.fn()} />);
+
+    expect(screen.queryByText("Job")).not.toBeInTheDocument();
+  });
+});
+
+describe("Inspector device section", () => {
+  it("renders nothing for a device with no fault profile", () => {
+    render(<Inspector vehicle={createVehicle({ id: "v1" })} onClose={vi.fn()} />);
+
+    expect(screen.queryByText("Device")).not.toBeInTheDocument();
+  });
+
+  it("says a profiled device is reporting clean", () => {
+    render(
+      <Inspector vehicle={createVehicle({ id: "v1", faults: { active: [] } })} onClose={vi.fn()} />
+    );
+
+    expect(screen.getByText("Device")).toBeInTheDocument();
+    expect(screen.getByText("Reporting clean")).toBeInTheDocument();
+  });
+
+  it("names each fault shaping the current sample", () => {
+    render(
+      <Inspector
+        vehicle={createVehicle({ id: "v1", faults: { active: ["frozen_gps", "duplicate"] } })}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("frozen")).toBeInTheDocument();
+    expect(screen.getByText("duplicate")).toBeInTheDocument();
+    expect(screen.queryByText("Reporting clean")).not.toBeInTheDocument();
+  });
+
+  it("shows the remaining battery when the profile models one", () => {
+    render(
+      <Inspector
+        vehicle={createVehicle({ id: "v1", faults: { active: [], battery: 37.4 } })}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("37%")).toBeInTheDocument();
+  });
+
+  it("shows a signed clock skew and the device's own clock", () => {
+    render(
+      <Inspector
+        vehicle={createVehicle({
+          id: "v1",
+          faults: { active: ["clock_skew"], skewMs: -45_000 },
+          timestamp: Date.UTC(2026, 0, 1, 12, 0, 0),
+        })}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("-45s")).toBeInTheDocument();
+    expect(screen.getByText("Clock skew")).toBeInTheDocument();
+    expect(screen.getByText("Device time")).toBeInTheDocument();
+  });
+
+  it("omits a zero skew rather than reporting 0s", () => {
+    render(
+      <Inspector
+        vehicle={createVehicle({ id: "v1", faults: { active: [], skewMs: 0 } })}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Clock skew")).not.toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/Inspector/Inspector.tsx
+++ b/apps/ui/src/Inspector/Inspector.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import type { Fleet, POI, Position, Vehicle } from "@/types";
+import type { Fleet, JobDTO, POI, Position, Vehicle } from "@/types";
 import { CloseIcon } from "@/components/Icons";
 import { invertLatLng } from "@/utils/coordinates";
 import { Eyebrow, Hairline, PanelHead, StatusDot, Tag, mono } from "@/Dock/DockPanelKit";
@@ -7,6 +7,8 @@ import VehicleDirections from "./VehicleDirections";
 import VehicleTelemetry from "./VehicleTelemetry";
 import VehicleEventTimeline from "./VehicleEventTimeline";
 import { useVehicleEventCapture } from "./useVehicleEventCapture";
+import { FAULT_KIND_LABEL } from "@/lib/faultPresets";
+import type { DeviceFaultInfo } from "@/types";
 
 /**
  * On-demand right-side detail panel for the currently selected vehicle or POI.
@@ -32,6 +34,8 @@ export interface InspectorProps {
   poi?: POI;
   /** Resolved fleet for the selected vehicle (App resolves it from `fleetId`). */
   fleet?: Fleet;
+  /** The live job this vehicle is carrying, if any (App resolves it from the board). */
+  job?: JobDTO;
   /** Close the inspector (clears selection upstream). */
   onClose: () => void;
 }
@@ -51,7 +55,60 @@ function formatCoords([lng, lat]: Position): string {
   return `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
 }
 
-export default function Inspector({ vehicle, poi, fleet, onClose }: InspectorProps) {
+/**
+ * What the simulated DEVICE is doing to this vehicle's telemetry.
+ *
+ * Renders nothing for a device with no fault profile (the common case), so the
+ * inspector is unchanged unless faults are actually armed. When they are, this
+ * is the difference between "the map looks wrong" and "this tracker is frozen".
+ */
+function DeviceFaults({ faults, timestamp }: { faults?: DeviceFaultInfo; timestamp?: number }) {
+  if (!faults) return null;
+
+  const active = faults.active;
+  const battery = faults.battery;
+  const skewSeconds = faults.skewMs != null ? Math.round(faults.skewMs / 1000) : undefined;
+
+  return (
+    <div className="shrink-0 border-t border-border-soft pt-2">
+      <div className="flex items-center justify-between gap-2 px-[15px] pb-1.5">
+        <Eyebrow>Device</Eyebrow>
+        {active.length === 0 ? (
+          <Tag tone="ok">Reporting clean</Tag>
+        ) : (
+          <span className="flex flex-wrap justify-end gap-1">
+            {active.map((kind) => (
+              <Tag key={kind} tone={kind === "battery_dead" ? "error" : "warn"}>
+                {FAULT_KIND_LABEL[kind]}
+              </Tag>
+            ))}
+          </span>
+        )}
+      </div>
+      {battery != null && (
+        <Field label="Battery">
+          <span
+            className={cn(mono, battery <= 10 ? "text-status-error" : undefined)}
+          >{`${Math.round(battery)}%`}</span>
+        </Field>
+      )}
+      {skewSeconds != null && skewSeconds !== 0 && (
+        <Field label="Clock skew">
+          <span className={cn(mono, "text-status-warn")}>
+            {skewSeconds > 0 ? `+${skewSeconds}s` : `${skewSeconds}s`}
+          </span>
+        </Field>
+      )}
+      {timestamp != null && (
+        <Field label="Device time">
+          <span className={mono}>{new Date(timestamp).toLocaleTimeString()}</span>
+        </Field>
+      )}
+    </div>
+  );
+}
+
+export default function Inspector({ vehicle, poi, fleet, job, onClose }: InspectorProps) {
   // App renders <Inspector/> unconditionally (it self-hides below), so this is
   // the app-lifetime home for per-vehicle event capture — history exists for a
   // vehicle selected long after the events happened.
@@ -113,6 +170,14 @@ export default function Inspector({ vehicle, poi, fleet, onClose }: InspectorPro
                 {moving ? "En route" : "Idle"}
               </span>
             </Field>
+            {job && (
+              <Field label="Job">
+                <span className="inline-flex items-center gap-1.5">
+                  {job.slaBreached && <Tag tone="error">Late</Tag>}
+                  <span className={mono}>{job.reference}</span>
+                </span>
+              </Field>
+            )}
             <Field label="Type">
               <Tag tone="accent">{vehicle.type}</Tag>
             </Field>
@@ -128,6 +193,7 @@ export default function Inspector({ vehicle, poi, fleet, onClose }: InspectorPro
             </Field>
           </div>
           <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain">
+            <DeviceFaults faults={vehicle.faults} timestamp={vehicle.timestamp} />
             <VehicleTelemetry vehicleId={vehicle.id} />
             {/* Vehicle positions are [lng, lat] here; edge coords are [lat, lng].
                 Invert so the active-step lookup compares matching axes. */}

--- a/apps/ui/src/components/CommandPalette/commands.tsx
+++ b/apps/ui/src/components/CommandPalette/commands.tsx
@@ -106,6 +106,15 @@ export interface CommandDeps {
   onStartJob: () => void;
   onCancelJobPlacement: () => void;
 
+  /**
+   * Device fault injection. `faultsArmed` flips the entry between arming and
+   * disarming; `onClearFaultState` is always offered so a run can be restarted
+   * from a known device state without opening the panel.
+   */
+  faultsArmed: boolean;
+  onToggleFaults: () => void;
+  onClearFaultState: () => void;
+
   /** Monitor panel. */
   onCreateRandomIncident: () => Promise<void>;
   onStartGeofenceDrawing: () => void;
@@ -151,6 +160,9 @@ export function buildCommands(deps: CommandDeps): PaletteAction[] {
     jobPlacementActive,
     onStartJob,
     onCancelJobPlacement,
+    faultsArmed,
+    onToggleFaults,
+    onClearFaultState,
     onCreateRandomIncident,
     onStartGeofenceDrawing,
     heatzones,
@@ -350,6 +362,26 @@ export function buildCommands(deps: CommandDeps): PaletteAction[] {
           icon: <JobIcon />,
           run: onStartJob,
         }
+  );
+
+  // ── Device faults ──────────────────────────────────────────────────
+  actions.push(
+    {
+      id: "faults-toggle",
+      label: faultsArmed ? "Disarm device faults" : "Arm device faults",
+      keywords: "fault injection gps clock battery spoof device broken",
+      hint: "Faults",
+      icon: <WarningTriangle />,
+      run: onToggleFaults,
+    },
+    {
+      id: "faults-clear-state",
+      label: "Clear device fault state",
+      keywords: "reset battery frozen queue faults device",
+      hint: "Faults",
+      icon: <Reset />,
+      run: onClearFaultState,
+    }
   );
 
   // ── Monitor panel actions ──────────────────────────────────────────

--- a/apps/ui/src/components/ModeBanner.test.tsx
+++ b/apps/ui/src/components/ModeBanner.test.tsx
@@ -101,4 +101,41 @@ describe("ModeBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: /exit/i }));
     expect(onExit).toHaveBeenCalledOnce();
   });
+
+  /**
+   * Job placement isn't a member of the mode union, but it IS a modal map mode
+   * that takes Escape first — so it must own the banner too, including when it
+   * was started from the command palette with no mode active underneath.
+   */
+  describe("job placement", () => {
+    it("announces the pickup step from browse mode", () => {
+      renderBanner({ mode: BROWSE, jobPlacementStage: "pickup" });
+
+      expect(screen.getByText("New job")).toBeInTheDocument();
+      expect(screen.getByText(/click the map to set the pickup/i)).toBeInTheDocument();
+    });
+
+    it("announces the dropoff step", () => {
+      renderBanner({ mode: BROWSE, jobPlacementStage: "dropoff" });
+
+      expect(screen.getByText(/click the map to set the dropoff/i)).toBeInTheDocument();
+    });
+
+    it("outranks an active mode's own hint", () => {
+      renderBanner({
+        mode: DRAW,
+        jobPlacementStage: "pickup",
+        drawVertexCount: 3,
+      });
+
+      expect(screen.getByText("New job")).toBeInTheDocument();
+      expect(screen.queryByText("Draw zone")).not.toBeInTheDocument();
+    });
+
+    it("goes back to the mode hint once placement ends", () => {
+      renderBanner({ mode: DRAW, jobPlacementStage: "idle", drawVertexCount: 3 });
+
+      expect(screen.getByText("Draw zone")).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/ui/src/components/ModeBanner.tsx
+++ b/apps/ui/src/components/ModeBanner.tsx
@@ -1,11 +1,18 @@
 import { cn } from "@/lib/utils";
-import { Directions, GeofenceIcon } from "@/components/Icons";
+import { Directions, GeofenceIcon, JobIcon } from "@/components/Icons";
 import { DispatchState } from "@/hooks/useDispatchState";
 import type { InteractionMode } from "@/hooks/useInteractionMode";
 import { drawProgressHint } from "@/lib/geofenceHints";
+import type { JobDraftStage } from "@/hooks/useJobDraft";
 
 interface ModeBannerProps {
   mode: InteractionMode;
+  /**
+   * A two-click job placement is in flight. Not a member of the mode union (see
+   * useJobDraft), but it IS a modal map mode that owns Escape first, so it owns
+   * the banner first too.
+   */
+  jobPlacementStage?: JobDraftStage;
   /** Dispatch sub-state, drives the per-phase hint while `mode` is dispatch. */
   dispatchState: DispatchState;
   selectedCount: number;
@@ -55,6 +62,12 @@ function drawHint(vertexCount: number): string {
   );
 }
 
+function jobHint(stage: JobDraftStage): string {
+  return stage === "pickup"
+    ? "Click the map to set the pickup"
+    : "Click the map to set the dropoff — this creates the job";
+}
+
 /**
  * The single top-center banner for the active interaction mode. Replaces the
  * dispatch flow's DispatchHint and the geofence draw tool's inline banner,
@@ -64,20 +77,27 @@ function drawHint(vertexCount: number): string {
  */
 export default function ModeBanner({
   mode,
+  jobPlacementStage = "idle",
   dispatchState,
   selectedCount,
   stopCount,
   drawVertexCount,
   onExit,
 }: ModeBannerProps) {
-  if (mode.kind === "browse") return null;
+  const placingJob = jobPlacementStage !== "idle";
+  if (mode.kind === "browse" && !placingJob) return null;
 
-  const isDraw = mode.kind === "draw-geofence";
-  const { text, busy } = isDraw
-    ? { text: drawHint(drawVertexCount), busy: false }
-    : dispatchHint(dispatchState, selectedCount, stopCount);
-  const Icon = isDraw ? GeofenceIcon : Directions;
-  const label = isDraw ? "Draw zone" : "Dispatch";
+  // Job placement outranks the mode union: it is the most modal thing on screen
+  // and takes Escape first, so the banner must describe it rather than whatever
+  // mode is (or isn't) active underneath.
+  const isDraw = !placingJob && mode.kind === "draw-geofence";
+  const { text, busy } = placingJob
+    ? { text: jobHint(jobPlacementStage), busy: false }
+    : isDraw
+      ? { text: drawHint(drawVertexCount), busy: false }
+      : dispatchHint(dispatchState, selectedCount, stopCount);
+  const Icon = placingJob ? JobIcon : isDraw ? GeofenceIcon : Directions;
+  const label = placingJob ? "New job" : isDraw ? "Draw zone" : "Dispatch";
 
   return (
     <div

--- a/apps/ui/src/hooks/useFaults.test.ts
+++ b/apps/ui/src/hooks/useFaults.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useFaults } from "./useFaults";
+import client from "@/utils/client";
+import { toast } from "@/lib/toast";
+import type { DeviceFaultConfig, DeviceFaultState, DeviceFaultStatus } from "@moveet/shared-types";
+
+vi.mock("@/utils/client", () => ({
+  default: {
+    getFaults: vi.fn(),
+    configureFaults: vi.fn(),
+    getFaultStatus: vi.fn(),
+    resetFaults: vi.fn(),
+    setVehicleFaultProfile: vi.fn(),
+    clearVehicleFaultProfile: vi.fn(),
+    onFaultsConfig: vi.fn(),
+    offFaultsConfig: vi.fn(),
+    onReset: vi.fn(),
+    offReset: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+function status(overrides: Partial<DeviceFaultStatus> = {}): DeviceFaultStatus {
+  return {
+    enabled: true,
+    devices: 3,
+    frozen: 1,
+    teleporting: 0,
+    dead: 0,
+    held: 0,
+    queued: 0,
+    counts: {
+      frozen_gps: 4,
+      clock_skew: 0,
+      duplicate: 2,
+      out_of_order: 0,
+      battery_dead: 0,
+      teleport: 1,
+    },
+    ...overrides,
+  };
+}
+
+function config(overrides: Partial<DeviceFaultConfig> = {}): DeviceFaultConfig {
+  return { enabled: true, seed: 42, vehicles: {}, ...overrides };
+}
+
+function state(overrides: Partial<DeviceFaultState> = {}): DeviceFaultState {
+  return { ...config(), status: status(), ...overrides };
+}
+
+describe("useFaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(client.getFaults).mockResolvedValue({ data: state() });
+    vi.mocked(client.getFaultStatus).mockResolvedValue({ data: status() });
+    vi.mocked(client.configureFaults).mockResolvedValue({ data: config() });
+    vi.mocked(client.resetFaults).mockResolvedValue({ data: status({ frozen: 0 }) });
+    vi.mocked(client.setVehicleFaultProfile).mockResolvedValue({ data: config() });
+    vi.mocked(client.clearVehicleFaultProfile).mockResolvedValue({ data: config() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads the configuration and status in one request", async () => {
+    const { result } = renderHook(() => useFaults(false));
+
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    expect(client.getFaults).toHaveBeenCalledTimes(1);
+    expect(result.current.config?.seed).toBe(42);
+    expect(result.current.status?.frozen).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a load failure", async () => {
+    vi.mocked(client.getFaults).mockResolvedValue({ data: undefined, error: "boom" });
+
+    const { result } = renderHook(() => useFaults(false));
+
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+  });
+
+  it("adopts a configuration pushed on faults:config", async () => {
+    const { result } = renderHook(() => useFaults(false));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    const pushed = vi.mocked(client.onFaultsConfig).mock.calls[0][0];
+    act(() => pushed(config({ enabled: false, seed: 7 })));
+
+    expect(result.current.config?.enabled).toBe(false);
+    expect(result.current.config?.seed).toBe(7);
+  });
+
+  it("polls status only while live, and stops on unmount", async () => {
+    vi.useFakeTimers();
+    const { result, unmount } = renderHook(() => useFaults(true));
+
+    await vi.waitFor(() => expect(result.current.config).not.toBeNull());
+    const afterLoad = vi.mocked(client.getFaultStatus).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+    expect(vi.mocked(client.getFaultStatus).mock.calls.length).toBeGreaterThan(afterLoad);
+
+    unmount();
+    const afterUnmount = vi.mocked(client.getFaultStatus).mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(vi.mocked(client.getFaultStatus).mock.calls.length).toBe(afterUnmount);
+  });
+
+  it("does not poll status when not live", async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useFaults(false));
+    await vi.waitFor(() => expect(result.current.config).not.toBeNull());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(client.getFaultStatus).not.toHaveBeenCalled();
+  });
+
+  it("arms the layer through configure and keeps the returned config", async () => {
+    vi.mocked(client.configureFaults).mockResolvedValue({ data: config({ enabled: false }) });
+    const { result } = renderHook(() => useFaults(false));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    await act(async () => {
+      await result.current.configure({ enabled: false });
+    });
+
+    expect(client.configureFaults).toHaveBeenCalledWith({ enabled: false });
+    expect(result.current.config?.enabled).toBe(false);
+  });
+
+  it("toasts and keeps the previous config when configure fails", async () => {
+    vi.mocked(client.configureFaults).mockResolvedValue({ data: undefined, error: "nope" });
+    const { result } = renderHook(() => useFaults(false));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    await act(async () => {
+      await result.current.configure({ enabled: false });
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("nope");
+    expect(result.current.config?.enabled).toBe(true);
+  });
+
+  it("clears latched device state without touching the configuration", async () => {
+    const { result } = renderHook(() => useFaults(false));
+    await waitFor(() => expect(result.current.status?.frozen).toBe(1));
+
+    await act(async () => {
+      await result.current.reset();
+    });
+
+    expect(result.current.status?.frozen).toBe(0);
+    expect(result.current.config?.enabled).toBe(true);
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("sets and clears a per-vehicle profile", async () => {
+    const withVehicle = config({ vehicles: { v1: { clockSkew: { offsetMs: 5000 } } } });
+    vi.mocked(client.setVehicleFaultProfile).mockResolvedValue({ data: withVehicle });
+    const { result } = renderHook(() => useFaults(false));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+
+    await act(async () => {
+      await result.current.setVehicleProfile("v1", { clockSkew: { offsetMs: 5000 } });
+    });
+    expect(client.setVehicleFaultProfile).toHaveBeenCalledWith("v1", {
+      clockSkew: { offsetMs: 5000 },
+    });
+    expect(result.current.config?.vehicles.v1).toEqual({ clockSkew: { offsetMs: 5000 } });
+
+    vi.mocked(client.clearVehicleFaultProfile).mockResolvedValue({ data: config() });
+    await act(async () => {
+      await result.current.clearVehicleProfile("v1");
+    });
+    expect(result.current.config?.vehicles).toEqual({});
+  });
+
+  it("refetches after a simulation reset, which drops device state", async () => {
+    const { result } = renderHook(() => useFaults(false));
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    expect(client.getFaults).toHaveBeenCalledTimes(1);
+
+    const onReset = vi.mocked(client.onReset).mock.calls[0][0];
+    await act(async () => {
+      onReset({ vehicles: [], directions: [] });
+    });
+
+    await waitFor(() => expect(client.getFaults).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/ui/src/hooks/useFaults.ts
+++ b/apps/ui/src/hooks/useFaults.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import client from "@/utils/client";
+import { toast } from "@/lib/toast";
+import type { FaultConfigPatch } from "@/utils/client/faults";
+import type { DeviceFaultConfig, DeviceFaultProfile, DeviceFaultStatus } from "@/types";
+
+/**
+ * How often the live device counters are re-read while the panel is on screen.
+ *
+ * Status is a snapshot of continuously-moving state (frozen windows opening and
+ * closing, batteries draining) with no push channel, so it is polled — but only
+ * while something is watching, and never for the configuration, which arrives on
+ * `faults:config` the moment it changes.
+ */
+const STATUS_POLL_MS = 2000;
+
+export interface UseFaults {
+  config: DeviceFaultConfig | null;
+  status: DeviceFaultStatus | null;
+  /** True until the first snapshot lands. */
+  loading: boolean;
+  error: string | null;
+  configure: (patch: FaultConfigPatch) => Promise<void>;
+  setVehicleProfile: (vehicleId: string, profile: DeviceFaultProfile) => Promise<void>;
+  clearVehicleProfile: (vehicleId: string) => Promise<void>;
+  /** Clears latched device state (dead batteries, frozen windows), keeping the config. */
+  reset: () => Promise<void>;
+}
+
+/**
+ * The device fault layer, as an operator surface.
+ *
+ * The configuration is authoritative on the simulator: it can also be set by an
+ * env var at boot or by another client, so this hook treats `faults:config` as
+ * the source of truth rather than trusting its own last write. A simulation reset
+ * drops per-device state (but not the config), so it refetches both.
+ *
+ * @param live Whether the live status counters should be polled — pass the
+ *   panel's visibility so a closed panel costs nothing.
+ */
+export function useFaults(live: boolean): UseFaults {
+  const [config, setConfig] = useState<DeviceFaultConfig | null>(null);
+  const [status, setStatus] = useState<DeviceFaultStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guards every async setState against a unmount mid-flight.
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+
+    const load = () => {
+      client
+        .getFaults()
+        .then((res) => {
+          if (!mounted.current) return;
+          if (res.error || !res.data) {
+            setError(res.error ?? "Failed to load fault configuration");
+            return;
+          }
+          const { status: snapshot, ...rest } = res.data;
+          setConfig(rest);
+          setStatus(snapshot);
+          setError(null);
+        })
+        .finally(() => {
+          if (mounted.current) setLoading(false);
+        });
+    };
+
+    load();
+
+    const onConfig = (pushed: DeviceFaultConfig) => setConfig(pushed);
+    client.onFaultsConfig(onConfig);
+    client.onReset(load);
+
+    return () => {
+      mounted.current = false;
+      client.offFaultsConfig(onConfig);
+      client.offReset(load);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!live) return;
+    const poll = () => {
+      client.getFaultStatus().then((res) => {
+        if (!mounted.current || !res.data) return;
+        setStatus(res.data);
+      });
+    };
+    const interval = setInterval(poll, STATUS_POLL_MS);
+    return () => clearInterval(interval);
+  }, [live]);
+
+  /** Runs a mutation that answers with the resolved configuration. */
+  const applyConfig = useCallback(
+    async (
+      run: () => Promise<{ data?: DeviceFaultConfig; error?: string }>,
+      successMessage?: string
+    ) => {
+      const res = await run();
+      if (res.error || !res.data) {
+        const message = res.error ?? "Fault update failed";
+        setError(message);
+        toast.error(message);
+        return;
+      }
+      setConfig(res.data);
+      setError(null);
+      if (successMessage) toast.success(successMessage);
+    },
+    []
+  );
+
+  const configure = useCallback(
+    (patch: FaultConfigPatch) => applyConfig(() => client.configureFaults(patch)),
+    [applyConfig]
+  );
+
+  const setVehicleProfile = useCallback(
+    (vehicleId: string, profile: DeviceFaultProfile) =>
+      applyConfig(() => client.setVehicleFaultProfile(vehicleId, profile)),
+    [applyConfig]
+  );
+
+  const clearVehicleProfile = useCallback(
+    (vehicleId: string) => applyConfig(() => client.clearVehicleFaultProfile(vehicleId)),
+    [applyConfig]
+  );
+
+  const reset = useCallback(async () => {
+    const res = await client.resetFaults();
+    if (res.error || !res.data) {
+      const message = res.error ?? "Failed to reset device state";
+      setError(message);
+      toast.error(message);
+      return;
+    }
+    setStatus(res.data);
+    toast.success("Device state cleared");
+  }, []);
+
+  return {
+    config,
+    status,
+    loading,
+    error,
+    configure,
+    setVehicleProfile,
+    clearVehicleProfile,
+    reset,
+  };
+}

--- a/apps/ui/src/hooks/useJobs.test.ts
+++ b/apps/ui/src/hooks/useJobs.test.ts
@@ -180,6 +180,46 @@ describe("useJobs", () => {
     expect(result.current.liveJobs.map((j) => j.id)).toEqual(["a", "b"]);
   });
 
+  it("indexes live jobs by the vehicle carrying them", async () => {
+    vi.mocked(client.getJobs).mockResolvedValue({
+      data: [
+        createJob({ id: "a", status: "en_route", vehicleId: "v1" }),
+        createJob({ id: "b", status: "transporting", vehicleId: "v2" }),
+      ],
+    });
+
+    const { result } = renderHook(() => useJobs());
+
+    await vi.waitFor(() => expect(result.current.jobs).toHaveLength(2));
+    expect(result.current.jobByVehicleId.get("v1")?.id).toBe("a");
+    expect(result.current.jobByVehicleId.get("v2")?.id).toBe("b");
+    expect(result.current.jobByVehicleId.has("v3")).toBe(false);
+  });
+
+  it("stops claiming a vehicle once its job is finished", async () => {
+    // A terminal job keeps its vehicle on the record for the audit trail, but
+    // the unit is free — the vehicle list must not still show it as busy.
+    vi.mocked(client.getJobs).mockResolvedValue({
+      data: [createJob({ id: "a", status: "complete", vehicleId: "v1" })],
+    });
+
+    const { result } = renderHook(() => useJobs());
+
+    await vi.waitFor(() => expect(result.current.jobs).toHaveLength(1));
+    expect(result.current.jobByVehicleId.size).toBe(0);
+  });
+
+  it("leaves an unassigned pending job out of the index", async () => {
+    vi.mocked(client.getJobs).mockResolvedValue({
+      data: [createJob({ id: "a", status: "pending", vehicleId: undefined })],
+    });
+
+    const { result } = renderHook(() => useJobs());
+
+    await vi.waitFor(() => expect(result.current.jobs).toHaveLength(1));
+    expect(result.current.jobByVehicleId.size).toBe(0);
+  });
+
   it("reports an assigned vehicle after a successful create", async () => {
     const { result } = renderHook(() => useJobs());
 

--- a/apps/ui/src/hooks/useJobs.ts
+++ b/apps/ui/src/hooks/useJobs.ts
@@ -22,6 +22,12 @@ export interface UseJobs {
   jobs: JobDTO[];
   /** Live jobs only — what the map draws and the header counts. */
   liveJobs: JobDTO[];
+  /**
+   * vehicleId → the live job it is carrying. Lets the vehicle list and the
+   * inspector answer "is this unit busy, and on what" without each row
+   * scanning the board.
+   */
+  jobByVehicleId: Map<string, JobDTO>;
   counts: JobCounts;
   createJob: (request: CreateJobRequest) => Promise<JobDTO | null>;
   assignJob: (
@@ -109,6 +115,16 @@ export function useJobs(): UseJobs {
 
   const liveJobs = useMemo(() => jobs.filter(isJobLive), [jobs]);
 
+  const jobByVehicleId = useMemo(() => {
+    const map = new Map<string, JobDTO>();
+    // Terminal jobs keep their vehicle on the record for the audit trail, so
+    // only live ones can claim a unit.
+    for (const job of liveJobs) {
+      if (job.vehicleId) map.set(job.vehicleId, job);
+    }
+    return map;
+  }, [liveJobs]);
+
   const counts = useMemo<JobCounts>(
     () => ({
       total: jobs.length,
@@ -167,5 +183,15 @@ export function useJobs(): UseJobs {
     }
   }, []);
 
-  return { jobs, liveJobs, counts, createJob, assignJob, cancelJob, deleteJob, error };
+  return {
+    jobs,
+    liveJobs,
+    jobByVehicleId,
+    counts,
+    createJob,
+    assignJob,
+    cancelJob,
+    deleteJob,
+    error,
+  };
 }

--- a/apps/ui/src/lib/faultPresets.test.ts
+++ b/apps/ui/src/lib/faultPresets.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  FAULT_KIND_LABEL,
+  FAULT_PRESETS,
+  countMisbehavingDevices,
+  describeProfile,
+  matchPreset,
+} from "./faultPresets";
+import type { DeviceFaultKind, DeviceFaultStatus } from "@/types";
+
+const KINDS: DeviceFaultKind[] = [
+  "frozen_gps",
+  "clock_skew",
+  "duplicate",
+  "out_of_order",
+  "battery_dead",
+  "teleport",
+];
+
+function status(overrides: Partial<DeviceFaultStatus> = {}): DeviceFaultStatus {
+  return {
+    enabled: true,
+    devices: 4,
+    frozen: 0,
+    teleporting: 0,
+    dead: 0,
+    held: 0,
+    queued: 0,
+    counts: {
+      frozen_gps: 0,
+      clock_skew: 0,
+      duplicate: 0,
+      out_of_order: 0,
+      battery_dead: 0,
+      teleport: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("fault presets", () => {
+  it("labels every fault kind the wire can carry", () => {
+    for (const kind of KINDS) {
+      expect(FAULT_KIND_LABEL[kind]).toBeTruthy();
+    }
+  });
+
+  it("gives every preset a distinct id and a non-empty profile", () => {
+    const ids = FAULT_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const preset of FAULT_PRESETS) {
+      expect(Object.keys(preset.profile).length).toBeGreaterThan(0);
+      expect(preset.hint).toBeTruthy();
+    }
+  });
+
+  it("keeps every preset within the simulator's validation bounds", () => {
+    // Mirrors `faultProfileSchema`: probabilities in [0, 1], durations
+    // non-negative integers, max >= min. A preset that 400s is a dead button.
+    for (const { profile } of FAULT_PRESETS) {
+      if (profile.frozenGps) {
+        expect(profile.frozenGps.probability).toBeGreaterThanOrEqual(0);
+        expect(profile.frozenGps.probability).toBeLessThanOrEqual(1);
+        expect(profile.frozenGps.maxDurationMs).toBeGreaterThanOrEqual(
+          profile.frozenGps.minDurationMs
+        );
+        expect(Number.isInteger(profile.frozenGps.minDurationMs)).toBe(true);
+      }
+      if (profile.duplicate) {
+        expect(profile.duplicate.maxCopies).toBeGreaterThanOrEqual(1);
+        expect(profile.duplicate.maxCopies).toBeLessThanOrEqual(10);
+      }
+      if (profile.battery) {
+        expect(profile.battery.initialPercent).toBeLessThanOrEqual(100);
+        expect(profile.battery.dieAtPercent).toBeLessThanOrEqual(profile.battery.initialPercent);
+      }
+      if (profile.outOfOrder) expect(Number.isInteger(profile.outOfOrder.holdMs)).toBe(true);
+      if (profile.teleport) expect(profile.teleport.radiusMeters).toBeGreaterThanOrEqual(0);
+      if (profile.clockSkew) expect(Number.isInteger(profile.clockSkew.offsetMs)).toBe(true);
+    }
+  });
+});
+
+describe("describeProfile", () => {
+  it("summarises each armed group as a percentage or magnitude", () => {
+    expect(
+      describeProfile({
+        frozenGps: { probability: 0.15, minDurationMs: 1000, maxDurationMs: 2000 },
+        clockSkew: { offsetMs: -45_000 },
+        battery: { initialPercent: 40, drainPercentPerHour: 10, dieAtPercent: 5 },
+      })
+    ).toBe("freeze 15% · skew -45s · battery 40%");
+  });
+
+  it("says so for an empty profile", () => {
+    expect(describeProfile({})).toBe("nothing armed");
+  });
+});
+
+describe("matchPreset", () => {
+  it("recognises a profile that came from a preset", () => {
+    expect(matchPreset(FAULT_PRESETS[3].profile)?.id).toBe(FAULT_PRESETS[3].id);
+  });
+
+  it("does not claim a hand-tuned profile", () => {
+    expect(matchPreset({ duplicate: { probability: 0.99, maxCopies: 9 } })).toBeUndefined();
+  });
+
+  it("handles an absent profile", () => {
+    expect(matchPreset(undefined)).toBeUndefined();
+  });
+});
+
+describe("countMisbehavingDevices", () => {
+  it("counts frozen, dead and spoofing devices", () => {
+    const count = countMisbehavingDevices(
+      { enabled: true, vehicles: {} },
+      status({ frozen: 2, dead: 1, teleporting: 3 })
+    );
+    expect(count).toBe(6);
+  });
+
+  it("ignores in-flight bookkeeping", () => {
+    const count = countMisbehavingDevices(
+      { enabled: true, vehicles: {} },
+      status({ held: 5, queued: 7 })
+    );
+    expect(count).toBe(0);
+  });
+
+  it("reads as zero while the layer is disarmed, even with latched counters", () => {
+    const count = countMisbehavingDevices(
+      { enabled: false, vehicles: {} },
+      status({ frozen: 4, dead: 2 })
+    );
+    expect(count).toBe(0);
+  });
+
+  it("reads as zero before anything has loaded", () => {
+    expect(countMisbehavingDevices(null, null)).toBe(0);
+    expect(countMisbehavingDevices({ enabled: true, vehicles: {} }, null)).toBe(0);
+  });
+});

--- a/apps/ui/src/lib/faultPresets.ts
+++ b/apps/ui/src/lib/faultPresets.ts
@@ -1,0 +1,126 @@
+import type {
+  DeviceFaultConfig,
+  DeviceFaultKind,
+  DeviceFaultProfile,
+  DeviceFaultStatus,
+} from "@/types";
+
+/** Operator-facing wording for the wire's snake_case fault kinds. */
+export const FAULT_KIND_LABEL: Record<DeviceFaultKind, string> = {
+  frozen_gps: "frozen",
+  clock_skew: "clock",
+  duplicate: "duplicate",
+  out_of_order: "reordered",
+  battery_dead: "battery",
+  teleport: "spoofed",
+};
+
+export interface FaultPreset {
+  id: string;
+  label: string;
+  hint: string;
+  profile: DeviceFaultProfile;
+}
+
+/**
+ * Ready-made device profiles.
+ *
+ * These are the misbehaviours a downstream consumer actually has to survive,
+ * each expressed as one named device rather than as six independent probability
+ * knobs. Values are deliberately visible-within-a-minute at the default report
+ * cadence: a preset that fires once an hour teaches an operator nothing.
+ */
+export const FAULT_PRESETS: FaultPreset[] = [
+  {
+    id: "flaky-gps",
+    label: "Flaky GPS",
+    hint: "The tracker latches its last fix for seconds at a time",
+    profile: {
+      frozenGps: { probability: 0.15, minDurationMs: 5_000, maxDurationMs: 20_000 },
+    },
+  },
+  {
+    id: "bad-clock",
+    label: "Bad clock",
+    hint: "Device timestamps run 45s late and drift further as it runs",
+    profile: {
+      clockSkew: { offsetMs: -45_000, driftMsPerMinute: 250 },
+    },
+  },
+  {
+    id: "chatty",
+    label: "Chatty",
+    hint: "Retransmits: duplicate samples, and some arriving out of order",
+    profile: {
+      duplicate: { probability: 0.25, maxCopies: 2 },
+      outOfOrder: { probability: 0.15, holdMs: 4_000 },
+    },
+  },
+  {
+    id: "dying-battery",
+    label: "Dying battery",
+    hint: "Drains fast from 40% and goes silent at 5%",
+    profile: {
+      battery: { initialPercent: 40, drainPercentPerHour: 120, dieAtPercent: 5 },
+    },
+  },
+  {
+    id: "spoofed",
+    label: "Spoofed",
+    hint: "Position jumps up to 2km away and holds there briefly",
+    profile: {
+      teleport: { probability: 0.08, radiusMeters: 2000, holdMs: 10_000 },
+    },
+  },
+  {
+    id: "worst-case",
+    label: "Worst case",
+    hint: "Everything at once — the integration test nobody wants to fail",
+    profile: {
+      frozenGps: { probability: 0.1, minDurationMs: 4_000, maxDurationMs: 15_000 },
+      clockSkew: { offsetMs: 30_000, driftMsPerMinute: 100 },
+      duplicate: { probability: 0.2, maxCopies: 3 },
+      outOfOrder: { probability: 0.1, holdMs: 3_000 },
+      battery: { initialPercent: 60, drainPercentPerHour: 90, dieAtPercent: 2 },
+      teleport: { probability: 0.05, radiusMeters: 1500, holdMs: 8_000 },
+    },
+  },
+];
+
+/** One-line summary of what a profile does, for a list row. */
+export function describeProfile(profile: DeviceFaultProfile): string {
+  const parts: string[] = [];
+  if (profile.frozenGps) parts.push(`freeze ${pct(profile.frozenGps.probability)}`);
+  if (profile.clockSkew) parts.push(`skew ${Math.round(profile.clockSkew.offsetMs / 1000)}s`);
+  if (profile.duplicate) parts.push(`dupe ${pct(profile.duplicate.probability)}`);
+  if (profile.outOfOrder) parts.push(`reorder ${pct(profile.outOfOrder.probability)}`);
+  if (profile.battery) parts.push(`battery ${profile.battery.initialPercent}%`);
+  if (profile.teleport) parts.push(`spoof ${pct(profile.teleport.probability)}`);
+  return parts.length > 0 ? parts.join(" · ") : "nothing armed";
+}
+
+/**
+ * Devices currently misbehaving in a way an operator would want badged: a fix
+ * that isn't moving, a device that has gone silent, or a position that isn't
+ * real. Withheld/queued samples are in-flight bookkeeping, not a bad device, so
+ * they are deliberately excluded. Reads as zero while the layer is disarmed —
+ * latched counters from an earlier armed run must not badge a quiet fleet.
+ */
+export function countMisbehavingDevices(
+  config: DeviceFaultConfig | null,
+  status: DeviceFaultStatus | null
+): number {
+  if (!config?.enabled || !status) return 0;
+  return status.frozen + status.dead + status.teleporting;
+}
+
+/** Which preset (if any) a profile is, so the panel can mark it as active. */
+export function matchPreset(profile: DeviceFaultProfile | undefined): FaultPreset | undefined {
+  if (!profile) return undefined;
+  const serialized = JSON.stringify(profile);
+  return FAULT_PRESETS.find((p) => JSON.stringify(p.profile) === serialized);
+}
+
+function pct(probability: number): string {
+  return `${Math.round(probability * 100)}%`;
+}

--- a/apps/ui/src/types.ts
+++ b/apps/ui/src/types.ts
@@ -22,6 +22,12 @@ export type {
   JobStop,
   JobAssignmentStrategy,
   CreateJobRequest,
+  DeviceFaultKind,
+  DeviceFaultInfo,
+  DeviceFaultProfile,
+  DeviceFaultConfig,
+  DeviceFaultStatus,
+  DeviceFaultState,
   RecordingMetadata,
   ReplayStatus,
   // Moved from this file into shared-types (single cross-service source of truth).

--- a/apps/ui/src/utils/client.ts
+++ b/apps/ui/src/utils/client.ts
@@ -16,6 +16,7 @@ import { RecordingSegment } from "./client/recording";
 import { TelemetrySegment } from "./client/telemetry";
 import { GeofenceSegment } from "./client/geofences";
 import { ScenarioSegment } from "./client/scenarios";
+import { FaultSegment } from "./client/faults";
 
 class SimulationService {
   // ─── Connection / core real-time channels ──────────────────────
@@ -95,6 +96,16 @@ class SimulationService {
   offJobSlaBreach: JobSegment["offJobSlaBreach"];
   onJobDeleted: JobSegment["onJobDeleted"];
   offJobDeleted: JobSegment["offJobDeleted"];
+
+  // ─── Device faults ──────────────────────────────────────────────
+  getFaults: FaultSegment["getFaults"];
+  configureFaults: FaultSegment["configureFaults"];
+  getFaultStatus: FaultSegment["getFaultStatus"];
+  resetFaults: FaultSegment["resetFaults"];
+  setVehicleFaultProfile: FaultSegment["setVehicleFaultProfile"];
+  clearVehicleFaultProfile: FaultSegment["clearVehicleFaultProfile"];
+  onFaultsConfig: FaultSegment["onFaultsConfig"];
+  offFaultsConfig: FaultSegment["offFaultsConfig"];
 
   // ─── Incidents ──────────────────────────────────────────────────
   getIncidents: IncidentSegment["getIncidents"];
@@ -176,6 +187,7 @@ class SimulationService {
     const telemetry = new TelemetrySegment(deps);
     const geofences = new GeofenceSegment(deps);
     const scenarios = new ScenarioSegment(deps);
+    const faults = new FaultSegment(deps);
 
     // Re-expose each segment's bound methods. They are already bound in their
     // segment constructors, so assigning the references keeps them safe to
@@ -253,6 +265,15 @@ class SimulationService {
     this.offJobSlaBreach = jobs.offJobSlaBreach;
     this.onJobDeleted = jobs.onJobDeleted;
     this.offJobDeleted = jobs.offJobDeleted;
+
+    this.getFaults = faults.getFaults;
+    this.configureFaults = faults.configureFaults;
+    this.getFaultStatus = faults.getFaultStatus;
+    this.resetFaults = faults.resetFaults;
+    this.setVehicleFaultProfile = faults.setVehicleFaultProfile;
+    this.clearVehicleFaultProfile = faults.clearVehicleFaultProfile;
+    this.onFaultsConfig = faults.onFaultsConfig;
+    this.offFaultsConfig = faults.offFaultsConfig;
 
     this.getIncidents = incidents.getIncidents;
     this.createRandomIncident = incidents.createRandomIncident;

--- a/apps/ui/src/utils/client/faults.ts
+++ b/apps/ui/src/utils/client/faults.ts
@@ -1,0 +1,75 @@
+import type { ClientDeps } from "./types";
+import type { ApiResponse } from "@/types";
+import type {
+  DeviceFaultConfig,
+  DeviceFaultProfile,
+  DeviceFaultState,
+  DeviceFaultStatus,
+} from "@moveet/shared-types";
+
+/** Patch body for `POST /faults`. Every field is optional; `default: null` clears it. */
+export interface FaultConfigPatch {
+  enabled?: boolean;
+  seed?: number;
+  default?: DeviceFaultProfile | null;
+  vehicles?: Record<string, DeviceFaultProfile>;
+}
+
+/**
+ * Device fault injection: the configuration (what is armed), the live status
+ * snapshot (what the devices are doing), and the `faults:config` channel the
+ * simulator pushes on every configuration change — including ones made by
+ * another operator or by a startup env var.
+ */
+export class FaultSegment {
+  constructor(private deps: ClientDeps) {
+    this.getFaults = this.getFaults.bind(this);
+    this.configureFaults = this.configureFaults.bind(this);
+    this.getFaultStatus = this.getFaultStatus.bind(this);
+    this.resetFaults = this.resetFaults.bind(this);
+    this.setVehicleFaultProfile = this.setVehicleFaultProfile.bind(this);
+    this.clearVehicleFaultProfile = this.clearVehicleFaultProfile.bind(this);
+    this.onFaultsConfig = this.onFaultsConfig.bind(this);
+    this.offFaultsConfig = this.offFaultsConfig.bind(this);
+  }
+
+  /** Configuration plus a live status snapshot, in one request. */
+  async getFaults(): Promise<ApiResponse<DeviceFaultState>> {
+    return this.deps.http.get<DeviceFaultState>("/faults");
+  }
+
+  async configureFaults(patch: FaultConfigPatch): Promise<ApiResponse<DeviceFaultConfig>> {
+    return this.deps.http.post<FaultConfigPatch, DeviceFaultConfig>("/faults", patch);
+  }
+
+  async getFaultStatus(): Promise<ApiResponse<DeviceFaultStatus>> {
+    return this.deps.http.get<DeviceFaultStatus>("/faults/status");
+  }
+
+  /** Clears latched device state (dead batteries, frozen windows) — not the config. */
+  async resetFaults(): Promise<ApiResponse<DeviceFaultStatus>> {
+    return this.deps.http.post<undefined, DeviceFaultStatus>("/faults/reset");
+  }
+
+  async setVehicleFaultProfile(
+    vehicleId: string,
+    profile: DeviceFaultProfile
+  ): Promise<ApiResponse<DeviceFaultConfig>> {
+    return this.deps.http.put<DeviceFaultProfile, DeviceFaultConfig>(
+      `/faults/vehicles/${vehicleId}`,
+      profile
+    );
+  }
+
+  async clearVehicleFaultProfile(vehicleId: string): Promise<ApiResponse<DeviceFaultConfig>> {
+    return this.deps.http.delete<DeviceFaultConfig>(`/faults/vehicles/${vehicleId}`);
+  }
+
+  onFaultsConfig(handler: (data: DeviceFaultConfig) => void): void {
+    this.deps.ws.on("faults:config", handler);
+  }
+
+  offFaultsConfig(handler?: (data: DeviceFaultConfig) => void): void {
+    this.deps.ws.off("faults:config", handler);
+  }
+}

--- a/apps/ui/src/utils/client/segments.test.ts
+++ b/apps/ui/src/utils/client/segments.test.ts
@@ -9,6 +9,7 @@ import { RecordingSegment } from "./recording";
 import { TelemetrySegment } from "./telemetry";
 import { GeofenceSegment } from "./geofences";
 import { ScenarioSegment } from "./scenarios";
+import { FaultSegment } from "./faults";
 
 // Per-segment delegation tests. The facade test (../client.test.ts) drives the
 // singleton, but the per-segment source modules (utils/client/*.ts) are mostly
@@ -21,6 +22,7 @@ function makeDeps() {
     get: vi.fn().mockResolvedValue({ data: undefined }),
     post: vi.fn().mockResolvedValue({ data: undefined }),
     patch: vi.fn().mockResolvedValue({ data: undefined }),
+    put: vi.fn().mockResolvedValue({ data: undefined }),
     delete: vi.fn().mockResolvedValue({ data: undefined }),
   };
   const ws = {
@@ -312,6 +314,44 @@ describe("JobSegment", () => {
       expect(h.ws.on).toHaveBeenCalledWith(e, fn);
       expect(h.ws.off).toHaveBeenCalledWith(e, undefined);
     }
+  });
+});
+
+describe("FaultSegment", () => {
+  let h: ReturnType<typeof makeDeps>;
+  let seg: FaultSegment;
+  beforeEach(() => {
+    h = makeDeps();
+    seg = new FaultSegment(h.deps);
+  });
+
+  it("routes the device-fault endpoints", async () => {
+    const profile = { duplicate: { probability: 0.2, maxCopies: 2 } };
+    await seg.getFaults();
+    await seg.getFaultStatus();
+    await seg.configureFaults({ enabled: true, seed: 7 });
+    await seg.resetFaults();
+    await seg.setVehicleFaultProfile("v1", profile);
+    await seg.clearVehicleFaultProfile("v1");
+    expect(h.http.get).toHaveBeenCalledWith("/faults");
+    expect(h.http.get).toHaveBeenCalledWith("/faults/status");
+    expect(h.http.post).toHaveBeenCalledWith("/faults", { enabled: true, seed: 7 });
+    expect(h.http.post).toHaveBeenCalledWith("/faults/reset");
+    expect(h.http.put).toHaveBeenCalledWith("/faults/vehicles/v1", profile);
+    expect(h.http.delete).toHaveBeenCalledWith("/faults/vehicles/v1");
+  });
+
+  it("clears the fleet-wide profile with an explicit null", async () => {
+    await seg.configureFaults({ default: null });
+    expect(h.http.post).toHaveBeenCalledWith("/faults", { default: null });
+  });
+
+  it("wires the faults:config ws channel", () => {
+    const fn = vi.fn();
+    seg.onFaultsConfig(fn);
+    seg.offFaultsConfig();
+    expect(h.ws.on).toHaveBeenCalledWith("faults:config", fn);
+    expect(h.ws.off).toHaveBeenCalledWith("faults:config", undefined);
   });
 });
 

--- a/apps/ui/src/utils/httpClient.test.ts
+++ b/apps/ui/src/utils/httpClient.test.ts
@@ -208,5 +208,45 @@ describe("HttpClient", () => {
 
       expect(result.error).toBe("intensity must be between 0 and 1");
     });
+
+    it("reports the server's message on a rejected PUT", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: "maxDurationMs must be >= minDurationMs" }),
+      });
+
+      const result = await client.put("/faults/vehicles/v1", {});
+
+      expect(result.error).toBe("maxDurationMs must be >= minDurationMs");
+    });
+  });
+
+  describe("put", () => {
+    it("sends a JSON body and returns the parsed response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ enabled: true, vehicles: {} }),
+      });
+
+      const result = await client.put("/faults/vehicles/v1", { clockSkew: { offsetMs: 1000 } });
+
+      expect(mockFetch).toHaveBeenCalledWith("http://localhost:5010/faults/vehicles/v1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clockSkew: { offsetMs: 1000 } }),
+      });
+      expect(result.data).toEqual({ enabled: true, vehicles: {} });
+    });
+
+    it("returns a transport failure as an error rather than throwing", async () => {
+      mockFetch.mockRejectedValue(new Error("Network down"));
+
+      const result = await client.put("/faults/vehicles/v1", {});
+
+      expect(result.error).toBe("Network down");
+      expect(result.data).toBeUndefined();
+    });
   });
 });

--- a/apps/ui/src/utils/httpClient.ts
+++ b/apps/ui/src/utils/httpClient.ts
@@ -77,6 +77,22 @@ export class HttpClient {
     }
   }
 
+  async put<TBody, TReturn = void>(path: string, body?: TBody): Promise<ApiResponse<TReturn>> {
+    try {
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!res.ok) return { data: undefined, error: await readErrorMessage(res, `PUT ${path}`) };
+      const data = await res.json();
+      return { data };
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return { data: undefined, error: errorMessage };
+    }
+  }
+
   async patch<TBody, TReturn = void>(path: string, body?: TBody): Promise<ApiResponse<TReturn>> {
     try {
       const res = await fetch(`${this.baseUrl}${path}`, {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -136,6 +136,14 @@ export interface DeviceFaultStatus {
 }
 
 /**
+ * `GET /faults`: the configuration plus a live status snapshot, so an operator
+ * surface can render "what is armed" and "what is happening" from one request.
+ */
+export interface DeviceFaultState extends DeviceFaultConfig {
+  status: DeviceFaultStatus;
+}
+
+/**
  * Vehicle data exported from a data source (adapter) or consumed by the simulator.
  * Known as `DataVehicle` in the simulator and `ExportVehicle` in the adapter.
  */

--- a/packages/shared-types/src/ws.ts
+++ b/packages/shared-types/src/ws.ts
@@ -46,6 +46,24 @@ export interface Heatzone {
 }
 
 /**
+ * Why a vehicle's route changed.
+ *
+ * Needed because "this vehicle got a new route" is ambiguous on its own: an
+ * incident reroute keeps driving the same trip, whereas an operator dispatch
+ * replaces it. `JobManager` uses this to tell its own assignment apart from a
+ * vehicle being taken off its job mid-trip.
+ */
+export type DirectionReason =
+  /** Single-destination dispatch (`POST /direction`). */
+  | "dispatch"
+  /** Multi-stop route set, including a job assignment. */
+  | "waypoints"
+  /** The simulator picked the next wander destination itself. */
+  | "random"
+  /** Same trip, new path around an incident. */
+  | "reroute";
+
+/**
  * A vehicle's active route + ETA, broadcast on the `direction` channel and
  * carried in `ResetPayload.directions`. `eta` is optional because the
  * simulator's reset-time direction snapshot may omit it.
@@ -56,6 +74,11 @@ export interface VehicleDirection {
   eta?: number;
   waypoints?: Waypoint[];
   currentWaypointIndex?: number;
+  /**
+   * Why this route was set. Optional for backward compatibility: a reset-time
+   * snapshot describes an existing route rather than a change.
+   */
+  reason?: DirectionReason;
 }
 
 /**


### PR DESCRIPTION
The last three PRs landed the trip/job model (#235), unified interaction modes (#238) and device-level fault injection (#237). Each is sound in isolation; this closes the seams between them.

Closes fleetsim-all-51d6, fleetsim-all-n8yk, fleetsim-all-d12p, fleetsim-all-6v15.

## The bug worth reading first (fleetsim-all-51d6, P1)

Jobs reported deliveries that never happened.

`RouteManager.updateVehicle` handed a vehicle a random destination whenever a dwell expired — including the dwell at an **intermediate** stop, where `handleRouteCompleted` had already loaded the next leg. So a job's vehicle abandoned its dropoff leg the instant it finished collecting the load. And because neither `findAndSetRoutes` nor `setRandomDestination` cleared `vehicle.waypoints` / `waypointRoutes`, when that wander route finished, `handleRouteCompleted` took the multi-stop branch, replayed the abandoned trip's `waypoint:reached`, and emitted `route:completed` — which `JobManager` reads as a delivery. At a random location.

- A dwell with a route still loaded resumes the trip; only a dwell with nothing left to drive picks a new destination.
- A single-destination route (operator dispatch or wander) clears the multi-stop state it replaces.
- `direction` now carries a `reason` (`dispatch` / `waypoints` / `random` / `reroute`), so `JobManager` can tell its own assignment from a vehicle being taken off its job: re-queue if the load was not yet collected, **fail with an explicit error** if it was, and ignore an incident re-route (same trip, new path).

## API precision (fleetsim-all-n8yk)

`vehicleId` was shape-checked but never resolved, so a manual job naming an unknown or busy vehicle was accepted and then pended forever behind `"Waiting for an available vehicle"`.

- `POST /jobs` and `POST /jobs/:id/assign`: `404` for an unknown vehicle, `409` for one already carrying another job (body names it under `job`; naming the vehicle that already holds *this* job is still fine).
- A manual job whose vehicle left the fleet, or cannot reach the pickup, now fails instead of pending forever; while waiting it says which vehicle and which job it is queued behind.
- `GET /faults` gained a shared response type (`DeviceFaultState`) instead of an ad-hoc config+status merge. OpenAPI updated, including a `VehicleJobConflict` schema.

## Device faults, now operable (fleetsim-all-d12p)

The fault layer shipped with a full REST surface, a `faults:config` broadcast and per-sample `vehicle.faults` — and zero UI. Added:

- `FaultSegment` client (+ `HttpClient.put`) and a `useFaults` hook that treats the simulator as authoritative (config can also come from an env var at boot or another client) and polls the live counters only while the panel is open.
- **Monitor → Faults**: arm/disarm, seed, profile presets applied fleet-wide or to one device, live device counters, per-kind trigger totals, state clear.
- Per-vehicle: a fault badge on vehicle rows, and an inspector **Device** section (active kinds, remaining battery, clock skew, device clock). Both render nothing for a device with no fault profile, so the default UI is unchanged.
- Command palette: arm/disarm faults, clear device state.

## Job board seams (fleetsim-all-6v15)

- Reassignment is reachable at last (`client.assignJob` was dead code): a pre-pickup job can re-run a strategy or be handed a named vehicle, with busy units left out of the picker.
- Vehicle rows and the inspector show the job reference a unit is carrying, so an operator can see a busy vehicle *before* re-dispatching it.
- Job placement renders the shared `ModeBanner` — it already took Escape first, but a placement started from the command palette was previously just a cursor change.

## Verification

- `npm run type-check`, `npm run lint`, `npm run build`: clean.
- Tests: simulator 1854 (3 consecutive full-suite runs), UI 1308, adapter 688, server-kit 41, repo-policy 12. Simulator coverage thresholds hold.
- Against a live simulator with faults armed:
  - a job ran `en_route → on_scene → transporting → complete` and was delivered at the actual dropoff coordinate (this is the fix; before it completed wherever the wander route happened to end);
  - `404` / `409` / `200` confirmed for unknown, busy and free vehicles;
  - in the browser: the Faults tab badged 24 misbehaving devices, arming a preset on one device from the panel took effect on the server and showed up as a `spoofed` badge on that vehicle's row, the inspector showed `JOB-2D8C` plus battery 6% and clock skew, reassign moved a live job between vehicles, and the placement banner appeared and cleared on Escape.

One caveat: a single full-suite simulator run failed once in `routes/replay.test.ts` with `Parse Error: Expected HTTP/, RTSP/ or ICE/` (a supertest transport flake, unrelated to these code paths). It did not reproduce across three subsequent full-suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
