### PR TITLE
feat(ui): lift the map ground out of near-black

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -126,6 +126,7 @@ mode goes through `useModeGuard`, which asks before discarding in-flight work
 
 - Tailwind v4 utilities + an oklch `@theme` palette in `src/index.css` (dark-only). A small motion scale (`duration-fast|normal|slow`) maps to `--transition-duration-*`; the 700 ms entrance animation is reserved for the one-time `[data-ready]` reveal.
 - A polish token layer in `src/index.css` adds refined easing curves (`--ease-*`), a layered shadow scale with a built-in edge highlight (`shadow-raised|elevated|floating|glow-accent`), whisper-soft surface gradient utilities (`surface-glass|raised|accent`), and curated entrance animations, all under a `prefers-reduced-motion` guard. Applied across panels, the icon rail, floating overlays, and the shadcn input primitives.
+- The map's ground is CSS, not WebGL: deck.gl clears its canvas transparent, so the `map-backdrop` utility on the map surface paints it: a lifted field (`--color-map-ground|lift|edge`), a tiled inline-SVG graticule (32 px hairline grid + a crosshair every 160 px), and a vignette. All static paint, so panning costs nothing extra.
 - `src/styles/tokens.css` holds the few domain color tokens read at runtime by canvas/deck.gl code that can't use Tailwind classes (POI category fills, `--color-vehicle-*`).
 - Components compose classes with `cn()` (`src/lib/utils.ts`); shadcn/ui primitives live in `src/components/ui/`.
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -540,7 +540,10 @@ export default function App() {
           data-ready={dataReady ? "" : undefined}
         >
           <ErrorBoundary fallback={<SectionErrorFallback section="Map" />}>
-            <div className="relative flex min-h-0 min-w-0 flex-1">
+            {/* `map-backdrop` paints the map's ground: deck.gl clears its
+                canvas transparent, so this element is what shows between the
+                roads and vehicles. */}
+            <div className="map-backdrop relative flex min-h-0 min-w-0 flex-1">
               <ConnectionStatus connectionInfo={connectionInfo} onRetry={client.retryConnection} />
               <LoadingOverlay visible={mapLoading} />
               <MapView

--- a/apps/ui/src/Map/Map.tsx
+++ b/apps/ui/src/Map/Map.tsx
@@ -196,7 +196,7 @@ export default function Map({
       <DeckGLMap
         data={network}
         strokeOpacity={modifiers.showDirections ? 0.4 : 0}
-        strokeColor="#444"
+        strokeColor="#5b6575"
         strokeWidth={1.5}
         onClick={onMapClick}
         onContextClick={onMapContextClick}

--- a/apps/ui/src/components/Map/components/DeckGLMap.tsx
+++ b/apps/ui/src/components/Map/components/DeckGLMap.tsx
@@ -55,6 +55,12 @@ interface DeckGLMapProps {
   panLocked?: boolean;
 }
 
+// Highways sit a step above minor roads (whose color arrives as `strokeColor`)
+// so the trunk network reads first. Both are pitched to stay legible over the
+// lifted map ground (`map-backdrop` in index.css); the old near-black-era
+// #444 disappeared into it.
+const HIGHWAY_COLOR = "#6d7889";
+
 // Separate road features into regular roads and highways for distinct styling,
 // then cull each group to the current viewport + zoom LOD before binding.
 function useRoadLayers(
@@ -100,7 +106,7 @@ function useRoadLayers(
 
   return useMemo(() => {
     const roadColor = hexToRgba(strokeColor, strokeOpacity);
-    const highwayColor = hexToRgba("#444", strokeOpacity);
+    const highwayColor = hexToRgba(HIGHWAY_COLOR, strokeOpacity);
     // Color/opacity flows through getColor with an updateTriggers key so only
     // the color attribute re-evaluates. Geometry re-uploads only when the
     // bound `data` array actually changes (viewport/zoom cull), and deck.gl
@@ -131,7 +137,7 @@ function useRoadLayers(
         widthMinPixels: 1,
         jointRounded: true,
         capRounded: true,
-        updateTriggers: { getColor: `#444:${strokeOpacity}` },
+        updateTriggers: { getColor: `${HIGHWAY_COLOR}:${strokeOpacity}` },
       }),
     ];
   }, [visibleRoads, visibleHighways, strokeColor, strokeWidth, strokeOpacity]);

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -13,19 +13,25 @@
 
   /* Professional dark palette: deep near-neutral base, clearly elevated
      surfaces, visible borders, crisp text, one refined-blue accent
-     (primary = accent = ring for a single coherent highlight). */
-  --color-background: oklch(0.155 0.008 255);
+     (primary = accent = ring for a single coherent highlight).
+
+     The whole ladder sits ~4 lightness points above where it started: the map
+     ground is no longer a near-black void (see `map-backdrop` below), so every
+     surface stacked on it had to come up with it to keep the same elevation
+     gaps. Read the numbers as a scale, not as absolutes: background < card <
+     popover < muted < secondary, ~4 points apart. */
+  --color-background: oklch(0.185 0.009 255);
   --color-foreground: oklch(0.965 0.004 255);
-  --color-card: oklch(0.205 0.009 255);
+  --color-card: oklch(0.245 0.011 255);
   --color-card-foreground: oklch(0.965 0.004 255);
-  --color-popover: oklch(0.215 0.01 255);
+  --color-popover: oklch(0.258 0.012 255);
   --color-popover-foreground: oklch(0.965 0.004 255);
   --color-primary: oklch(0.62 0.15 250);
   --color-primary-foreground: oklch(0.99 0 0);
-  --color-secondary: oklch(0.255 0.011 255);
+  --color-secondary: oklch(0.295 0.013 255);
   --color-secondary-foreground: oklch(0.965 0.004 255);
-  --color-muted: oklch(0.235 0.009 255);
-  --color-muted-foreground: oklch(0.7 0.012 255);
+  --color-muted: oklch(0.275 0.011 255);
+  --color-muted-foreground: oklch(0.72 0.012 255);
   --color-accent: oklch(0.62 0.15 250);
   --color-accent-foreground: oklch(0.99 0 0);
   --color-destructive: oklch(0.62 0.2 22);
@@ -38,6 +44,18 @@
   --color-border-soft: oklch(1 0 0 / 6%);
   --color-input: oklch(1 0 0 / 16%);
   --color-ring: oklch(0.62 0.15 250);
+
+  /* ── Map ground ────────────────────────────────────────────────────────
+     The deck.gl canvas is transparent, so whatever sits behind it *is* the
+     map's ground. These three drive the `map-backdrop` utility: a lit centre,
+     a base field, and a cool edge the vignette fades into. Kept a touch more
+     chromatic than the chrome neutrals so the ground reads as terrain rather
+     than as one more panel. */
+  --color-map-lift: oklch(0.232 0.014 258);
+  --color-map-ground: oklch(0.205 0.012 258);
+  /* Slightly translucent so the graticule stays faintly readable inside the
+     vignette instead of being painted out at the corners. */
+  --color-map-edge: oklch(0.17 0.013 258 / 0.5);
 
   /* Domain semantic status tokens (decoupled from deck.gl color ramps) */
   --color-status-ok: oklch(0.74 0.15 152);
@@ -111,11 +129,11 @@
   /* Bottom stop of the `surface-glass` gradient, promoted to a token so the
      cluster badge rings reference one value instead of re-inlining the oklch
      literal. */
-  --color-glass-bot: oklch(0.21 0.009 255 / 0.55);
+  --color-glass-bot: oklch(0.25 0.011 255 / 0.55);
   /* Bottom stop of the more-transparent `surface-glass-strong` — used by the
      floating dock panel and its notch so it reads as frosted glass, not a
      flat slab, at panel size. */
-  --color-glass-strong-bot: oklch(0.21 0.009 255 / 0.5);
+  --color-glass-strong-bot: oklch(0.25 0.011 255 / 0.5);
 }
 
 /* ── Polish layer: whisper-soft surface gradients ────────────────────────
@@ -135,8 +153,8 @@
 @utility surface-glass {
   background-image: linear-gradient(
     180deg,
-    oklch(0.245 0.011 255 / 0.6),
-    oklch(0.21 0.009 255 / 0.55)
+    oklch(0.285 0.013 255 / 0.6),
+    oklch(0.25 0.011 255 / 0.55)
   );
 }
 /* A markedly more transparent glass for large floating surfaces (the dock
@@ -147,8 +165,8 @@
 @utility surface-glass-strong {
   background-image: linear-gradient(
     180deg,
-    oklch(0.245 0.011 255 / 0.56),
-    oklch(0.21 0.009 255 / 0.5)
+    oklch(0.285 0.013 255 / 0.56),
+    oklch(0.25 0.011 255 / 0.5)
   );
 }
 /* ── The frosting itself ─────────────────────────────────────────────────
@@ -168,7 +186,44 @@
   backdrop-filter: blur(40px) saturate(1.7) brightness(1.35);
 }
 @utility surface-raised {
-  background-image: linear-gradient(180deg, oklch(0.224 0.009 255), oklch(0.198 0.009 255));
+  background-image: linear-gradient(180deg, oklch(0.264 0.011 255), oklch(0.238 0.011 255));
+}
+
+/* ── The map ground ──────────────────────────────────────────────────────
+   deck.gl clears its canvas transparent, so the element behind it paints the
+   map's ground. This is that ground: a lit field with a surveyor's graticule
+   on it, replacing the flat near-black that used to read as an empty void
+   whenever roads were hidden (road strokes only draw at 0.4 alpha, and only
+   with `showDirections` on).
+
+   Three stacked layers, top to bottom:
+     1. vignette      = darkens toward the edges so the centre reads focused
+                        and the dock/rails have something to sit against
+     2. graticule     = one 160px SVG tile: a 32px hairline grid plus a
+                        stronger cross tick at the tile corner, so every 160px
+                        intersection lands a small crosshair. Static, tiled by
+                        the compositor, so no repaint while panning the map,
+                        since the deck canvas is a separate element.
+     3. centre lift   = a wide radial that lifts the middle a few points
+
+   All of it is paint-once CSS: no animation, no per-frame cost, nothing the
+   RAF vehicle loop has to share the main thread with. */
+@utility map-backdrop {
+  background-color: var(--color-map-ground);
+  background-image:
+    radial-gradient(
+      ellipse 130% 110% at 50% 38%,
+      transparent 0%,
+      transparent 55%,
+      var(--color-map-edge) 100%
+    ),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cg fill='none' stroke='white'%3E%3Cpath stroke-opacity='.016' d='M0 .5h160M0 32.5h160M0 64.5h160M0 96.5h160M0 128.5h160M.5 0v160M32.5 0v160M64.5 0v160M96.5 0v160M128.5 0v160'/%3E%3Cpath stroke-opacity='.045' d='M.5 0v6M.5 154v6M0 .5h6M154 .5h6'/%3E%3C/g%3E%3C/svg%3E"),
+    radial-gradient(ellipse 90% 80% at 50% 42%, var(--color-map-lift), transparent 70%);
+  background-repeat: no-repeat, repeat, no-repeat;
+  background-size:
+    cover,
+    160px 160px,
+    cover;
 }
 @utility surface-accent {
   background-image: linear-gradient(180deg, oklch(0.658 0.15 250), oklch(0.6 0.15 250));


### PR DESCRIPTION
## What

The deck.gl canvas clears transparent, so whatever sits behind it *is* the map's ground. That ground was a flat `oklch(0.155)` near-black, and road strokes only draw at 0.4 alpha and only with `showDirections` on, so most of the time the map read as an empty void with vehicles floating in it.

This gives the map surface its own backdrop, `map-backdrop` (new `@utility` in `index.css`), built from three static layers:

1. **lifted field** — `--color-map-ground` / `--color-map-lift`, a wide radial that raises the centre a few lightness points
2. **graticule** — one 160px tiled inline SVG: 32px hairline grid plus a crosshair at every 160px intersection
3. **vignette** — `--color-map-edge`, soft, so the centre reads focused and the rails/dock have something to sit against

Because the ground came up, every surface stacked on it came up with it: `background/card/popover/muted/secondary`, both glass gradients and `surface-raised` shift ~4 lightness points, so the elevation gaps land where they were before. Road and highway strokes move to lighter, cooler hues for the same reason (the old `#444` vanished into the lifted ground); highways now sit a step above minor roads so the trunk network reads first.

The texture is deliberately near the threshold of perception: hairlines at 1.6% white, crosshairs at 4.5%, vignette at half strength. It should register as depth, not as a pattern.

## Cost

Nothing per frame. It is paint-once CSS on an element that is a *sibling* of the deck canvas, so panning and the RAF vehicle loop are untouched. No animation, so nothing new under the `prefers-reduced-motion` guard.

## Verification

- `npm test` in `apps/ui`: 121 files, 1443 tests passing
- `turbo type-check`: 6/6 packages
- `biome check` on the touched files: no new findings (the 4 pre-existing `noImportantStyles` warnings in the reduced-motion block are unchanged)
- Checked live against a running simulator at 1440x900: map ground, dock, Fleet panel over the lighter ground, rails, legends

Closes fleetsim-all-7gtf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)