### PR TITLE
fix: dispatch on true positions, bucketed analytics fetch, landmarks env through zod

### DIFF
--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -89,6 +89,11 @@ WS_GATEWAY_PORT=5020
 # Routing tunables
 # Minimum time (ms) between pathfinding retries for an unrouted vehicle
 PATHFIND_COOLDOWN_MS=3000
+# ALT landmarks precomputed for the A* heuristic (0-32). 0 disables the
+# preprocessing and restores the plain haversine heuristic; higher values narrow
+# the search further at a linear cost in build time and memory. Out-of-range and
+# malformed values are clamped/defaulted, never rejected.
+PATHFINDING_LANDMARKS=4
 
 # Adapter sync tunables
 # Maximum backoff delay (ms) between adapter sync attempts after consecutive failures

--- a/apps/simulator/src/__tests__/JobManager.test.ts
+++ b/apps/simulator/src/__tests__/JobManager.test.ts
@@ -15,13 +15,24 @@ class FakeVehicles extends EventEmitter implements JobVehicleGateway {
   unroutable = new Set<string>();
   /** vehicleId → ETA seconds returned by the probe. */
   etas = new Map<string, number>();
+  /**
+   * The fault-projected roster the WS/REST surface serves, when a test arms
+   * one. Deliberately allowed to disagree with the true roster so a test can
+   * prove which of the two assignment actually scores.
+   */
+  reported: VehicleDTO[] | null = null;
 
   constructor(private roster: VehicleDTO[]) {
     super();
   }
 
-  getVehicles(): VehicleDTO[] {
+  getTrueVehicles(): VehicleDTO[] {
     return this.roster;
+  }
+
+  /** The observer's view. Not an assignment input — here as the wrong answer. */
+  getVehicles(): VehicleDTO[] {
+    return this.reported ?? this.roster;
   }
 
   async findAndSetWaypointRoutes(
@@ -169,6 +180,41 @@ describe("JobManager", () => {
       });
 
       expect(job.vehicleId).toBe("near");
+    });
+
+    /**
+     * A device fault changes what a vehicle REPORTS, not where it is. Dispatch
+     * is the simulator's own decision, so arming a fault profile must not move
+     * a job onto a different unit.
+     */
+    it("scores true positions rather than the device-reported fix under nearest", async () => {
+      setup([vehicle("spoofed", 0.11, 0.11), vehicle("other", 1, 1)]);
+      // The spoofed device claims to be 9 degrees out; the vehicle has not moved.
+      vehicles.reported = [vehicle("spoofed", 9, 9), vehicle("other", 1, 1)];
+
+      const job = await manager.createJob({ pickup: PICKUP, dropoff: DROPOFF });
+
+      expect(job.vehicleId).toBe("spoofed");
+    });
+
+    it("shortlists best_eta probes from the positions the probe itself uses", async () => {
+      // Seven candidates, so the ETA shortlist actually truncates and a
+      // mis-scored unit is dropped before it is ever probed.
+      const fillers = [1, 2, 3, 4, 5, 6].map((n) => vehicle(`f${n}`, n, n));
+      setup([vehicle("spoofed", 0.11, 0.11), ...fillers]);
+      vehicles.reported = [vehicle("spoofed", 9, 9), ...fillers];
+      // estimateTo pathfinds from the TRUE position and rates the truly-nearest
+      // unit quickest, so the shortlist has to agree about where it is.
+      vehicles.etas.set("spoofed", 60);
+      for (const filler of fillers) vehicles.etas.set(filler.id, 900);
+
+      const job = await manager.createJob({
+        pickup: PICKUP,
+        dropoff: DROPOFF,
+        strategy: "best_eta",
+      });
+
+      expect(job.vehicleId).toBe("spoofed");
     });
 
     it("uses the named vehicle and marks the job manual when vehicleId is given", async () => {

--- a/apps/simulator/src/__tests__/config.test.ts
+++ b/apps/simulator/src/__tests__/config.test.ts
@@ -69,6 +69,21 @@ describe("envSchema / parseEnv", () => {
     );
   });
 
+  it("defaults, clamps and never rejects PATHFINDING_LANDMARKS", () => {
+    // The pathfinding worker cannot import this module (its esbuild bundle must
+    // stay free of zod/dotenv/pino), so the schema resolves the value and
+    // PathfindingPool ships the number in workerData. Out-of-range input is
+    // clamped rather than rejected: a bad landmark count must never stop the
+    // simulator from booting.
+    expect(parseEnv({}).PATHFINDING_LANDMARKS).toBe(4);
+    expect(parseEnv(validEnv({ PATHFINDING_LANDMARKS: "" })).PATHFINDING_LANDMARKS).toBe(4);
+    expect(parseEnv(validEnv({ PATHFINDING_LANDMARKS: "0" })).PATHFINDING_LANDMARKS).toBe(0);
+    expect(parseEnv(validEnv({ PATHFINDING_LANDMARKS: "8" })).PATHFINDING_LANDMARKS).toBe(8);
+    expect(parseEnv(validEnv({ PATHFINDING_LANDMARKS: "1000" })).PATHFINDING_LANDMARKS).toBe(32);
+    expect(parseEnv(validEnv({ PATHFINDING_LANDMARKS: "-3" })).PATHFINDING_LANDMARKS).toBe(4);
+    expect(parseEnv(validEnv({ PATHFINDING_LANDMARKS: "banana" })).PATHFINDING_LANDMARKS).toBe(4);
+  });
+
   it("coerces string env values to numbers", () => {
     const cfg = parseEnv(validEnv({ PORT: "3000", VEHICLE_COUNT: "10" }));
     expect(cfg.PORT).toBe(3000);
@@ -191,6 +206,20 @@ describe("logConfig", () => {
     expect(context).toHaveProperty("config");
 
     consoleSpy.mockRestore();
+  });
+
+  it("includes the pathfinding landmark count in the dump", () => {
+    // The whole point of routing PATHFINDING_LANDMARKS through the schema: it
+    // is now visible in the startup config dump like every other tunable.
+    vi.mocked(logger.info).mockClear();
+
+    logConfig();
+
+    const [context] = vi.mocked(logger.info).mock.calls[0] as [
+      { config: { pathfindingLandmarks: number } },
+    ];
+    expect(context.config).toHaveProperty("pathfindingLandmarks");
+    expect(typeof context.config.pathfindingLandmarks).toBe("number");
   });
 
   it("redacts the adapter URL", () => {

--- a/apps/simulator/src/__tests__/deviceFaultEgress.test.ts
+++ b/apps/simulator/src/__tests__/deviceFaultEgress.test.ts
@@ -4,15 +4,18 @@ import { VehicleManager } from "../modules/VehicleManager";
 import { FleetManager } from "../modules/FleetManager";
 import { RoadNetwork } from "../modules/RoadNetwork";
 import { AdapterSyncManager } from "../modules/AdapterSyncManager";
+import { JobManager } from "../modules/JobManager";
 import { config } from "../utils/config";
-import type { Vehicle, VehicleDTO } from "../types";
+import type { DirectionResult, Vehicle, VehicleDTO } from "../types";
 
 const FIXTURE_PATH = path.join(__dirname, "fixtures", "test-network.geojson");
 
 /**
  * Device faults must be observable in the OUTGOING telemetry, not just inside
  * the fault module. These tests cover the two egress paths: the `update` event
- * (WebSocket + recording) and the periodic adapter push.
+ * (WebSocket + recording) and the periodic adapter push — plus the boundary on
+ * the other side of them, where a simulator-internal decision (job assignment)
+ * must keep reading the truth.
  */
 
 describe("device fault egress — vehicle update stream", () => {
@@ -288,5 +291,98 @@ describe("device fault egress — adapter push", () => {
     const payload = await pushOnce(() => []);
 
     expect(payload).toBeUndefined();
+  });
+});
+
+/**
+ * Job assignment is the simulator's own dispatch decision, not one of the
+ * consumers the fault layer exists to deceive. Arming a profile must change
+ * what the fleet REPORTS without quietly changing which unit gets the work.
+ */
+describe("device faults — job assignment", () => {
+  let network: RoadNetwork;
+  let manager: VehicleManager;
+  let jobs: JobManager;
+  let origVehicleCount: number;
+  let origAdapterURL: string;
+
+  beforeEach(() => {
+    origVehicleCount = config.vehicleCount;
+    origAdapterURL = config.adapterURL;
+    (config as any).vehicleCount = 2;
+    (config as any).adapterURL = "";
+
+    network = new RoadNetwork(FIXTURE_PATH);
+
+    const proto = VehicleManager.prototype as any;
+    const origSetRandom = proto.setRandomDestination;
+    proto.setRandomDestination = function () {};
+    manager = new VehicleManager(network, new FleetManager());
+    proto.setRandomDestination = origSetRandom;
+
+    // The fixture network cannot route, and routing is not what is under test —
+    // only which vehicle the dispatcher hands the job to.
+    vi.spyOn(manager, "findAndSetWaypointRoutes").mockImplementation(
+      async (vehicleId: string): Promise<DirectionResult> => ({
+        vehicleId,
+        status: "ok",
+        route: { start: [0, 0], end: [1, 1], distance: 12 },
+        legs: [
+          { start: [0, 0], end: [0.5, 0.5], distance: 4 },
+          { start: [0.5, 0.5], end: [1, 1], distance: 8 },
+        ],
+      })
+    );
+
+    jobs = new JobManager(manager, { slaSeconds: 600, pickupDwellSeconds: 30 });
+  });
+
+  afterEach(() => {
+    jobs.dispose();
+    vi.restoreAllMocks();
+    (config as any).vehicleCount = origVehicleCount;
+    (config as any).adapterURL = origAdapterURL;
+    for (const v of manager.getVehicles()) manager.stopVehicleMovement(v.id);
+    manager.stopLocationUpdates();
+  });
+
+  function dtoFor(vehicle: Vehicle): VehicleDTO {
+    return {
+      id: vehicle.id,
+      name: vehicle.name,
+      type: vehicle.type,
+      position: vehicle.position,
+      speed: vehicle.speed,
+      heading: vehicle.bearing,
+    };
+  }
+
+  it("dispatches on the true position while the device reports a frozen fix", async () => {
+    const [spoofed, other] = [...manager.registry.getAll().values()];
+    manager.faults.configure({
+      enabled: true,
+      seed: 3,
+      vehicles: {
+        [spoofed.id]: {
+          frozenGps: { probability: 1, minDurationMs: 60_000, maxDurationMs: 60_000 },
+        },
+      },
+    });
+
+    // The device latches its fix a long way out, then the vehicle drives to
+    // within a stone's throw of the pickup while the fix stays behind.
+    spoofed.position = [9, 9];
+    manager.gameLoop.emit("update", dtoFor(spoofed));
+    spoofed.position = [0.11, 0.11];
+    other.position = [1, 1];
+
+    const job = await jobs.createJob({
+      pickup: { lat: 0.1, lng: 0.1 },
+      dropoff: { lat: 0.4, lng: 0.4 },
+    });
+
+    expect(job.vehicleId).toBe(spoofed.id);
+    // ...and the fault is still on the wire, which is the whole point of it.
+    expect(manager.getVehicles().find((v) => v.id === spoofed.id)!.position).toEqual([9, 9]);
   });
 });

--- a/apps/simulator/src/__tests__/pathfinding/altRealNetwork.test.ts
+++ b/apps/simulator/src/__tests__/pathfinding/altRealNetwork.test.ts
@@ -13,9 +13,11 @@ import { sortedNodeIds } from "../../modules/pathfinding/landmarks";
  * only place the landmark work is exercised at production scale, which is where
  * both the payoff and the risk live:
  *
- *  1. Routes must be IDENTICAL to the pre-ALT heuristic. `PATHFINDING_LANDMARKS=0`
- *     restores exactly the old haversine bound, so an L=0 run is a faithful
- *     baseline. Over long random cross-city pairs this doubles as the empirical
+ *  1. Routes must be IDENTICAL to the pre-ALT heuristic. A landmark count of 0
+ *     (`PATHFINDING_LANDMARKS=0`) restores exactly the old haversine bound, so
+ *     an L=0 run is a faithful baseline. The count is passed straight to
+ *     `RoadNetwork`, the same way `config.pathfindingLandmarks` reaches it in
+ *     production. Over long random cross-city pairs this doubles as the empirical
  *     admissibility check — an overestimating heuristic would surface as a
  *     different (costlier) path.
  *  2. Nodes expanded per route must drop substantially.
@@ -68,54 +70,26 @@ function describeRoute(route: { edges: Edge[]; distance: number } | null): strin
  * comparison battery against it. The `RoadNetwork` stays local so the ~750 MB
  * graph is collectable before the next build.
  */
-function collect(landmarkCount: string): Collected {
-  const previous = process.env.PATHFINDING_LANDMARKS;
-  process.env.PATHFINDING_LANDMARKS = landmarkCount;
-  try {
-    const started = Date.now();
-    const network = new RoadNetwork(networkPath);
-    const buildMs = Date.now() - started;
+function collect(landmarkCount: number): Collected {
+  const started = Date.now();
+  const network = new RoadNetwork(networkPath, { landmarkCount });
+  const buildMs = Date.now() - started;
 
-    // @ts-expect-error — private graph, as the other RoadNetwork tests do.
-    const nodes = network.nodes as Map<string, Node>;
-    // Sorted ids make the sample identical across builds.
-    const ids = sortedNodeIds(nodes.keys());
-    const random = mulberry32(20260725);
+  // @ts-expect-error — private graph, as the other RoadNetwork tests do.
+  const nodes = network.nodes as Map<string, Node>;
+  // Sorted ids make the sample identical across builds.
+  const ids = sortedNodeIds(nodes.keys());
+  const random = mulberry32(20260725);
 
-    const pairs: Array<[string, string]> = [];
-    while (pairs.length < PAIRS) {
-      const a = ids[Math.floor(random() * ids.length)];
-      const b = ids[Math.floor(random() * ids.length)];
-      if (a !== b) pairs.push([a, b]);
-    }
+  const pairs: Array<[string, string]> = [];
+  while (pairs.length < PAIRS) {
+    const a = ids[Math.floor(random() * ids.length)];
+    const b = ids[Math.floor(random() * ids.length)];
+    if (a !== b) pairs.push([a, b]);
+  }
 
-    const run = (): PairResult[] =>
-      pairs.map(([startId, endId]) => {
-        const route = network.findRoute(nodes.get(startId)!, nodes.get(endId)!);
-        return {
-          key: `${startId}->${endId}`,
-          route: describeRoute(route),
-          expanded: network.lastExpandedNodes,
-        };
-      });
-
-    const plain = run();
-
-    // Incident set derived from the first route's own edges, so it actually
-    // perturbs the search rather than penalising untravelled roads. Because the
-    // routes are asserted identical, both runs derive the identical set — which
-    // the test verifies rather than assumes.
-    const firstRoute = network.findRoute(nodes.get(pairs[0][0])!, nodes.get(pairs[0][1])!);
-    const routeEdgeIds = firstRoute ? firstRoute.edges.map((e) => e.id) : [];
-    const incidents = new Map<string, number>();
-    routeEdgeIds.forEach((id, i) => {
-      // Mix slowdowns with hard closures so both dynamic-cost branches are hit.
-      if (i % 7 === 0) incidents.set(id, 0);
-      else if (i % 3 === 0) incidents.set(id, 0.2);
-    });
-    network.setIncidentEdges(new Map(incidents));
-
-    const withIncidents = pairs.slice(0, INCIDENT_PAIRS).map(([startId, endId]) => {
+  const run = (): PairResult[] =>
+    pairs.map(([startId, endId]) => {
       const route = network.findRoute(nodes.get(startId)!, nodes.get(endId)!);
       return {
         key: `${startId}->${endId}`,
@@ -124,17 +98,38 @@ function collect(landmarkCount: string): Collected {
       };
     });
 
+  const plain = run();
+
+  // Incident set derived from the first route's own edges, so it actually
+  // perturbs the search rather than penalising untravelled roads. Because the
+  // routes are asserted identical, both runs derive the identical set — which
+  // the test verifies rather than assumes.
+  const firstRoute = network.findRoute(nodes.get(pairs[0][0])!, nodes.get(pairs[0][1])!);
+  const routeEdgeIds = firstRoute ? firstRoute.edges.map((e) => e.id) : [];
+  const incidents = new Map<string, number>();
+  routeEdgeIds.forEach((id, i) => {
+    // Mix slowdowns with hard closures so both dynamic-cost branches are hit.
+    if (i % 7 === 0) incidents.set(id, 0);
+    else if (i % 3 === 0) incidents.set(id, 0.2);
+  });
+  network.setIncidentEdges(new Map(incidents));
+
+  const withIncidents = pairs.slice(0, INCIDENT_PAIRS).map(([startId, endId]) => {
+    const route = network.findRoute(nodes.get(startId)!, nodes.get(endId)!);
     return {
-      plain,
-      withIncidents,
-      incidentEdgeIds: [...incidents.keys()].sort(),
-      nodeCount: nodes.size,
-      buildMs,
+      key: `${startId}->${endId}`,
+      route: describeRoute(route),
+      expanded: network.lastExpandedNodes,
     };
-  } finally {
-    if (previous === undefined) delete process.env.PATHFINDING_LANDMARKS;
-    else process.env.PATHFINDING_LANDMARKS = previous;
-  }
+  });
+
+  return {
+    plain,
+    withIncidents,
+    incidentEdgeIds: [...incidents.keys()].sort(),
+    nodeCount: nodes.size,
+    buildMs,
+  };
 }
 
 const totals = (results: PairResult[]): number => results.reduce((sum, r) => sum + r.expanded, 0);
@@ -153,8 +148,8 @@ describe.skipIf(!hasRealNetwork)("ALT landmarks on the real road network", () =>
   it(
     "produces byte-identical routes to the pre-ALT haversine heuristic",
     () => {
-      baseline = collect("0");
-      withAlt = collect("4");
+      baseline = collect(0);
+      withAlt = collect(4);
 
       expect(withAlt.nodeCount).toBe(baseline.nodeCount);
       expect(withAlt.plain.length).toBe(PAIRS);

--- a/apps/simulator/src/__tests__/pathfinding/landmarks.test.ts
+++ b/apps/simulator/src/__tests__/pathfinding/landmarks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import fs from "fs";
 import path from "path";
 import type { FeatureCollection } from "geojson";
@@ -23,33 +23,28 @@ import {
   findRoute as workerFindRoute,
   landmarkHeuristic,
 } from "../../workers/pathfinding-worker";
+import { parseEnv } from "../../utils/config";
 
 /**
  * ALT (A*, Landmarks, Triangle inequality) heuristic.
  *
- * The load-bearing test here is ROUTE EQUIVALENCE: with `PATHFINDING_LANDMARKS=0`
- * the engine uses exactly the pre-ALT haversine heuristic, so comparing an
- * `L=0` run against an `L=N` run over every node pair is a direct assertion
- * that the optimisation did not change any route. Everything else (admissibility,
- * expansion counts) supports that claim.
+ * The load-bearing test here is ROUTE EQUIVALENCE: with a landmark count of 0
+ * (`PATHFINDING_LANDMARKS=0`) the engine uses exactly the pre-ALT haversine
+ * heuristic, so comparing an `L=0` run against an `L=N` run over every node pair
+ * is a direct assertion that the optimisation did not change any route.
+ * Everything else (admissibility, expansion counts) supports that claim.
+ *
+ * The count is passed explicitly rather than smuggled through `process.env`:
+ * `PATHFINDING_LANDMARKS` is parsed once by the zod schema in `utils/config.ts`
+ * and threaded down through `RoadNetwork` → `GraphBuilder` / `PathfindingPool` →
+ * `workerData`, so that is the seam these tests drive.
  */
 
 const fixture = path.join(__dirname, "..", "fixtures", "test-network.geojson");
 const integrationFixture = path.join(__dirname, "..", "fixtures", "integration-network.geojson");
 
-/** Restore whatever the ambient env had, since these tests toggle it. */
-const originalEnv = process.env.PATHFINDING_LANDMARKS;
-beforeEach(() => {
-  delete process.env.PATHFINDING_LANDMARKS;
-});
-afterEach(() => {
-  if (originalEnv === undefined) delete process.env.PATHFINDING_LANDMARKS;
-  else process.env.PATHFINDING_LANDMARKS = originalEnv;
-});
-
-function buildNetwork(landmarks: string, geojsonPath = fixture): RoadNetwork {
-  process.env.PATHFINDING_LANDMARKS = landmarks;
-  return new RoadNetwork(geojsonPath);
+function buildNetwork(landmarkCount: number, geojsonPath = fixture): RoadNetwork {
+  return new RoadNetwork(geojsonPath, { landmarkCount });
 }
 
 /** All node ids of a network, in a stable order. */
@@ -92,9 +87,15 @@ describe("resolveLandmarkCount", () => {
     expect(resolveLandmarkCount("-3")).toBe(DEFAULT_LANDMARK_COUNT);
   });
 
-  it("reads process.env by default", () => {
-    process.env.PATHFINDING_LANDMARKS = "7";
-    expect(resolveLandmarkCount()).toBe(7);
+  it("is the exact clamp the env schema applies", () => {
+    // config.ts owns the only read of process.env.PATHFINDING_LANDMARKS and
+    // delegates the range to this function, so the two can never diverge.
+    expect(parseEnv({}).PATHFINDING_LANDMARKS).toBe(resolveLandmarkCount(undefined));
+    for (const raw of ["0", "6", "1000", "banana", "-3", "   "]) {
+      expect(parseEnv({ PATHFINDING_LANDMARKS: raw }).PATHFINDING_LANDMARKS).toBe(
+        resolveLandmarkCount(raw)
+      );
+    }
   });
 });
 
@@ -260,12 +261,11 @@ describe("AltHeuristic", () => {
 describe("the landmark bound never overestimates the true A* cost", () => {
   for (const geojsonPath of [fixture, integrationFixture]) {
     it(`holds for every reachable node pair in ${path.basename(geojsonPath)}`, () => {
-      process.env.PATHFINDING_LANDMARKS = "4";
       const data = JSON.parse(fs.readFileSync(geojsonPath, "utf8")) as FeatureCollection;
-      const built = new GraphBuilder().build(data);
+      const built = new GraphBuilder({ landmarkCount: 4 }).build(data);
       expect(built.landmarks).not.toBeNull();
 
-      const network = buildNetwork("4", geojsonPath);
+      const network = buildNetwork(4, geojsonPath);
       const ids = nodeIdsOf(network);
       const alt = new AltHeuristic(built.landmarks!);
 
@@ -305,7 +305,7 @@ describe("main-thread routes are byte-identical with and without landmarks", () 
     const name = path.basename(geojsonPath);
 
     it(`matches for every node pair in ${name}`, () => {
-      const baseline = buildNetwork("0", geojsonPath);
+      const baseline = buildNetwork(0, geojsonPath);
       const ids = nodeIdsOf(baseline);
       const before = new Map<string, string>();
       for (const startId of ids) {
@@ -319,7 +319,7 @@ describe("main-thread routes are byte-identical with and without landmarks", () 
       }
       expect(before.size).toBeGreaterThan(0);
 
-      for (const count of ["1", "4", "16"]) {
+      for (const count of [1, 4, 16]) {
         const withAlt = buildNetwork(count, geojsonPath);
         expect(nodeIdsOf(withAlt)).toEqual(ids);
         for (const [key, expected] of before) {
@@ -338,7 +338,7 @@ describe("main-thread routes are byte-identical with and without landmarks", () 
       const scenarios = ["slowdown", "closure"] as const;
 
       for (const scenario of scenarios) {
-        const baseline = buildNetwork("0", geojsonPath);
+        const baseline = buildNetwork(0, geojsonPath);
         const ids = nodeIdsOf(baseline);
         // @ts-expect-error — private edge map, as the other RoadNetwork tests do.
         const edgeIds = [...(baseline.edges as Map<string, Edge>).keys()].sort();
@@ -359,7 +359,7 @@ describe("main-thread routes are byte-identical with and without landmarks", () 
           }
         }
 
-        const withAlt = buildNetwork("4", geojsonPath);
+        const withAlt = buildNetwork(4, geojsonPath);
         withAlt.setIncidentEdges(new Map(incidents));
         for (const [key, expected] of before) {
           const [startId, endId] = key.split("->");
@@ -378,9 +378,11 @@ describe("main-thread routes are byte-identical with and without landmarks", () 
   }
 
   it("PATHFINDING_LANDMARKS=0 really does disable preprocessing", () => {
-    process.env.PATHFINDING_LANDMARKS = "0";
     const data = JSON.parse(fs.readFileSync(fixture, "utf8")) as FeatureCollection;
-    expect(new GraphBuilder().build(data).landmarks).toBeNull();
+    // The env value travels as a number: schema → RoadNetwork → GraphBuilder.
+    const landmarkCount = parseEnv({ PATHFINDING_LANDMARKS: "0" }).PATHFINDING_LANDMARKS;
+    expect(landmarkCount).toBe(0);
+    expect(new GraphBuilder({ landmarkCount }).build(data).landmarks).toBeNull();
   });
 });
 
@@ -389,9 +391,9 @@ describe("main-thread routes are byte-identical with and without landmarks", () 
 describe("worker routes are byte-identical with and without landmarks", () => {
   it("matches for every node pair in the fixture", () => {
     // buildGraph installs the module-level heuristic, so these two passes must
-    // stay sequential — build, exhaust, rebuild.
-    process.env.PATHFINDING_LANDMARKS = "0";
-    const plainNodes = buildGraph(fixture);
+    // stay sequential — build, exhaust, rebuild. The count is the one the pool
+    // puts in `workerData`.
+    const plainNodes = buildGraph(fixture, 0);
     expect(landmarkHeuristic()).toBeNull();
 
     const ids = [...plainNodes.keys()].sort();
@@ -408,8 +410,7 @@ describe("worker routes are byte-identical with and without landmarks", () => {
     }
     expect(before.size).toBeGreaterThan(0);
 
-    process.env.PATHFINDING_LANDMARKS = "4";
-    const altNodes = buildGraph(fixture);
+    const altNodes = buildGraph(fixture, 4);
     expect(landmarkHeuristic()).not.toBeNull();
     expect([...altNodes.keys()].sort()).toEqual(ids);
 
@@ -426,10 +427,9 @@ describe("worker routes are byte-identical with and without landmarks", () => {
   it("assigns the same sorted ALT indices as the main-thread GraphBuilder", () => {
     // This is what lets both sides select the same landmarks — and therefore run
     // the identical search — without exchanging any preprocessed data.
-    process.env.PATHFINDING_LANDMARKS = "4";
-    const workerNodes = buildGraph(fixture);
+    const workerNodes = buildGraph(fixture, 4);
     const data = JSON.parse(fs.readFileSync(fixture, "utf8")) as FeatureCollection;
-    const built = new GraphBuilder().build(data);
+    const built = new GraphBuilder({ landmarkCount: 4 }).build(data);
 
     expect([...workerNodes.keys()].sort()).toEqual(sortedNodeIds(built.nodes.keys()));
     for (const [id, workerNode] of workerNodes) {

--- a/apps/simulator/src/__tests__/pathfinding/workerBootstrap.test.ts
+++ b/apps/simulator/src/__tests__/pathfinding/workerBootstrap.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { builtinModules } from "module";
+
+/**
+ * How configuration reaches a pathfinding worker.
+ *
+ * `PATHFINDING_LANDMARKS` is parsed once by the zod schema in `utils/config.ts`,
+ * but the worker runs as a self-contained esbuild bundle that must NOT import
+ * that module — pulling in zod/dotenv/pino would balloon the bundle and drag a
+ * dotenv/logger boot into every worker thread. So the resolved number travels in
+ * `workerData`. These tests pin both halves of that contract:
+ *
+ *  1. `PathfindingPool` actually puts the count in `workerData` (Worker mocked).
+ *  2. The built bundle still requires nothing but Node builtins.
+ */
+
+// Hoisted so the vi.mock factory (which is hoisted above the imports) can see it.
+const { workerSpawns } = vi.hoisted(() => ({
+  workerSpawns: [] as Array<{ workerPath: string; options: { workerData?: unknown } }>,
+}));
+
+vi.mock("worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("worker_threads")>();
+  // Imported inside the factory: the factory is hoisted above this file's own
+  // imports, so it cannot touch their bindings yet.
+  const { EventEmitter } = await import("events");
+  class RecordingWorker extends EventEmitter {
+    postMessage = vi.fn();
+    terminate = vi.fn().mockResolvedValue(0);
+    constructor(workerPath: string | URL, options: { workerData?: unknown } = {}) {
+      super();
+      workerSpawns.push({ workerPath: String(workerPath), options });
+    }
+  }
+  return { ...actual, Worker: RecordingWorker };
+});
+
+import { PathfindingPool } from "../../modules/PathfindingPool";
+import { DEFAULT_LANDMARK_COUNT } from "../../modules/pathfinding/landmarks";
+import type { PathfindingWorkerData } from "../../workers/pathfinding-worker";
+
+const geojsonPath = path.join(__dirname, "..", "fixtures", "test-network.geojson");
+
+function spawnedWorkerData(): PathfindingWorkerData[] {
+  return workerSpawns.map((s) => s.options.workerData as PathfindingWorkerData);
+}
+
+describe("PathfindingPool → worker bootstrap (workerData)", () => {
+  beforeEach(() => {
+    workerSpawns.length = 0;
+  });
+
+  it("gives every worker the geojson path and the resolved landmark count", async () => {
+    const pool = new PathfindingPool(geojsonPath, { poolSize: 2, landmarkCount: 7 });
+
+    expect(workerSpawns).toHaveLength(2);
+    for (const data of spawnedWorkerData()) {
+      expect(data.geojsonPath).toBe(geojsonPath);
+      expect(data.landmarkCount).toBe(7);
+    }
+
+    await pool.shutdown();
+  });
+
+  it("passes an explicit 0 through instead of falling back to the default", async () => {
+    // 0 disables ALT preprocessing entirely; a `||` fallback anywhere on this
+    // path would silently re-enable it.
+    const pool = new PathfindingPool(geojsonPath, { poolSize: 1, landmarkCount: 0 });
+
+    expect(spawnedWorkerData()[0].landmarkCount).toBe(0);
+
+    await pool.shutdown();
+  });
+
+  it("falls back to the module default under the legacy (geojsonPath, poolSize) signature", async () => {
+    const pool = new PathfindingPool(geojsonPath, 1);
+
+    expect(spawnedWorkerData()[0].landmarkCount).toBe(DEFAULT_LANDMARK_COUNT);
+
+    await pool.shutdown();
+  });
+});
+
+// ─── The bundle must stay dependency-free ─────────────────────────────
+
+describe("the built pathfinding worker bundle", () => {
+  // Built by `npm run build:worker`, which `pretest` chains before vitest.
+  const bundlePath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "dist",
+    "workers",
+    "pathfinding-worker.cjs"
+  );
+
+  it("requires nothing but Node builtins", () => {
+    expect(fs.existsSync(bundlePath), `${bundlePath} missing — run "npm run build:worker"`).toBe(
+      true
+    );
+    const source = fs.readFileSync(bundlePath, "utf8");
+
+    const required = [
+      ...new Set(
+        [...source.matchAll(/require\(\s*["']([^"']+)["']\s*\)/g)].map((m) =>
+          m[1].replace(/^node:/, "")
+        )
+      ),
+    ];
+    expect(required.length).toBeGreaterThan(0);
+    const thirdParty = required.filter((id) => !builtinModules.includes(id));
+    expect(thirdParty, `worker bundle pulled in ${thirdParty.join(", ")}`).toEqual([]);
+  });
+
+  it("contains no trace of the zod/dotenv/pino config module", () => {
+    const source = fs.readFileSync(bundlePath, "utf8");
+
+    for (const marker of ["zod", "dotenv", "pino", "Simulator config"]) {
+      expect(source.includes(marker), `worker bundle mentions "${marker}"`).toBe(false);
+    }
+    // Sanity check that this is the real bundle and not an empty file.
+    expect(source).toContain("buildLandmarkIndex");
+  });
+});

--- a/apps/simulator/src/modules/JobManager.ts
+++ b/apps/simulator/src/modules/JobManager.ts
@@ -26,7 +26,11 @@ import logger from "../utils/logger";
  * and neither depends on real pathfinding.
  */
 export interface JobVehicleGateway {
-  getVehicles(): VehicleDTO[];
+  /**
+   * The roster at its true positions. Deliberately not `getVehicles()`, which
+   * projects the device-fault layer — see {@link JobManager.pickVehicle}.
+   */
+  getTrueVehicles(): VehicleDTO[];
   findAndSetWaypointRoutes(vehicleId: string, waypoints: Waypoint[]): Promise<DirectionResult>;
   estimateTo(
     vehicleId: string,
@@ -369,7 +373,16 @@ export class JobManager extends EventEmitter {
     /** Why no vehicle came back, when the reason is specific enough to say. */
     blocked?: { message: string; fatal: boolean };
   }> {
-    const roster = this.vehicles.getVehicles();
+    // Scored on TRUE positions, never the device-reported ones. `getVehicles()`
+    // projects the armed fault layer (frozen, teleported, stale), and dispatch
+    // is the simulator's own decision — it authors the scenario rather than
+    // being one of the consumers the fault layer exists to deceive. Reading the
+    // projected roster here would let a spoofed device win or lose a job on a
+    // position it is not at, and would split `best_eta` down the middle: its
+    // proximity shortlist off the reported fix, its ETA probe (`estimateTo`)
+    // off the registry's true one. The fault stays visible where it belongs, on
+    // the WS feed, `GET /vehicles` and the adapter push.
+    const roster = this.vehicles.getTrueVehicles();
     const available = roster.filter((v) => {
       if (this.busyVehicles.has(v.id)) return false;
       if (state.attempted.has(v.id)) return false;

--- a/apps/simulator/src/modules/PathfindingPool.ts
+++ b/apps/simulator/src/modules/PathfindingPool.ts
@@ -4,6 +4,10 @@
  * Distributes route requests across N workers via round-robin, each worker
  * holding its own copy of the road-network graph. The main thread only
  * sends lightweight { startId, endId } messages and receives { edgeIds, distance }.
+ *
+ * Workers run as a self-contained esbuild bundle that must not import the
+ * zod/dotenv/pino config module, so anything they need from the environment is
+ * resolved here and handed over in `workerData` ({@link PathfindingWorkerData}).
  */
 
 import { Worker } from "worker_threads";
@@ -11,6 +15,8 @@ import { fileURLToPath } from "url";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { DEFAULT_LANDMARK_COUNT } from "./pathfinding/landmarks";
+import type { PathfindingWorkerData } from "../workers/pathfinding-worker";
 import logger from "../utils/logger";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -41,6 +47,12 @@ export interface PathfindingPoolOptions {
   requestTimeoutMs?: number;
   /** Maximum number of pending requests before new ones are rejected. */
   maxPendingRequests?: number;
+  /**
+   * ALT landmarks each worker precomputes; `0` disables the preprocessing.
+   * `RoadNetwork` passes `config.pathfindingLandmarks` (the parsed, clamped
+   * `PATHFINDING_LANDMARKS`) so the workers and the main-thread graph agree.
+   */
+  landmarkCount?: number;
 }
 
 export class PathfindingPool {
@@ -55,14 +67,17 @@ export class PathfindingPool {
   constructor(geojsonPath: string, options?: PathfindingPoolOptions | number) {
     // Support legacy signature: constructor(geojsonPath, poolSize?)
     let poolSize: number | undefined;
+    let landmarkCount: number;
     if (typeof options === "number") {
       poolSize = options;
       this.requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS;
       this.maxPendingRequests = DEFAULT_MAX_PENDING_REQUESTS;
+      landmarkCount = DEFAULT_LANDMARK_COUNT;
     } else {
       poolSize = options?.poolSize;
       this.requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
       this.maxPendingRequests = options?.maxPendingRequests ?? DEFAULT_MAX_PENDING_REQUESTS;
+      landmarkCount = options?.landmarkCount ?? DEFAULT_LANDMARK_COUNT;
     }
 
     const size = poolSize ?? Math.min(os.cpus().length, 4);
@@ -89,10 +104,10 @@ export class PathfindingPool {
       workerCandidates.find((p) => fs.existsSync(p)) ??
       workerCandidates[workerCandidates.length - 1];
 
+    const workerData: PathfindingWorkerData = { geojsonPath, landmarkCount };
+
     for (let i = 0; i < size; i++) {
-      const worker = new Worker(workerPath, {
-        workerData: { geojsonPath },
-      });
+      const worker = new Worker(workerPath, { workerData });
 
       worker.on("message", (msg: { type: string; id: number; route: PathfindingResult | null }) => {
         if (msg.type === "result") {

--- a/apps/simulator/src/modules/RoadNetwork.ts
+++ b/apps/simulator/src/modules/RoadNetwork.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import type { FeatureCollection } from "geojson";
 import type { Node, Edge, Route, HeatZoneFeature, POI, BoundingBox } from "../types";
 import { HEAT_ZONE_DEFAULTS } from "../constants";
+import { config } from "../utils/config";
 import type { TrafficProfile } from "../utils/trafficProfiles";
 import type { CacheStats } from "../utils/LRUCache";
 import { HeatZoneManager } from "./HeatZoneManager";
@@ -11,6 +12,20 @@ import { SpatialIndex } from "./roadnetwork/SpatialIndex";
 import { PathfindingEngine } from "./roadnetwork/PathfindingEngine";
 import type { Road } from "./roadnetwork/types";
 import EventEmitter from "events";
+
+/** Construction-time knobs for {@link RoadNetwork}. */
+export interface RoadNetworkOptions {
+  /** Route-cache capacity (see {@link PathfindingEngine}). */
+  maxSize?: number;
+  /** Route-cache entry TTL in ms. */
+  ttlMs?: number;
+  /**
+   * ALT landmarks to precompute; `0` disables the preprocessing and restores
+   * the pre-ALT haversine heuristic. Defaults to `config.pathfindingLandmarks`
+   * (the parsed, clamped `PATHFINDING_LANDMARKS`).
+   */
+  landmarkCount?: number;
+}
 
 /**
  * RoadNetwork is a thin facade over four cohesive collaborators (architecture
@@ -59,16 +74,24 @@ export class RoadNetwork extends EventEmitter {
   // Worker-thread pathfinding pool (lazy-initialized)
   private pathfindingPool: PathfindingPool | null = null;
   private geojsonPath: string;
+  /**
+   * ALT landmarks used by both the main-thread graph and every pool worker.
+   * Resolved once here — this is the only place `PATHFINDING_LANDMARKS` (via
+   * the zod schema) is read — and threaded down, because the worker bundle
+   * cannot import the config module.
+   */
+  private landmarkCount: number;
 
-  constructor(geojsonPath: string, cacheOptions?: { maxSize?: number; ttlMs?: number }) {
+  constructor(geojsonPath: string, options?: RoadNetworkOptions) {
     super();
     this.geojsonPath = geojsonPath;
+    this.landmarkCount = options?.landmarkCount ?? config.pathfindingLandmarks;
 
     // Parse the raw GeoJSON into a local — NOT a field — so the only reference
     // is dropped when the constructor returns and the blob can be GC'd.
     const data = JSON.parse(fs.readFileSync(geojsonPath, "utf8")) as FeatureCollection;
 
-    const built = new GraphBuilder().build(data);
+    const built = new GraphBuilder({ landmarkCount: this.landmarkCount }).build(data);
     // `data` is now unreferenced from here on; it is released for GC.
 
     this.nodes = built.nodes;
@@ -92,7 +115,7 @@ export class RoadNetwork extends EventEmitter {
         maxNetworkSpeed: built.maxNetworkSpeed,
         landmarks: built.landmarks,
       },
-      cacheOptions
+      options
     );
   }
 
@@ -281,7 +304,9 @@ export class RoadNetwork extends EventEmitter {
 
     // Lazy-init the pool on first async call
     if (!this.pathfindingPool) {
-      this.pathfindingPool = new PathfindingPool(this.geojsonPath);
+      this.pathfindingPool = new PathfindingPool(this.geojsonPath, {
+        landmarkCount: this.landmarkCount,
+      });
     }
 
     const incidentEdges = this.pathfinding.incidents;

--- a/apps/simulator/src/modules/StateStore.ts
+++ b/apps/simulator/src/modules/StateStore.ts
@@ -3,6 +3,26 @@ import fs from "fs";
 import path from "path";
 import logger from "../utils/logger";
 import type { AnalyticsSummary, FleetAnalytics, RecordingMetadata } from "../types";
+import {
+  ANALYTICS_BUCKET_AGGREGATION,
+  type AnalyticsBucketInfo,
+  type AnalyticsBucketMeta,
+  type AnalyticsHistoryMeta,
+  type AnalyticsHistoryRow,
+  type AnalyticsOrder,
+} from "@moveet/shared-types";
+
+// Re-exported so the routes and tests that already read the analytics contract
+// from this module keep one import site; the declarations themselves are the
+// shared ones.
+export {
+  ANALYTICS_BUCKET_AGGREGATION,
+  type AnalyticsBucketInfo,
+  type AnalyticsBucketMeta,
+  type AnalyticsHistoryMeta,
+  type AnalyticsHistoryRow,
+  type AnalyticsOrder,
+};
 
 /**
  * Shape of a simulation state snapshot.
@@ -23,122 +43,12 @@ export interface SnapshotMeta {
 
 export interface SnapshotRow extends SnapshotMeta, SnapshotData {}
 
-export interface AnalyticsHistoryRow {
-  id: number;
-  timestamp: string;
-  summary: AnalyticsSummary;
-  fleets: FleetAnalytics[];
-  /**
-   * Present only on downsampled rows. Its absence means the row is a verbatim
-   * stored sample.
-   */
-  bucket?: AnalyticsBucketInfo;
-}
-
 // ─── Analytics history query shaping ────────────────────────────────
-
-/** Sort order of the rows handed back by {@link StateStore.getAnalyticsHistory}. */
-export type AnalyticsOrder = "asc" | "desc";
-
-/** Provenance of a single downsampled row. */
-export interface AnalyticsBucketInfo {
-  /** Bucket width in milliseconds. */
-  durationMs: number;
-  /** Canonical width label, e.g. `"5m"`. */
-  label: string;
-  /** ISO start of the bucket window (inclusive). */
-  start: string;
-  /** ISO end of the bucket window (exclusive). */
-  end: string;
-  /** Stored samples folded into this row. */
-  sampleCount: number;
-  /** ISO timestamp of the oldest sample folded in. */
-  firstTimestamp: string;
-  /** ISO timestamp of the newest sample folded in. */
-  lastTimestamp: string;
-}
-
-/**
- * How each analytics field is folded when a query is bucketed.
- *
- * The distinction matters: `totalDistanceTraveled` and `totalIdleTime` are
- * monotonically accumulating counters — averaging them would understate the
- * fleet and break monotonicity, so the bucket keeps the LAST value. Gauges
- * (`activeVehicles`, `avgSpeed`, `avgRouteEfficiency`) are averaged across the
- * samples in the bucket. `totalVehicles` is a slow-moving gauge (fleet size),
- * so the last value is the honest representative rather than a fractional mean.
- *
- * `fleets[].vehicles` (the per-vehicle `VehicleStats[]`) is NOT aggregated: it
- * is a point-in-time array mixing cumulative counters with per-vehicle gauges
- * and there is no meaningful element-wise fold, so the newest sample's array is
- * carried through verbatim.
- *
- * Shipped inside the response metadata so a caller can never mistake a bucketed
- * counter for a mean.
- */
-export const ANALYTICS_BUCKET_AGGREGATION = {
-  "summary.totalVehicles": "last",
-  "summary.activeVehicles": "mean",
-  "summary.totalDistanceTraveled": "last (cumulative counter)",
-  "summary.avgSpeed": "mean",
-  "summary.totalIdleTime": "last (cumulative counter)",
-  "summary.avgRouteEfficiency": "mean",
-  "summary.timestamp": "bucket start",
-  "fleets[].vehicleCount": "last",
-  "fleets[].activeCount": "mean",
-  "fleets[].totalDistance": "last (cumulative counter)",
-  "fleets[].avgSpeed": "mean",
-  "fleets[].totalIdleTime": "last (cumulative counter)",
-  "fleets[].routeEfficiency": "mean",
-  "fleets[].vehicles": "last (not aggregated)",
-} as const;
-
-/** Bucket summary attached to the metadata of a downsampled query. */
-export interface AnalyticsBucketMeta {
-  durationMs: number;
-  label: string;
-  /** Buckets in the payload. */
-  count: number;
-  /** Stored samples folded into those buckets. */
-  sampleCount: number;
-  /** True when the width was derived from the data rather than requested. */
-  auto: boolean;
-  aggregation: typeof ANALYTICS_BUCKET_AGGREGATION;
-}
-
-/**
- * Everything the caller needs to know about what the query did NOT return.
- *
- * A limited query is answered from the RECENT end of the window, so anything
- * omitted is always older than the payload.
- */
-export interface AnalyticsHistoryMeta {
-  /** Stored rows inside the requested window, before limiting or bucketing. */
-  matched: number;
-  /** Stored rows actually read (and therefore represented in the payload). */
-  scanned: number;
-  /** Entries in the payload (buckets when bucketed, rows otherwise). */
-  returned: number;
-  /** Stored rows in the window that are NOT represented at all. */
-  omitted: number;
-  /** True whenever `omitted > 0` — i.e. the payload is not the whole window. */
-  truncated: boolean;
-  /** Which end of the window survives the limit. Always the newest. */
-  anchor: "newest";
-  /** Limit actually applied after clamping to [1, 10000]. */
-  limit: number;
-  order: AnalyticsOrder;
-  /** Echo of the requested window (`null` = unbounded). */
-  from: string | null;
-  to: string | null;
-  /** Span the payload actually covers (`null` when empty). */
-  coveredFrom: string | null;
-  coveredTo: string | null;
-  /** Oldest/newest stored timestamps inside the requested window. */
-  windowFrom: string | null;
-  windowTo: string | null;
-  bucket: AnalyticsBucketMeta | null;
-}
+//
+// The row, bucket and metadata shapes are the wire contract with the UI, so
+// they live in `@moveet/shared-types` (see its `rest.ts`) rather than here.
+// Only the store-internal pieces below — how a query is asked for, and how the
+// result carries its metadata in-process — are simulator-local.
 
 /**
  * Analytics rows plus their metadata.

--- a/apps/simulator/src/modules/VehicleManager.ts
+++ b/apps/simulator/src/modules/VehicleManager.ts
@@ -338,8 +338,24 @@ export class VehicleManager extends EventEmitter {
     if (!this.faults.isActive()) return vehicles;
     // Project each device's currently-reported fix so a polling reader sees the
     // frozen/teleported/stale position the stream is reporting, not the truth.
+    // Callers that need the truth instead want {@link getTrueVehicles}.
     const now = Date.now();
     return vehicles.map((vehicle) => this.faults.view(vehicle, now));
+  }
+
+  /**
+   * The roster at its TRUE positions, with no device-fault projection.
+   *
+   * {@link getVehicles} answers "what is the fleet reporting?", which is the
+   * right question for every observer surface — the WS feed, `GET /vehicles`,
+   * the adapter push — because a fault the observer cannot see is not a fault.
+   * This answers "where is the fleet?", which is what the simulator's own
+   * internal decisions need: it authors the scenario rather than consuming it,
+   * so a spoofed or frozen device must not move a vehicle for them. Its one
+   * caller today is job assignment; see `JobManager.pickVehicle`.
+   */
+  public getTrueVehicles(): VehicleDTO[] {
+    return this.registry.getAllSerialized();
   }
 
   /**

--- a/apps/simulator/src/modules/pathfinding/landmarks.ts
+++ b/apps/simulator/src/modules/pathfinding/landmarks.ts
@@ -66,18 +66,21 @@ export const DEFAULT_LANDMARK_COUNT = 4;
 export const MAX_LANDMARK_COUNT = 32;
 
 /**
- * Landmark count from the environment.
+ * Parses and clamps a raw `PATHFINDING_LANDMARKS` value.
  *
- * Read straight from `process.env` rather than `utils/config.ts` on purpose:
- * the pathfinding worker is an esbuild bundle that deliberately avoids pulling
- * in the zod/dotenv/logger config module, and `PathfindingPool` passes the
- * worker nothing but `{ geojsonPath }`, so the worker has no other way to learn
- * the setting. `0` disables ALT entirely and restores the pure-haversine
- * heuristic.
+ * `0` disables ALT entirely and restores the pure-haversine heuristic; blank,
+ * malformed and negative values fall back to the default; anything above
+ * {@link MAX_LANDMARK_COUNT} is clamped rather than rejected.
+ *
+ * This lives beside the constants that define the range and is called by the
+ * zod env schema in `utils/config.ts` — the ONE place the variable is read from
+ * the environment. The dependency deliberately runs config → landmarks and never
+ * the reverse: this module is bundled into the pathfinding worker (esbuild),
+ * which must stay free of zod/dotenv/pino. The worker is handed the resolved
+ * number through `workerData` (see `PathfindingPool`), so nothing on this side
+ * of the boundary touches `process.env`.
  */
-export function resolveLandmarkCount(
-  raw: string | undefined = process.env.PATHFINDING_LANDMARKS
-): number {
+export function resolveLandmarkCount(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") return DEFAULT_LANDMARK_COUNT;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_LANDMARK_COUNT;

--- a/apps/simulator/src/modules/roadnetwork/GraphBuilder.ts
+++ b/apps/simulator/src/modules/roadnetwork/GraphBuilder.ts
@@ -19,9 +19,9 @@ import { computeBaseTravelTime } from "../pathfinding/cost";
 import {
   type AltIndexed,
   type LandmarkIndex,
+  DEFAULT_LANDMARK_COUNT,
   buildCsrPair,
   buildLandmarkIndex,
-  resolveLandmarkCount,
   sortedNodeIds,
 } from "../pathfinding/landmarks";
 import {
@@ -58,15 +58,27 @@ export interface BuiltNetwork {
   lineStringFeatures: FeatureCollection;
   /**
    * Precomputed ALT landmark distance tables, or `null` when landmarks are
-   * disabled (`PATHFINDING_LANDMARKS=0`) or the graph is empty. Every `Node` in
-   * `nodes` is stamped with its `altIndex` into these tables.
+   * disabled (a landmark count of 0, i.e. `PATHFINDING_LANDMARKS=0`) or the
+   * graph is empty. Every `Node` in `nodes` is stamped with its `altIndex` into
+   * these tables.
    */
   landmarks: LandmarkIndex | null;
 }
 
 const COORD_SNAP_EPSILON = 1e-7;
 
+export interface GraphBuilderOptions {
+  /**
+   * Number of ALT landmarks to precompute; `0` disables the preprocessing and
+   * leaves `BuiltNetwork.landmarks` null. Passed in rather than read from the
+   * environment: `PATHFINDING_LANDMARKS` is parsed once by the zod schema in
+   * `utils/config.ts` and threaded down from `RoadNetwork`.
+   */
+  landmarkCount?: number;
+}
+
 export class GraphBuilder {
+  private readonly landmarkCount: number;
   private nodes: Map<string, Node> = new Map();
   private edges: Map<string, Edge> = new Map();
   private roads: Map<string, Road> = new Map();
@@ -74,6 +86,10 @@ export class GraphBuilder {
   private connectedEdges: Map<string, Edge[]> = new Map();
   private turnRestrictions: Map<string, Set<string>> = new Map();
   private turnRestrictionTypes: Map<string, "prohibitory" | "mandatory"> = new Map();
+
+  constructor(options?: GraphBuilderOptions) {
+    this.landmarkCount = options?.landmarkCount ?? DEFAULT_LANDMARK_COUNT;
+  }
 
   private snapCoord(val: number): string {
     return (Math.round(val / COORD_SNAP_EPSILON) * COORD_SNAP_EPSILON).toFixed(7);
@@ -143,7 +159,7 @@ export class GraphBuilder {
    * excludes them, which tightens the bound without threatening admissibility.
    */
   private buildLandmarks(): LandmarkIndex | null {
-    const requested = resolveLandmarkCount();
+    const requested = this.landmarkCount;
     const nodeCount = this.nodes.size;
     if (requested <= 0 || nodeCount === 0) return null;
 

--- a/apps/simulator/src/routes/analytics.ts
+++ b/apps/simulator/src/routes/analytics.ts
@@ -1,10 +1,11 @@
 import { Router } from "express";
-import { parseBucketSpec } from "../modules/StateStore";
 import type {
+  AnalyticsHistoryEnvelope,
   AnalyticsHistoryMeta,
   AnalyticsHistoryRow,
   AnalyticsOrder,
-} from "../modules/StateStore";
+} from "@moveet/shared-types";
+import { parseBucketSpec } from "../modules/StateStore";
 import type { RouteContext } from "./types";
 
 /**
@@ -127,7 +128,10 @@ export function createAnalyticsRoutes(ctx: RouteContext): Router {
     }
 
     if (envelope) {
-      res.json({ meta: meta ?? null, rows });
+      // Typed against the shared contract, so the body the UI parses and the
+      // body this writes cannot drift apart silently.
+      const body: AnalyticsHistoryEnvelope = { meta: meta ?? null, rows };
+      res.json(body);
       return;
     }
 

--- a/apps/simulator/src/utils/config.ts
+++ b/apps/simulator/src/utils/config.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
 import { z } from "zod";
+import { resolveLandmarkCount } from "../modules/pathfinding/landmarks";
 import logger from "./logger";
 
 dotenv.config();
@@ -152,6 +153,26 @@ const envObjectSchema = z.object({
   PATHFIND_COOLDOWN_MS: z.coerce.number().int().min(0).default(3000),
 
   /**
+   * Number of ALT landmarks precomputed for the A* heuristic. `0` disables the
+   * preprocessing entirely and restores the exact pre-ALT haversine heuristic;
+   * blank, malformed and negative values fall back to the default; anything
+   * above the ceiling is clamped rather than rejected, because preprocessing
+   * time and memory are both linear in the count.
+   *
+   * The parse/clamp is `resolveLandmarkCount` from `modules/pathfinding/
+   * landmarks` rather than an inline zod chain so the schema and the pathfinding
+   * code share ONE implementation of the range. The dependency runs config →
+   * landmarks and never the reverse: that module is bundled into the pathfinding
+   * worker (esbuild), which must stay free of zod/dotenv/pino. Workers therefore
+   * receive the already-resolved number through `PathfindingPool`'s
+   * `workerData`, not by re-reading the environment.
+   */
+  PATHFINDING_LANDMARKS: z
+    .string()
+    .optional()
+    .transform((v) => resolveLandmarkCount(v)),
+
+  /**
    * Maximum backoff delay (ms) between adapter sync attempts after
    * consecutive failures. Caps the exponential backoff in
    * AdapterSyncManager so an unhealthy adapter is still retried periodically.
@@ -248,6 +269,7 @@ function buildConfig(env: EnvConfig) {
     wsPubSubChannel: env.WS_PUBSUB_CHANNEL,
     wsGatewayPort: env.WS_GATEWAY_PORT,
     pathfindCooldownMs: env.PATHFIND_COOLDOWN_MS,
+    pathfindingLandmarks: env.PATHFINDING_LANDMARKS,
     maxSyncBackoffMs: env.MAX_SYNC_BACKOFF_MS,
     sectorsN: env.SECTORS_N,
     faultsEnabled: env.FAULTS_ENABLED,

--- a/apps/simulator/src/workers/pathfinding-worker.ts
+++ b/apps/simulator/src/workers/pathfinding-worker.ts
@@ -1,9 +1,9 @@
 /**
  * Worker thread for A* pathfinding on the road network.
  *
- * Receives the GeoJSON path via `workerData`, builds a lightweight adjacency
- * graph (no circular references), and processes route requests from the main
- * thread.
+ * Receives its bootstrap settings via `workerData` (see
+ * {@link PathfindingWorkerData}), builds a lightweight adjacency graph (no
+ * circular references), and processes route requests from the main thread.
  *
  * Protocol:
  *   Request:  { type: 'findRoute', id: number, startId: string, endId: string, incidentEdges?: Record<string, number> }
@@ -26,11 +26,12 @@
  *
  * The A* heuristic is ALT (landmarks + triangle inequality) with the original
  * haversine bound as a floor; the preprocessing itself is shared with the main
- * thread via `../modules/pathfinding/landmarks`. Because `PathfindingPool` sends
- * workers nothing but `{ geojsonPath }`, each worker recomputes its own landmark
- * tables from the same GeoJSON. Selection is deterministic, so all copies are
- * identical — but they are also duplicated per worker (see the memory note in
- * apps/simulator/CLAUDE.md).
+ * thread via `../modules/pathfinding/landmarks`. The landmark COUNT arrives in
+ * `workerData` (parsed from `PATHFINDING_LANDMARKS` by the zod schema on the
+ * main thread — the bundle must not import that module), but the tables
+ * themselves are recomputed here from the same GeoJSON. Selection is
+ * deterministic, so all copies are identical — but they are also duplicated per
+ * worker (see the memory note in apps/simulator/CLAUDE.md).
  */
 
 import { parentPort, workerData } from "worker_threads";
@@ -41,9 +42,9 @@ import { PathNodeHeap } from "../modules/pathfinding/heap";
 import {
   AltHeuristic,
   type LandmarkIndex,
+  DEFAULT_LANDMARK_COUNT,
   buildCsrPair,
   buildLandmarkIndex,
-  resolveLandmarkCount,
   sortedNodeIds,
 } from "../modules/pathfinding/landmarks";
 import {
@@ -53,6 +54,31 @@ import {
   VALID_HIGHWAYS,
 } from "../modules/roadnetwork/types";
 import type { HighwayType } from "../types";
+
+// ---------------------------------------------------------------------------
+// Bootstrap contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything `PathfindingPool` hands a worker at spawn time.
+ *
+ * This is the ONLY channel by which configuration reaches a worker: the bundle
+ * must stay free of the zod/dotenv/pino config module (see the header above and
+ * `scripts/build-worker.mjs`), so `PathfindingPool` resolves settings on the
+ * main thread and passes the resolved values here. `PathfindingPool` imports
+ * this interface as a type, which erases at build time and cannot pull the pool
+ * (and its logger) into the worker bundle.
+ */
+export interface PathfindingWorkerData {
+  /** Path to the GeoJSON road network the worker builds its graph from. */
+  geojsonPath: string;
+  /**
+   * ALT landmarks to precompute, already parsed and clamped from
+   * `PATHFINDING_LANDMARKS` by the zod schema in `utils/config.ts`. `0`
+   * disables preprocessing and restores the pure-haversine heuristic.
+   */
+  landmarkCount?: number;
+}
 
 // ---------------------------------------------------------------------------
 // Lightweight graph types (no circular refs)
@@ -133,7 +159,10 @@ function calculateDistance(p1: [number, number], p2: [number, number]): number {
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-function buildGraph(geojsonPath: string): Map<string, WorkerNode> {
+function buildGraph(
+  geojsonPath: string,
+  landmarkCount: number = DEFAULT_LANDMARK_COUNT
+): Map<string, WorkerNode> {
   const data: FeatureCollection = JSON.parse(fs.readFileSync(geojsonPath, "utf8"));
   const nodes = new Map<string, WorkerNode>();
 
@@ -264,7 +293,7 @@ function buildGraph(geojsonPath: string): Map<string, WorkerNode> {
 
   // ALT landmark preprocessing over the static base costs (see
   // ../modules/pathfinding/landmarks.ts for the admissibility argument).
-  _alt = buildWorkerLandmarks(nodes);
+  _alt = buildWorkerLandmarks(nodes, landmarkCount);
 
   return nodes;
 }
@@ -278,8 +307,10 @@ function buildGraph(geojsonPath: string): Map<string, WorkerNode> {
  * (`smoothnessFactor === 0` excluded, exactly as the A* loop excludes them),
  * same selection — so both sides derive identical tables from identical GeoJSON.
  */
-function buildWorkerLandmarks(nodes: Map<string, WorkerNode>): AltHeuristic | null {
-  const requested = resolveLandmarkCount();
+function buildWorkerLandmarks(
+  nodes: Map<string, WorkerNode>,
+  requested: number
+): AltHeuristic | null {
   const nodeCount = nodes.size;
   if (requested <= 0 || nodeCount === 0) return null;
 
@@ -457,8 +488,8 @@ function findRoute(
 // ---------------------------------------------------------------------------
 
 if (parentPort) {
-  const geojsonPath: string = workerData.geojsonPath;
-  const nodes = buildGraph(geojsonPath);
+  const { geojsonPath, landmarkCount } = workerData as PathfindingWorkerData;
+  const nodes = buildGraph(geojsonPath, landmarkCount);
 
   parentPort.on(
     "message",

--- a/apps/ui/src/Controls/AnalyticsPanel.test.tsx
+++ b/apps/ui/src/Controls/AnalyticsPanel.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnalyticsSummary, FleetAnalytics } from "@/hooks/analyticsStore";
-import type { AnalyticsHistoryRow } from "@/hooks/useAnalytics";
+import type {
+  AnalyticsBucketMeta,
+  AnalyticsHistoryMeta,
+  AnalyticsHistoryRow,
+} from "@/hooks/useAnalytics";
 
 const resetAnalytics = vi.fn();
 
@@ -230,5 +234,150 @@ describe("AnalyticsPanel — persisted history", () => {
 
     await user.click(screen.getByRole("tab", { name: "Live" }));
     expect(await screen.findByText(/In-memory window · 2 samples/)).toBeInTheDocument();
+  });
+});
+
+describe("AnalyticsPanel — server-side bucketing", () => {
+  const BUCKET: AnalyticsBucketMeta = {
+    durationMs: 300_000,
+    label: "5m",
+    count: 3,
+    sampleCount: 180,
+    auto: true,
+  };
+
+  function makeBucketedRow(index: number): AnalyticsHistoryRow {
+    const start = T0 + index * 300_000;
+    return {
+      id: index,
+      timestamp: new Date(start).toISOString(),
+      summary: makeSummary(index, { timestamp: start }),
+      fleets: [makeFleet({ avgSpeed: 20 + index })],
+      bucket: {
+        durationMs: 300_000,
+        label: "5m",
+        start: new Date(start).toISOString(),
+        end: new Date(start + 300_000).toISOString(),
+        sampleCount: 60,
+        firstTimestamp: new Date(start).toISOString(),
+        lastTimestamp: new Date(start + 295_000).toISOString(),
+      },
+    };
+  }
+
+  function makeMeta(overrides: Partial<AnalyticsHistoryMeta> = {}): AnalyticsHistoryMeta {
+    return {
+      matched: 180,
+      scanned: 180,
+      returned: 3,
+      omitted: 0,
+      truncated: false,
+      anchor: "newest",
+      limit: 240,
+      order: "asc",
+      from: new Date(T0).toISOString(),
+      to: null,
+      coveredFrom: new Date(T0).toISOString(),
+      coveredTo: new Date(T0 + 600_000).toISOString(),
+      windowFrom: new Date(T0).toISOString(),
+      windowTo: new Date(T0 + 600_000).toISOString(),
+      bucket: BUCKET,
+      ...overrides,
+    };
+  }
+
+  function bucketedResponse(overrides: Partial<AnalyticsHistoryMeta> = {}) {
+    return {
+      data: {
+        meta: makeMeta(overrides),
+        rows: [makeBucketedRow(0), makeBucketedRow(1), makeBucketedRow(2)],
+      },
+    };
+  }
+
+  async function openRange(fetchHistory: ReturnType<typeof vi.fn>, tab: string) {
+    const user = userEvent.setup();
+    renderPanel({ summary: makeSummary(0), summaryHistory: [makeSummary(0)], fetchHistory });
+    await user.click(screen.getByRole("tab", { name: tab }));
+    return user;
+  }
+
+  it("asks for one bucket per plotted point instead of a slab to thin locally", async () => {
+    const fetchHistory = vi.fn().mockResolvedValue(bucketedResponse());
+    await openRange(fetchHistory, "24h");
+
+    await waitFor(() => expect(fetchHistory).toHaveBeenCalledTimes(1));
+    expect(fetchHistory.mock.calls[0][0]).toMatchObject({ limit: 240, bucket: "auto" });
+  });
+
+  it("reads the enveloped body and names the bucket width", async () => {
+    const fetchHistory = vi.fn().mockResolvedValue(bucketedResponse());
+    await openRange(fetchHistory, "6h");
+
+    expect(await screen.findByText(/Stored history · 3 samples · 5m buckets/)).toBeInTheDocument();
+    expect(screen.getByTestId("facet-speed")).toBeInTheDocument();
+  });
+
+  it("badges a window the server could not cover in full", async () => {
+    const fetchHistory = vi
+      .fn()
+      .mockResolvedValue(bucketedResponse({ truncated: true, omitted: 4200 }));
+    await openRange(fetchHistory, "24h");
+
+    const badge = await screen.findByTestId("analytics-truncated");
+    expect(badge).toHaveTextContent(/clipped/i);
+    expect(badge).toHaveAttribute("title", expect.stringContaining("4,200 older samples"));
+  });
+
+  it("leaves the badge off when the whole window came back", async () => {
+    const fetchHistory = vi.fn().mockResolvedValue(bucketedResponse());
+    await openRange(fetchHistory, "24h");
+
+    await screen.findByTestId("facet-speed");
+    expect(screen.queryByTestId("analytics-truncated")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes a last-in-bucket counter from a bucket mean", async () => {
+    const fetchHistory = vi.fn().mockResolvedValue(bucketedResponse());
+    await openRange(fetchHistory, "6h");
+
+    const distance = await screen.findByTestId("facet-label-distance");
+    expect(distance).toHaveAttribute("title", expect.stringMatching(/cumulative counter/i));
+    expect(distance).toHaveAttribute(
+      "title",
+      expect.stringMatching(/last sample in its 5m bucket/i)
+    );
+
+    const speed = screen.getByTestId("facet-label-speed");
+    expect(speed).toHaveAttribute("title", expect.stringMatching(/mean of the samples/i));
+    expect(speed.getAttribute("title")).not.toMatch(/cumulative/i);
+  });
+
+  it("carries the same distinction into the table view", async () => {
+    const fetchHistory = vi.fn().mockResolvedValue(bucketedResponse());
+    const user = await openRange(fetchHistory, "6h");
+
+    await screen.findByTestId("facet-speed");
+    await user.click(screen.getByRole("button", { name: "table" }));
+
+    expect(screen.getByTestId("series-th-distance")).toHaveAttribute(
+      "title",
+      expect.stringMatching(/cumulative counter/i)
+    );
+    expect(screen.getByTestId("series-th-speed")).toHaveAttribute(
+      "title",
+      expect.stringMatching(/mean of the samples/i)
+    );
+  });
+
+  it("says nothing about aggregation when the rows are verbatim samples", async () => {
+    const fetchHistory = vi
+      .fn()
+      .mockResolvedValue({ data: [makeBucketedRow(0), makeBucketedRow(1)] });
+    await openRange(fetchHistory, "1h");
+
+    const distance = await screen.findByTestId("facet-label-distance");
+    expect(distance).not.toHaveAttribute("title");
+    expect(screen.queryByTestId("analytics-truncated")).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/Controls/AnalyticsPanel.test.tsx
+++ b/apps/ui/src/Controls/AnalyticsPanel.test.tsx
@@ -2,11 +2,12 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnalyticsSummary, FleetAnalytics } from "@/hooks/analyticsStore";
-import type {
-  AnalyticsBucketMeta,
-  AnalyticsHistoryMeta,
-  AnalyticsHistoryRow,
-} from "@/hooks/useAnalytics";
+import {
+  ANALYTICS_BUCKET_AGGREGATION,
+  type AnalyticsBucketMeta,
+  type AnalyticsHistoryMeta,
+  type AnalyticsHistoryRow,
+} from "@moveet/shared-types";
 
 const resetAnalytics = vi.fn();
 
@@ -244,6 +245,7 @@ describe("AnalyticsPanel — server-side bucketing", () => {
     count: 3,
     sampleCount: 180,
     auto: true,
+    aggregation: ANALYTICS_BUCKET_AGGREGATION,
   };
 
   function makeBucketedRow(index: number): AnalyticsHistoryRow {

--- a/apps/ui/src/Controls/AnalyticsPanel.tsx
+++ b/apps/ui/src/Controls/AnalyticsPanel.tsx
@@ -8,12 +8,14 @@ import {
   type FacetSeries,
   type StatDelta,
 } from "@/components/charts";
-import { Eyebrow, SegTabs, StatusDot, mono, type SegTab } from "@/Dock/DockPanelKit";
+import { Eyebrow, SegTabs, StatusDot, Tag, mono, type SegTab } from "@/Dock/DockPanelKit";
 import type { AnalyticsSummary, FleetAnalytics } from "@/hooks/analyticsStore";
 import {
   ANALYTICS_RANGES,
+  describeAggregation,
   useAnalyticsSeries,
   type AnalyticsHistoryFetcher,
+  type AnalyticsHistoryMeta,
   type AnalyticsRange,
 } from "@/hooks/useAnalytics";
 import { cn } from "@/lib/utils";
@@ -63,6 +65,24 @@ const RANGE_TABS: SegTab<AnalyticsRange>[] = ANALYTICS_RANGES.map((r) => ({
 
 /** Trend samples shown in a KPI tile's sparkline. */
 const SPARK_POINTS = 24;
+
+/**
+ * Why the plotted window is narrower than the one that was asked for.
+ *
+ * The simulator answers a limited query from the RECENT end, so whatever it
+ * dropped is always older than the first point on the chart. Saying so beats
+ * silently drawing a range that does not start where the tab claims it does.
+ */
+function truncationDetail(meta: AnalyticsHistoryMeta): string {
+  const omitted = meta.omitted.toLocaleString();
+  const start = meta.coveredFrom ? new Date(meta.coveredFrom).toLocaleString() : null;
+  return [
+    `The stored window holds more than this query could read: ${omitted} older samples were left out.`,
+    start ? `The series starts at ${start} rather than at the start of the range.` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
 
 function tail(values: number[], count: number): number[] {
   return values.length > count ? values.slice(-count) : values;
@@ -165,7 +185,7 @@ export default function AnalyticsPanel({
     client.resetAnalytics();
   }, []);
 
-  const { summaries, latest, status } = series;
+  const { summaries, latest, status, bucket, truncated, meta } = series;
 
   const timestamps = useMemo(() => summaries.map((s) => s.timestamp), [summaries]);
 
@@ -197,14 +217,23 @@ export default function AnalyticsPanel({
         unit: "veh",
         values: columns.active,
         format: axisCount,
+        hint: describeAggregation("activeVehicles", bucket),
       },
-      { id: "speed", label: "Avg speed", unit: "km/h", values: columns.speed, format: axisSpeed },
+      {
+        id: "speed",
+        label: "Avg speed",
+        unit: "km/h",
+        values: columns.speed,
+        format: axisSpeed,
+        hint: describeAggregation("avgSpeed", bucket),
+      },
       {
         id: "distance",
         label: "Distance travelled",
         unit: "km",
         values: columns.distance,
         format: axisDistance,
+        hint: describeAggregation("totalDistanceTraveled", bucket),
       },
       {
         id: "efficiency",
@@ -212,9 +241,10 @@ export default function AnalyticsPanel({
         unit: "%",
         values: columns.efficiency,
         format: axisPercent,
+        hint: describeAggregation("avgRouteEfficiency", bucket),
       },
     ],
-    [columns]
+    [columns, bucket]
   );
 
   const sinceLabel = range === "live" ? "over window" : `over ${RANGE_LABEL[range]}`;
@@ -238,10 +268,29 @@ export default function AnalyticsPanel({
             ariaLabel="Analytics time range"
           />
           <div className="flex items-center justify-between gap-2">
-            <span className="truncate text-[10px] text-muted-foreground">
-              {series.source === "live" ? "In-memory window" : "Stored history"}
-              {summaries.length > 0 ? ` · ${summaries.length} samples` : ""}
-            </span>
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span
+                className="truncate text-[10px] text-muted-foreground"
+                title={
+                  bucket
+                    ? `Aggregated server-side into ${bucket.label} buckets from ${bucket.sampleCount.toLocaleString()} stored samples. Rates and counts are bucket means; cumulative totals keep the last value in each bucket.`
+                    : undefined
+                }
+              >
+                {series.source === "live" ? "In-memory window" : "Stored history"}
+                {summaries.length > 0 ? ` · ${summaries.length} samples` : ""}
+                {bucket ? ` · ${bucket.label} buckets` : ""}
+              </span>
+              {truncated && meta ? (
+                <span
+                  className="shrink-0"
+                  data-testid="analytics-truncated"
+                  title={truncationDetail(meta)}
+                >
+                  <Tag tone="warn">Clipped</Tag>
+                </span>
+              ) : null}
+            </div>
             <div className="flex items-center gap-1.5">
               <div className="flex gap-0.5" role="group" aria-label="Analytics view">
                 {(["chart", "table"] as const).map((v) => (

--- a/apps/ui/src/Controls/AnalyticsPanel.tsx
+++ b/apps/ui/src/Controls/AnalyticsPanel.tsx
@@ -9,13 +9,13 @@ import {
   type StatDelta,
 } from "@/components/charts";
 import { Eyebrow, SegTabs, StatusDot, Tag, mono, type SegTab } from "@/Dock/DockPanelKit";
+import type { AnalyticsHistoryMeta } from "@moveet/shared-types";
 import type { AnalyticsSummary, FleetAnalytics } from "@/hooks/analyticsStore";
 import {
   ANALYTICS_RANGES,
   describeAggregation,
   useAnalyticsSeries,
   type AnalyticsHistoryFetcher,
-  type AnalyticsHistoryMeta,
   type AnalyticsRange,
 } from "@/hooks/useAnalytics";
 import { cn } from "@/lib/utils";

--- a/apps/ui/src/components/charts/SeriesTable.tsx
+++ b/apps/ui/src/components/charts/SeriesTable.tsx
@@ -32,7 +32,13 @@ export function SeriesTable({ timestamps, series, maxRows = 40, caption }: Serie
               Time
             </th>
             {series.map((s) => (
-              <th key={s.id} scope="col" className="py-1 pl-2 text-right font-medium">
+              <th
+                key={s.id}
+                scope="col"
+                className="py-1 pl-2 text-right font-medium"
+                title={s.hint}
+                data-testid={`series-th-${s.id}`}
+              >
                 {s.label}
                 {s.unit ? <span className="ml-0.5 font-normal opacity-70">({s.unit})</span> : null}
               </th>

--- a/apps/ui/src/components/charts/TimeSeriesFacet.tsx
+++ b/apps/ui/src/components/charts/TimeSeriesFacet.tsx
@@ -14,6 +14,13 @@ export interface FacetSeries {
   unit?: string;
   values: number[];
   format: (value: number) => string;
+  /**
+   * How one plotted point was derived — surfaced on hover next to the label.
+   * Set it whenever the points are not raw samples (a bucket mean reads very
+   * differently from a bucket's last counter value, and the chart cannot show
+   * that difference on its own).
+   */
+  hint?: string;
 }
 
 export interface TimeSeriesFacetProps {
@@ -91,12 +98,19 @@ export function TimeSeriesFacet({
   return (
     <div className="flex flex-col gap-1 py-1.5" data-testid={`facet-${series.id}`}>
       <div className="flex items-baseline justify-between gap-2 pl-[34px] pr-2">
-        <span className="truncate text-[10.5px] font-medium text-muted-foreground">
+        <span
+          className="truncate text-[10.5px] font-medium text-muted-foreground"
+          title={series.hint}
+          data-testid={`facet-label-${series.id}`}
+        >
           {series.label}
         </span>
         {/* Direct label: exactly one number per facet — the crosshair sample,
             or the latest value when nothing is hovered. Never one per point. */}
-        <span className="shrink-0 font-mono text-[11px] font-semibold tabular-nums text-foreground">
+        <span
+          className="shrink-0 font-mono text-[11px] font-semibold tabular-nums text-foreground"
+          title={series.hint}
+        >
           {series.format(shownValue)}
           {series.unit ? (
             <span className="ml-0.5 font-sans text-[9.5px] font-normal text-muted-foreground">

--- a/apps/ui/src/hooks/useAnalytics.test.ts
+++ b/apps/ui/src/hooks/useAnalytics.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ANALYTICS_BUCKET_AGGREGATION,
+  type AnalyticsAggregatedField,
+  type AnalyticsBucketMeta,
+  type AnalyticsHistoryMeta,
+  type AnalyticsHistoryRow,
+} from "@moveet/shared-types";
+import {
   BUCKET_AGGREGATION,
   describeAggregation,
   fetchAnalyticsHistory,
   readHistoryPayload,
   rowsToSeries,
-  type AnalyticsBucketMeta,
-  type AnalyticsHistoryMeta,
-  type AnalyticsHistoryRow,
 } from "./useAnalytics";
 import type { AnalyticsSummary, FleetAnalytics } from "./analyticsStore";
 
@@ -65,6 +69,7 @@ const BUCKET_META: AnalyticsBucketMeta = {
   count: 2,
   sampleCount: 120,
   auto: true,
+  aggregation: ANALYTICS_BUCKET_AGGREGATION,
 };
 
 function makeMeta(overrides: Partial<AnalyticsHistoryMeta> = {}): AnalyticsHistoryMeta {
@@ -168,13 +173,17 @@ describe("describeAggregation", () => {
     }
   });
 
-  it("mirrors the simulator's own counter/gauge split", () => {
-    expect(BUCKET_AGGREGATION).toEqual({
-      activeVehicles: "mean",
-      avgSpeed: "mean",
-      totalDistanceTraveled: "last",
-      totalIdleTime: "last",
-      avgRouteEfficiency: "mean",
-    });
+  // The split is no longer restated here: `BUCKET_AGGREGATION` is derived from
+  // the shared `ANALYTICS_BUCKET_AGGREGATION` contract, and the derivation
+  // indexes it by `summary.<measure>`, so renaming a field in the simulator
+  // fails to compile here rather than drifting past a hand-copied literal.
+  // What is still worth asserting is that the narrowing itself is faithful.
+  it("narrows every plotted measure to the fold the shared contract states", () => {
+    for (const [measure, fold] of Object.entries(BUCKET_AGGREGATION)) {
+      const declared =
+        ANALYTICS_BUCKET_AGGREGATION[`summary.${measure}` as AnalyticsAggregatedField];
+      expect(declared).toBeDefined();
+      expect(declared).toMatch(fold === "last" ? /^last/ : /^mean$/);
+    }
   });
 });

--- a/apps/ui/src/hooks/useAnalytics.test.ts
+++ b/apps/ui/src/hooks/useAnalytics.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BUCKET_AGGREGATION,
+  describeAggregation,
+  fetchAnalyticsHistory,
+  readHistoryPayload,
+  rowsToSeries,
+  type AnalyticsBucketMeta,
+  type AnalyticsHistoryMeta,
+  type AnalyticsHistoryRow,
+} from "./useAnalytics";
+import type { AnalyticsSummary, FleetAnalytics } from "./analyticsStore";
+
+const T0 = Date.UTC(2026, 6, 25, 10, 0, 0);
+
+function makeSummary(index: number): AnalyticsSummary {
+  return {
+    totalVehicles: 10,
+    activeVehicles: 6 + index,
+    totalDistanceTraveled: 100 + index * 10,
+    avgSpeed: 30 + index,
+    totalIdleTime: 20,
+    avgRouteEfficiency: 0.8,
+    timestamp: T0 + index * 300_000,
+  };
+}
+
+function makeFleet(overrides: Partial<FleetAnalytics> = {}): FleetAnalytics {
+  return {
+    fleetId: "alpha",
+    vehicleCount: 4,
+    activeCount: 3,
+    totalDistance: 42,
+    avgSpeed: 31,
+    totalIdleTime: 5,
+    routeEfficiency: 0.9,
+    vehicles: [],
+    ...overrides,
+  };
+}
+
+/** A server-side bucketed row: bucket-start timestamp plus its provenance. */
+function makeBucketedRow(index: number): AnalyticsHistoryRow {
+  const start = T0 + index * 300_000;
+  return {
+    id: index,
+    timestamp: new Date(start).toISOString(),
+    summary: makeSummary(index),
+    fleets: [makeFleet()],
+    bucket: {
+      durationMs: 300_000,
+      label: "5m",
+      start: new Date(start).toISOString(),
+      end: new Date(start + 300_000).toISOString(),
+      sampleCount: 60,
+      firstTimestamp: new Date(start).toISOString(),
+      lastTimestamp: new Date(start + 295_000).toISOString(),
+    },
+  };
+}
+
+const BUCKET_META: AnalyticsBucketMeta = {
+  durationMs: 300_000,
+  label: "5m",
+  count: 2,
+  sampleCount: 120,
+  auto: true,
+};
+
+function makeMeta(overrides: Partial<AnalyticsHistoryMeta> = {}): AnalyticsHistoryMeta {
+  return {
+    matched: 120,
+    scanned: 120,
+    returned: 2,
+    omitted: 0,
+    truncated: false,
+    anchor: "newest",
+    limit: 240,
+    order: "asc",
+    from: new Date(T0).toISOString(),
+    to: null,
+    coveredFrom: new Date(T0).toISOString(),
+    coveredTo: new Date(T0 + 300_000).toISOString(),
+    windowFrom: new Date(T0).toISOString(),
+    windowTo: new Date(T0 + 300_000).toISOString(),
+    bucket: BUCKET_META,
+    ...overrides,
+  };
+}
+
+describe("fetchAnalyticsHistory", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => [] });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("asks the simulator to bucket server-side and to answer with an envelope", async () => {
+    const from = new Date(T0).toISOString();
+    await fetchAnalyticsHistory({ from, limit: 240, bucket: "auto" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+
+    expect(url.pathname).toBe("/analytics/history");
+    expect(url.searchParams.get("from")).toBe(from);
+    expect(url.searchParams.get("limit")).toBe("240");
+    expect(url.searchParams.get("bucket")).toBe("auto");
+    expect(url.searchParams.get("envelope")).toBe("true");
+  });
+});
+
+describe("readHistoryPayload", () => {
+  it("unwraps the enveloped body", () => {
+    const meta = makeMeta();
+    const rows = [makeBucketedRow(0), makeBucketedRow(1)];
+
+    expect(readHistoryPayload({ meta, rows })).toEqual({ meta, rows });
+  });
+
+  it("accepts a bare array from a simulator that ignores the envelope flag", () => {
+    const rows = [makeBucketedRow(0)];
+
+    expect(readHistoryPayload(rows)).toEqual({ rows, meta: null });
+  });
+
+  it("treats an unusable body as empty rather than throwing", () => {
+    expect(readHistoryPayload(undefined)).toEqual({ rows: [], meta: null });
+    expect(readHistoryPayload(null)).toEqual({ rows: [], meta: null });
+  });
+});
+
+describe("rowsToSeries", () => {
+  it("reads bucketed rows unchanged — the bucket start is the frame time", () => {
+    const { summaries, fleetHistory } = rowsToSeries([makeBucketedRow(1), makeBucketedRow(0)]);
+
+    expect(summaries.map((s) => s.timestamp)).toEqual([T0, T0 + 300_000]);
+    expect(summaries[0].avgSpeed).toBe(30);
+    expect(fleetHistory.get("alpha")).toHaveLength(2);
+  });
+});
+
+describe("describeAggregation", () => {
+  it("says nothing when the rows are verbatim samples", () => {
+    expect(describeAggregation("avgSpeed", null)).toBeUndefined();
+    expect(describeAggregation("totalDistanceTraveled", null)).toBeUndefined();
+  });
+
+  it("calls a cumulative counter a last-in-bucket value, not an average", () => {
+    const hint = describeAggregation("totalDistanceTraveled", BUCKET_META);
+
+    expect(hint).toMatch(/cumulative counter/i);
+    expect(hint).toMatch(/last sample in its 5m bucket/i);
+    expect(hint).toMatch(/not an average/i);
+  });
+
+  it("calls a gauge a bucket mean", () => {
+    for (const measure of ["avgSpeed", "activeVehicles", "avgRouteEfficiency"] as const) {
+      const hint = describeAggregation(measure, BUCKET_META);
+      expect(hint).toMatch(/mean of the samples in its 5m bucket/i);
+      expect(hint).not.toMatch(/cumulative/i);
+    }
+  });
+
+  it("mirrors the simulator's own counter/gauge split", () => {
+    expect(BUCKET_AGGREGATION).toEqual({
+      activeVehicles: "mean",
+      avgSpeed: "mean",
+      totalDistanceTraveled: "last",
+      totalIdleTime: "last",
+      avgRouteEfficiency: "mean",
+    });
+  });
+});

--- a/apps/ui/src/hooks/useAnalytics.ts
+++ b/apps/ui/src/hooks/useAnalytics.ts
@@ -63,11 +63,12 @@ export function useAnalytics(): UseAnalyticsResult {
 //  • "live"      — the WebSocket window analyticsStore already keeps (the last
 //                  60 snapshots, ~5 min at the simulator's 5 s cadence).
 //  • "persisted" — GET /analytics/history, the simulator's SQLite
-//                  `analytics_history` time series, which already accepts
-//                  from/to/limit. It answers 503 when the simulator runs
-//                  without persistence; that surfaces as an honest
-//                  "unavailable" state rather than a silent fallback to a
-//                  differently-scoped window.
+//                  `analytics_history` time series, which accepts
+//                  from/to/limit plus `bucket` (server-side downsampling) and
+//                  `envelope` (metadata in the body). It answers 503 when the
+//                  simulator runs without persistence; that surfaces as an
+//                  honest "unavailable" state rather than a silent fallback to
+//                  a differently-scoped window.
 //
 // Both normalise to the same `{ summaries, fleetHistory }` shape so the panel
 // (and its charts) never learn which source they are reading.
@@ -83,37 +84,186 @@ const RANGE_MS: Record<Exclude<AnalyticsRange, "live">, number> = {
   "24h": 24 * 60 * 60 * 1000,
 };
 
-/** Rows requested per query. The simulator itself clamps at 10 000. */
-const HISTORY_ROW_LIMIT = 2000;
-
 /** Samples kept for plotting — more than this is sub-pixel in a dock panel. */
 const MAX_PLOT_POINTS = 240;
 
+/**
+ * Entries requested per query. The panel plots at most `MAX_PLOT_POINTS`, so
+ * asking for more than that only pays to ship rows the charts thin away again.
+ * Paired with `bucket=auto` the simulator fits the WHOLE window into this many
+ * buckets instead of returning the newest N raw samples and nothing older.
+ */
+const HISTORY_ENTRY_LIMIT = MAX_PLOT_POINTS;
+
+/**
+ * Server-side downsample width. `auto` picks the smallest width off the
+ * simulator's ladder that fits the queried span into `limit` buckets.
+ */
+const HISTORY_BUCKET = "auto";
+
 const PERSISTED_REFRESH_MS = 15_000;
+
+/** Provenance of a single downsampled row (absent on verbatim rows). */
+export interface AnalyticsBucketInfo {
+  durationMs: number;
+  /** Canonical width label, e.g. `"5m"`. */
+  label: string;
+  /** ISO start of the bucket window (inclusive). */
+  start: string;
+  /** ISO end of the bucket window (exclusive). */
+  end: string;
+  /** Stored samples folded into this row. */
+  sampleCount: number;
+  firstTimestamp: string;
+  lastTimestamp: string;
+}
 
 /** A row of the simulator's `analytics_history` table. */
 export interface AnalyticsHistoryRow {
   id: number;
-  /** ISO-8601 row timestamp. */
+  /** ISO-8601 row timestamp. On a bucketed row, the bucket start. */
   timestamp: string;
   summary: AnalyticsSummary;
   fleets: FleetAnalytics[];
+  /** Present only when the server aggregated this row. */
+  bucket?: AnalyticsBucketInfo;
 }
 
-export type AnalyticsHistoryFetcher = (params: {
-  from: string;
+/** Bucket summary the server attaches to a downsampled query. */
+export interface AnalyticsBucketMeta {
+  durationMs: number;
+  label: string;
+  /** Buckets in the payload. */
+  count: number;
+  /** Stored samples folded into those buckets. */
+  sampleCount: number;
+  /** True when the width was derived from the data rather than requested. */
+  auto: boolean;
+  /** Per-field aggregation the server used, keyed by dotted field path. */
+  aggregation?: Record<string, string>;
+}
+
+/**
+ * What the server did NOT return. A limited query is answered from the RECENT
+ * end, so anything omitted is always older than the payload.
+ */
+export interface AnalyticsHistoryMeta {
+  matched: number;
+  scanned: number;
+  returned: number;
+  omitted: number;
+  truncated: boolean;
+  anchor: "newest";
   limit: number;
-}) => Promise<ApiResponse<AnalyticsHistoryRow[]>>;
+  order: "asc" | "desc";
+  from: string | null;
+  to: string | null;
+  coveredFrom: string | null;
+  coveredTo: string | null;
+  windowFrom: string | null;
+  windowTo: string | null;
+  bucket: AnalyticsBucketMeta | null;
+}
+
+/** Body shape returned by `?envelope=true`. */
+export interface AnalyticsHistoryEnvelope {
+  meta: AnalyticsHistoryMeta | null;
+  rows: AnalyticsHistoryRow[];
+}
+
+/**
+ * Either body the endpoint can answer with: the enveloped form we ask for, or
+ * the bare array a simulator that predates the bucketing work still returns.
+ */
+export type AnalyticsHistoryPayload = AnalyticsHistoryRow[] | AnalyticsHistoryEnvelope;
+
+export interface AnalyticsHistoryQuery {
+  /** ISO lower bound of the window. */
+  from: string;
+  /** Max entries — buckets, not raw samples, once `bucket` is set. */
+  limit: number;
+  /** Downsample width: `"auto"` or a duration such as `"30s"` / `"5m"`. */
+  bucket: string;
+}
+
+export type AnalyticsHistoryFetcher = (
+  params: AnalyticsHistoryQuery
+) => Promise<ApiResponse<AnalyticsHistoryPayload>>;
 
 let historyHttp: HttpClient | null = null;
 
 /** Default fetcher. Injectable so the panel's source can be swapped in tests. */
-export const fetchAnalyticsHistory: AnalyticsHistoryFetcher = ({ from, limit }) => {
+export const fetchAnalyticsHistory: AnalyticsHistoryFetcher = ({ from, limit, bucket }) => {
   historyHttp ??= new HttpClient(appConfig.apiUrl);
-  return historyHttp.get<AnalyticsHistoryRow[]>(
-    `/analytics/history?from=${encodeURIComponent(from)}&limit=${limit}`
-  );
+  const query = new URLSearchParams({
+    from,
+    limit: String(limit),
+    bucket,
+    // Truncation and bucket facts ride in the body rather than in the
+    // `X-Analytics-*` headers, because `HttpClient` hands back a parsed body
+    // and nothing else.
+    envelope: "true",
+  });
+  return historyHttp.get<AnalyticsHistoryPayload>(`/analytics/history?${query.toString()}`);
 };
+
+/**
+ * Normalises both response bodies into rows plus (when present) metadata.
+ *
+ * A simulator without the bucketing endpoint ignores `envelope` and answers a
+ * bare array; that path simply yields `meta: null`, and the panel degrades to
+ * what it showed before rather than erroring.
+ */
+export function readHistoryPayload(payload: AnalyticsHistoryPayload | undefined | null): {
+  rows: AnalyticsHistoryRow[];
+  meta: AnalyticsHistoryMeta | null;
+} {
+  if (Array.isArray(payload)) return { rows: payload, meta: null };
+  if (payload && Array.isArray(payload.rows)) {
+    return { rows: payload.rows, meta: payload.meta ?? null };
+  }
+  return { rows: [], meta: null };
+}
+
+/** Plotted measures, keyed the way `AnalyticsSummary` keys them. */
+export type BucketedMeasure =
+  | "activeVehicles"
+  | "avgSpeed"
+  | "totalDistanceTraveled"
+  | "totalIdleTime"
+  | "avgRouteEfficiency";
+
+/**
+ * How the simulator folds each measure when a query is bucketed. Mirrors its
+ * `ANALYTICS_BUCKET_AGGREGATION` map.
+ *
+ * The split matters: `totalDistanceTraveled` and `totalIdleTime` are
+ * monotonically accumulating counters, so a bucket keeps their LAST value —
+ * averaging them would understate the fleet. The rest are gauges and are
+ * averaged. Presenting the two identically invites reading a counter as a mean,
+ * so the panel labels them apart.
+ */
+export const BUCKET_AGGREGATION: Record<BucketedMeasure, "mean" | "last"> = {
+  activeVehicles: "mean",
+  avgSpeed: "mean",
+  totalDistanceTraveled: "last",
+  totalIdleTime: "last",
+  avgRouteEfficiency: "mean",
+};
+
+/**
+ * Hover copy explaining what one plotted point is. `undefined` when the series
+ * is verbatim — there is nothing to disclaim about an unaggregated sample.
+ */
+export function describeAggregation(
+  measure: BucketedMeasure,
+  bucket: AnalyticsBucketMeta | null
+): string | undefined {
+  if (!bucket) return undefined;
+  return BUCKET_AGGREGATION[measure] === "last"
+    ? `Cumulative counter: each point is the last sample in its ${bucket.label} bucket, not an average.`
+    : `Each point is the mean of the samples in its ${bucket.label} bucket.`;
+}
 
 export type AnalyticsSeriesStatus = "loading" | "collecting" | "ready" | "unavailable" | "error";
 
@@ -126,6 +276,15 @@ export interface AnalyticsSeriesResult {
   latest: AnalyticsSummary | null;
   /** Human-readable reason for a non-ready status. */
   message: string | null;
+  /** Server metadata for the persisted query. `null` for live/legacy sources. */
+  meta: AnalyticsHistoryMeta | null;
+  /**
+   * True when the server left older samples out of the requested window. The
+   * panel badges this rather than silently plotting a partial range.
+   */
+  truncated: boolean;
+  /** Bucket the server aggregated into. `null` when the rows are verbatim. */
+  bucket: AnalyticsBucketMeta | null;
 }
 
 /** Timestamp of a summary, falling back to the row's ISO timestamp. */
@@ -177,9 +336,12 @@ export interface UseAnalyticsSeriesOptions {
 /**
  * Resolves the selected range to a plottable series.
  *
- * The persisted branch re-queries every 15 s so a long window keeps up with the
- * running simulation, and holds the previous rows while a refetch is in flight
- * (no skeleton flash, no layout jump).
+ * The persisted branch asks the simulator to bucket server-side into exactly as
+ * many entries as the panel plots, so a 24 h window costs ~100 rows on the wire
+ * instead of the 2 000-row slab this hook used to thin down itself. It
+ * re-queries every 15 s so a long window keeps up with the running simulation,
+ * and holds the previous rows while a refetch is in flight (no skeleton flash,
+ * no layout jump).
  */
 export function useAnalyticsSeries({
   range,
@@ -190,6 +352,7 @@ export function useAnalyticsSeries({
   now = Date.now,
 }: UseAnalyticsSeriesOptions): AnalyticsSeriesResult {
   const [rows, setRows] = useState<AnalyticsHistoryRow[] | null>(null);
+  const [meta, setMeta] = useState<AnalyticsHistoryMeta | null>(null);
   const [remoteStatus, setRemoteStatus] = useState<AnalyticsSeriesStatus>("loading");
   const [remoteMessage, setRemoteMessage] = useState<string | null>(null);
 
@@ -199,12 +362,17 @@ export function useAnalyticsSeries({
 
     let cancelled = false;
     setRows(null);
+    setMeta(null);
     setRemoteStatus("loading");
     setRemoteMessage(null);
 
     const load = async () => {
       const from = new Date(now() - RANGE_MS[range]).toISOString();
-      const response = await fetchHistory({ from, limit: HISTORY_ROW_LIMIT });
+      const response = await fetchHistory({
+        from,
+        limit: HISTORY_ENTRY_LIMIT,
+        bucket: HISTORY_BUCKET,
+      });
       if (cancelled) return;
 
       if (response.error || !response.data) {
@@ -218,10 +386,13 @@ export function useAnalyticsSeries({
           setRemoteMessage(response.error ?? "Could not load analytics history.");
         }
         setRows([]);
+        setMeta(null);
         return;
       }
 
-      setRows(response.data);
+      const payload = readHistoryPayload(response.data);
+      setRows(payload.rows);
+      setMeta(payload.meta);
       setRemoteStatus("ready");
       setRemoteMessage(null);
     };
@@ -251,6 +422,9 @@ export function useAnalyticsSeries({
             : status === "collecting"
               ? "Collecting samples — the trend appears once a second snapshot arrives."
               : null,
+        meta: null,
+        truncated: false,
+        bucket: null,
       };
     }
 
@@ -262,6 +436,9 @@ export function useAnalyticsSeries({
         fleetHistory: new Map(),
         latest: null,
         message: "Loading stored history…",
+        meta: null,
+        truncated: false,
+        bucket: null,
       };
     }
 
@@ -276,11 +453,17 @@ export function useAnalyticsSeries({
     return {
       status,
       source: "persisted",
+      // The server already sized the payload to the plot; this stays as the
+      // safety net for a legacy simulator that ignores `bucket` and for a
+      // window whose bucket count overshoots.
       summaries: downsample(derived.summaries, MAX_PLOT_POINTS),
       fleetHistory: derived.fleetHistory,
       latest: derived.summaries[derived.summaries.length - 1] ?? null,
       message:
         status === "collecting" ? "No stored samples in this window yet." : (remoteMessage ?? null),
+      meta,
+      truncated: meta?.truncated ?? false,
+      bucket: meta?.bucket ?? null,
     };
-  }, [range, summary, summaryHistory, fleetHistory, rows, remoteStatus, remoteMessage]);
+  }, [range, summary, summaryHistory, fleetHistory, rows, meta, remoteStatus, remoteMessage]);
 }

--- a/apps/ui/src/hooks/useAnalytics.ts
+++ b/apps/ui/src/hooks/useAnalytics.ts
@@ -3,6 +3,13 @@ import { downsample } from "@/components/charts";
 import type { ApiResponse } from "@/types";
 import { HttpClient } from "@/utils/httpClient";
 import { config as appConfig } from "@/utils/config";
+import {
+  ANALYTICS_BUCKET_AGGREGATION,
+  type AnalyticsBucketMeta,
+  type AnalyticsHistoryMeta,
+  type AnalyticsHistoryPayload,
+  type AnalyticsHistoryRow,
+} from "@moveet/shared-types";
 import { analyticsStore, type AnalyticsSummary, type FleetAnalytics } from "./analyticsStore";
 
 const POLL_INTERVAL_MS = 1000;
@@ -103,80 +110,6 @@ const HISTORY_BUCKET = "auto";
 
 const PERSISTED_REFRESH_MS = 15_000;
 
-/** Provenance of a single downsampled row (absent on verbatim rows). */
-export interface AnalyticsBucketInfo {
-  durationMs: number;
-  /** Canonical width label, e.g. `"5m"`. */
-  label: string;
-  /** ISO start of the bucket window (inclusive). */
-  start: string;
-  /** ISO end of the bucket window (exclusive). */
-  end: string;
-  /** Stored samples folded into this row. */
-  sampleCount: number;
-  firstTimestamp: string;
-  lastTimestamp: string;
-}
-
-/** A row of the simulator's `analytics_history` table. */
-export interface AnalyticsHistoryRow {
-  id: number;
-  /** ISO-8601 row timestamp. On a bucketed row, the bucket start. */
-  timestamp: string;
-  summary: AnalyticsSummary;
-  fleets: FleetAnalytics[];
-  /** Present only when the server aggregated this row. */
-  bucket?: AnalyticsBucketInfo;
-}
-
-/** Bucket summary the server attaches to a downsampled query. */
-export interface AnalyticsBucketMeta {
-  durationMs: number;
-  label: string;
-  /** Buckets in the payload. */
-  count: number;
-  /** Stored samples folded into those buckets. */
-  sampleCount: number;
-  /** True when the width was derived from the data rather than requested. */
-  auto: boolean;
-  /** Per-field aggregation the server used, keyed by dotted field path. */
-  aggregation?: Record<string, string>;
-}
-
-/**
- * What the server did NOT return. A limited query is answered from the RECENT
- * end, so anything omitted is always older than the payload.
- */
-export interface AnalyticsHistoryMeta {
-  matched: number;
-  scanned: number;
-  returned: number;
-  omitted: number;
-  truncated: boolean;
-  anchor: "newest";
-  limit: number;
-  order: "asc" | "desc";
-  from: string | null;
-  to: string | null;
-  coveredFrom: string | null;
-  coveredTo: string | null;
-  windowFrom: string | null;
-  windowTo: string | null;
-  bucket: AnalyticsBucketMeta | null;
-}
-
-/** Body shape returned by `?envelope=true`. */
-export interface AnalyticsHistoryEnvelope {
-  meta: AnalyticsHistoryMeta | null;
-  rows: AnalyticsHistoryRow[];
-}
-
-/**
- * Either body the endpoint can answer with: the enveloped form we ask for, or
- * the bare array a simulator that predates the bucketing work still returns.
- */
-export type AnalyticsHistoryPayload = AnalyticsHistoryRow[] | AnalyticsHistoryEnvelope;
-
 export interface AnalyticsHistoryQuery {
   /** ISO lower bound of the window. */
   from: string;
@@ -234,8 +167,10 @@ export type BucketedMeasure =
   | "avgRouteEfficiency";
 
 /**
- * How the simulator folds each measure when a query is bucketed. Mirrors its
- * `ANALYTICS_BUCKET_AGGREGATION` map.
+ * How the simulator folds each measure when a query is bucketed, DERIVED from
+ * the shared `ANALYTICS_BUCKET_AGGREGATION` contract rather than restated —
+ * the server's own descriptions ("last (cumulative counter)", "mean") narrowed
+ * to the two cases the panel's copy distinguishes.
  *
  * The split matters: `totalDistanceTraveled` and `totalIdleTime` are
  * monotonically accumulating counters, so a bucket keeps their LAST value —
@@ -243,13 +178,20 @@ export type BucketedMeasure =
  * averaged. Presenting the two identically invites reading a counter as a mean,
  * so the panel labels them apart.
  */
-export const BUCKET_AGGREGATION: Record<BucketedMeasure, "mean" | "last"> = {
-  activeVehicles: "mean",
-  avgSpeed: "mean",
-  totalDistanceTraveled: "last",
-  totalIdleTime: "last",
-  avgRouteEfficiency: "mean",
-};
+export const BUCKET_AGGREGATION = Object.fromEntries(
+  (
+    [
+      "activeVehicles",
+      "avgSpeed",
+      "totalDistanceTraveled",
+      "totalIdleTime",
+      "avgRouteEfficiency",
+    ] as const
+  ).map((measure) => [
+    measure,
+    ANALYTICS_BUCKET_AGGREGATION[`summary.${measure}`].startsWith("last") ? "last" : "mean",
+  ])
+) as Record<BucketedMeasure, "mean" | "last">;
 
 /**
  * Hover copy explaining what one plotted point is. `undefined` when the series

--- a/packages/shared-types/src/__tests__/types.test.ts
+++ b/packages/shared-types/src/__tests__/types.test.ts
@@ -21,7 +21,10 @@ import type {
   IncidentDTO,
   RecordingMetadata,
   ReplayStatus,
+  AnalyticsSummary,
+  FleetAnalytics,
 } from "../index";
+import { ANALYTICS_BUCKET_AGGREGATION, type AnalyticsAggregatedField } from "../rest";
 
 // Helper to assert a value satisfies a type at compile time
 function assertType<T>(_value: T): void {
@@ -377,5 +380,28 @@ describe("VehicleUpdate telemetry fields", () => {
     expectTypeOf(u.accuracy).toEqualTypeOf<number | undefined>();
     expectTypeOf(u.timestamp).toEqualTypeOf<number | undefined>();
     expectTypeOf(u.connected).toEqualTypeOf<boolean | undefined>();
+  });
+});
+
+describe("ANALYTICS_BUCKET_AGGREGATION", () => {
+  // The map is what the simulator ships inside a bucketed response and what the
+  // UI derives its "counter vs mean" labelling from, so a summary field with no
+  // declared fold is a field one of them will silently guess at. This fails to
+  // compile the moment a measure is added without a decision.
+  it("declares a fold for every aggregated analytics field", () => {
+    type SummaryFolds = `summary.${keyof AnalyticsSummary}`;
+    type FleetFolds = `fleets[].${Exclude<keyof FleetAnalytics, "fleetId">}`;
+    assertType<AnalyticsAggregatedField>(null as unknown as SummaryFolds);
+    assertType<AnalyticsAggregatedField>(null as unknown as FleetFolds);
+
+    // `fleetId` is an identifier, not a measure, so it deliberately has none.
+    expect(ANALYTICS_BUCKET_AGGREGATION).not.toHaveProperty("fleets[].fleetId");
+  });
+
+  it("splits cumulative counters from gauges", () => {
+    expect(ANALYTICS_BUCKET_AGGREGATION["summary.totalDistanceTraveled"]).toMatch(/^last/);
+    expect(ANALYTICS_BUCKET_AGGREGATION["summary.totalIdleTime"]).toMatch(/^last/);
+    expect(ANALYTICS_BUCKET_AGGREGATION["summary.avgSpeed"]).toBe("mean");
+    expect(ANALYTICS_BUCKET_AGGREGATION["summary.activeVehicles"]).toBe("mean");
   });
 });

--- a/packages/shared-types/src/rest.ts
+++ b/packages/shared-types/src/rest.ts
@@ -3,7 +3,7 @@
 // The UI's client.ts imports these so a changed payload shape fails to
 // compile on the consumer side rather than drifting silently.
 
-import type { DirectionResult, Position } from "./index";
+import type { AnalyticsSummary, DirectionResult, FleetAnalytics, Position } from "./index";
 
 // ─── Road network (/network, /roads) ────────────────────────────────
 
@@ -87,3 +87,144 @@ export interface ScenarioStatus {
   eventsExecuted: number;
   upcomingEvents: Array<{ at: number; type: string }>;
 }
+
+// ─── Analytics history (/analytics/history) ─────────────────────────
+//
+// The simulator writes these rows, shapes them (limit + server-side bucketing)
+// and serves them; the UI plots them. They live here rather than in the
+// simulator because a consumer that hand-copies an aggregation contract is a
+// consumer that will eventually read a cumulative counter as an average.
+
+/** Sort order of the rows in an analytics history payload. */
+export type AnalyticsOrder = "asc" | "desc";
+
+/** Provenance of a single downsampled row. */
+export interface AnalyticsBucketInfo {
+  /** Bucket width in milliseconds. */
+  durationMs: number;
+  /** Canonical width label, e.g. `"5m"`. */
+  label: string;
+  /** ISO start of the bucket window (inclusive). */
+  start: string;
+  /** ISO end of the bucket window (exclusive). */
+  end: string;
+  /** Stored samples folded into this row. */
+  sampleCount: number;
+  /** ISO timestamp of the oldest sample folded in. */
+  firstTimestamp: string;
+  /** ISO timestamp of the newest sample folded in. */
+  lastTimestamp: string;
+}
+
+/**
+ * How each analytics field is folded when a query is bucketed.
+ *
+ * The distinction matters: `totalDistanceTraveled` and `totalIdleTime` are
+ * monotonically accumulating counters — averaging them would understate the
+ * fleet and break monotonicity, so the bucket keeps the LAST value. Gauges
+ * (`activeVehicles`, `avgSpeed`, `avgRouteEfficiency`) are averaged across the
+ * samples in the bucket. `totalVehicles` is a slow-moving gauge (fleet size),
+ * so the last value is the honest representative rather than a fractional mean.
+ *
+ * `fleets[].vehicles` (the per-vehicle `VehicleStats[]`) is NOT aggregated: it
+ * is a point-in-time array mixing cumulative counters with per-vehicle gauges
+ * and there is no meaningful element-wise fold, so the newest sample's array is
+ * carried through verbatim.
+ *
+ * Shipped inside the response metadata so a caller can never mistake a bucketed
+ * counter for a mean — and shared with the UI so its axis labels are derived
+ * from this map rather than restating it.
+ */
+export const ANALYTICS_BUCKET_AGGREGATION = {
+  "summary.totalVehicles": "last",
+  "summary.activeVehicles": "mean",
+  "summary.totalDistanceTraveled": "last (cumulative counter)",
+  "summary.avgSpeed": "mean",
+  "summary.totalIdleTime": "last (cumulative counter)",
+  "summary.avgRouteEfficiency": "mean",
+  "summary.timestamp": "bucket start",
+  "fleets[].vehicleCount": "last",
+  "fleets[].activeCount": "mean",
+  "fleets[].totalDistance": "last (cumulative counter)",
+  "fleets[].avgSpeed": "mean",
+  "fleets[].totalIdleTime": "last (cumulative counter)",
+  "fleets[].routeEfficiency": "mean",
+  "fleets[].vehicles": "last (not aggregated)",
+} as const;
+
+/** Dotted field paths {@link ANALYTICS_BUCKET_AGGREGATION} describes. */
+export type AnalyticsAggregatedField = keyof typeof ANALYTICS_BUCKET_AGGREGATION;
+
+/** Bucket summary attached to the metadata of a downsampled query. */
+export interface AnalyticsBucketMeta {
+  durationMs: number;
+  label: string;
+  /** Buckets in the payload. */
+  count: number;
+  /** Stored samples folded into those buckets. */
+  sampleCount: number;
+  /** True when the width was derived from the data rather than requested. */
+  auto: boolean;
+  aggregation: typeof ANALYTICS_BUCKET_AGGREGATION;
+}
+
+/** One row of the simulator's `analytics_history` table. */
+export interface AnalyticsHistoryRow {
+  id: number;
+  /** ISO-8601 row timestamp. On a bucketed row, the bucket start. */
+  timestamp: string;
+  summary: AnalyticsSummary;
+  fleets: FleetAnalytics[];
+  /**
+   * Present only on downsampled rows. Its absence means the row is a verbatim
+   * stored sample.
+   */
+  bucket?: AnalyticsBucketInfo;
+}
+
+/**
+ * Everything the caller needs to know about what the query did NOT return.
+ *
+ * A limited query is answered from the RECENT end of the window, so anything
+ * omitted is always older than the payload.
+ */
+export interface AnalyticsHistoryMeta {
+  /** Stored rows inside the requested window, before limiting or bucketing. */
+  matched: number;
+  /** Stored rows actually read (and therefore represented in the payload). */
+  scanned: number;
+  /** Entries in the payload (buckets when bucketed, rows otherwise). */
+  returned: number;
+  /** Stored rows in the window that are NOT represented at all. */
+  omitted: number;
+  /** True whenever `omitted > 0` — i.e. the payload is not the whole window. */
+  truncated: boolean;
+  /** Which end of the window survives the limit. Always the newest. */
+  anchor: "newest";
+  /** Limit actually applied after clamping to [1, 10000]. */
+  limit: number;
+  order: AnalyticsOrder;
+  /** Echo of the requested window (`null` = unbounded). */
+  from: string | null;
+  to: string | null;
+  /** Span the payload actually covers (`null` when empty). */
+  coveredFrom: string | null;
+  coveredTo: string | null;
+  /** Oldest/newest stored timestamps inside the requested window. */
+  windowFrom: string | null;
+  windowTo: string | null;
+  bucket: AnalyticsBucketMeta | null;
+}
+
+/** Body shape returned by `?envelope=true`. */
+export interface AnalyticsHistoryEnvelope {
+  meta: AnalyticsHistoryMeta | null;
+  rows: AnalyticsHistoryRow[];
+}
+
+/**
+ * Either body the endpoint can answer with. Without `?envelope=true` it stays
+ * a bare array, which is also what a simulator predating the bucketing work
+ * returns — so a client that asks for the envelope must still tolerate this.
+ */
+export type AnalyticsHistoryPayload = AnalyticsHistoryRow[] | AnalyticsHistoryEnvelope;


### PR DESCRIPTION
Three independent issues, worked in parallel worktrees and landed as one commit each, plus a fourth commit paying off the duplication the second one introduced.

Closes `fleetsim-all-crdr`, `fleetsim-all-ke5r.14`, `fleetsim-all-vtwk.14`, `fleetsim-all-i19m`.

---

### `fix(simulator)` — job assignment scores true positions, not device-reported ones (`fleetsim-all-crdr`)

`JobManager.pickVehicle` read the roster through `VehicleManager.getVehicles()`, which projects the device-fault layer. With a fault profile armed, a frozen or spoofed device was scored at the fix it was *reporting* rather than where it actually was, so arming faults silently changed which vehicle won a job. `best_eta` was worse: its proximity shortlist came from reported positions while its ETA probe (`RouteManager.estimateTo`) pathfinds from the registry's true one, so the two halves of a single decision disagreed about the same vehicle.

Assignment now reads truth, via a new `VehicleManager.getTrueVehicles()`. Dispatch is a simulator-internal decision: the simulator authors the scenario rather than being one of the consumers the fault layer exists to deceive. Observer surfaces are untouched — `getVehicles()` still projects for the WS feed, `GET /vehicles`, out-of-band `update` frames and the adapter push.

Two consequences worth reviewing, both beyond what the issue described:

- A battery-dead device used to contribute its last stale fix as an assignment input. Under truth, a dead tracker no longer misplaces its vehicle or makes it un-dispatchable. That reads as correct (the vehicle is fine, only its tracker died) but it is a behaviour change.
- The `[0, 0]` "not placed on the network yet" sentinel check in `pickVehicle` was defeatable by a teleport fault nudging an unplaced vehicle off the origin. Reading truth closes that incidentally.

New coverage includes an end-to-end test wiring a real `VehicleManager` + `DeviceFaultManager` + `JobManager`: a device freezes its fix 9 degrees out, the vehicle parks next to the pickup, and the job must go to it while `GET /vehicles` still shows the frozen fix.

### `perf(ui)` — request server-bucketed analytics instead of thinning client-side (`fleetsim-all-ke5r.14`)

The history endpoint gained server-side downsampling in `fleetsim-all-vtwk.10`, but `useAnalytics` still asked for 2 000 raw rows and thinned to 240 in the browser. It now requests `limit=240&bucket=auto&envelope=true`.

Measured against a real `StateStore` seeded with 24 h at the default `ANALYTICS_INTERVAL=5000` (17 280 samples):

| | rows | bytes | coverage |
|---|---|---|---|
| before (`limit=2000`) | 2 000 | 1 125 201 | ~2.8 h of a 24 h window, `truncated=true` |
| after (`limit=240&bucket=auto`) | 96 (15 m buckets) | 76 572 | the full 24 h, `truncated=false` |

20.8x fewer rows, 14.7x fewer bytes. The issue's estimate of "~8x" understated it.

Note the coverage column: **the old request was itself silently truncated on the 6 h and 24 h views**, showing a partial range with no indication. The panel now badges a clipped window ("Clipped", naming the omitted count and the real series start), so that class of bug is visible rather than only this instance of it being fixed.

The panel also now distinguishes aggregation semantics, which the issue asked for: `totalDistanceTraveled` and `totalIdleTime` are last-in-bucket values because they are cumulative counters, while `avgSpeed`, `activeVehicles` and `avgRouteEfficiency` are bucket means. Presenting both identically invites reading a counter as an average. Hints are wired through both the chart facet and the table header.

Two implementation notes:

- Truncation is read from the `envelope=true` body (`meta.truncated`) rather than the `X-Analytics-Truncated` header, because `utils/httpClient.ts` returns only `{ data, error }` and never exposes headers. Reading the header meant widening `HttpClient` for every caller. The envelope also carries `omitted` and `coveredFrom`, which the badge needs anyway.
- `readHistoryPayload` accepts the envelope *or* a bare array, and the client-side `downsample` stays as a no-op safety net.

### `refactor(simulator)` — route `PATHFINDING_LANDMARKS` through the env schema (`fleetsim-all-vtwk.14`)

Every other simulator env var goes through the zod schema in `utils/config.ts`, which gives it validation, a default and a line in `logConfig()`. `PATHFINDING_LANDMARKS` read `process.env` directly, so it was invisible in the startup config dump and validated only by an inline clamp. The reason was real: the value is needed inside the pathfinding worker, an esbuild bundle that deliberately avoids the zod/dotenv/logger module, and `PathfindingPool` passed workers nothing but `{ geojsonPath }`.

It is now threaded through `workerData` instead:

`config.ts` (zod, the only `process.env` read) → `RoadNetwork` (resolved once) → `GraphBuilder({landmarkCount})` for the main-thread graph, and `PathfindingPool({landmarkCount})` → `new Worker(path, { workerData: { geojsonPath, landmarkCount } })` → `buildGraph(geojsonPath, landmarkCount)`. `PathfindingPool` imports the `PathfindingWorkerData` shape with `import type`, which erases, so the dependency arrow never points from the worker back at the pool or logger.

The bundle stayed clean, and that is now enforced by a test rather than asserted once: `workerBootstrap.test.ts` parses every `require("…")` in the built bundle and asserts each is a Node builtin, plus greps for any trace of the config module. Verified on the built artifact — the only requires are `fs` and `worker_threads`, and `process.env` appears zero times (the worker no longer reads the environment at all). Bundle went 24 646 → 24 345 bytes.

Behaviour is preserved exactly: default 4, `0` disables preprocessing and restores the pre-ALT haversine heuristic, ceiling 32, garbage falls back to 4. The load-bearing route-equivalence tests still pass on the real 22 MB Nairobi network, including `basePops/altPops > 2`, which would fail outright if the landmark count were not actually reaching `GraphBuilder`.

Tests that previously drove behaviour by mutating `process.env` now pass the count at the same seam production uses. `.env.example` documents the var — the existing completeness test in `config.test.ts` forces that the moment a var enters the schema.

`PathfindingWorkerData` is also the extension point `fleetsim-all-pv8l` (SharedArrayBuffer-backed graph) needs; that work is not started here.

### `refactor(shared-types)` — declare the analytics history contract once (`fleetsim-all-i19m`)

The commit above taught the UI the `/analytics/history` contract by hand-copying it, because `shared-types` carried no analytics types and the UI cannot import from the simulator. That copy had already drifted on arrival: `AnalyticsBucketMeta.aggregation` was optional and typed `Record<string, string>` where the server always sends a known const, and the counter-vs-mean split was restated as a literal guarded by a hand-written parity test.

The row, bucket, metadata and envelope shapes now live in `packages/shared-types/src/rest.ts`, for the reason that file already states: a changed payload shape should fail to compile on the consumer side rather than drift silently. Three things get stronger rather than merely deduplicated:

- The route's `?envelope=true` body is typed `AnalyticsHistoryEnvelope` instead of an inline object literal, so what the simulator writes and what the UI parses are checked against one declaration.
- The UI's `BUCKET_AGGREGATION` is now **derived** from `ANALYTICS_BUCKET_AGGREGATION` by indexing it at `summary.<measure>`, so renaming a measure in the contract fails to compile in the UI. The hand-copied parity test is replaced by one asserting the narrowing is faithful.
- A new type test asserts every `AnalyticsSummary` and `FleetAnalytics` measure has a declared fold — so adding a measure forces an aggregation decision instead of letting two consumers guess. **Verified it bites** rather than assumed: adding `avgDwellTime` to `AnalyticsSummary` fails `tsc` with `Type '"summary.avgDwellTime"' is not assignable`, and the change was reverted.

`StateStore` re-exports the shared declarations so its existing importers keep one import site, and keeps what is genuinely store-local: `AnalyticsHistoryOptions` (how a query is asked for) and `AnalyticsHistoryResult` (the array-with-hidden-`meta` it hands back in-process, which never crosses the wire).

---

### Verification

Run on the integrated branch, not just per-worktree:

- `npm test` → 6/6 turbo tasks: simulator **91 files / 1908 tests**, ui **122 files / 1459 tests**, adapter 52 files, network 9, server-kit 4, shared-types 1
- `npm run type-check` → 6/6 successful
- `npm run test:repo` → 12 passed
- `npm run build` → 4/4 successful
- `biome lint .` → exit 0, **57 warnings / 39 infos, identical to `main`** — no new lint debt
- `biome format .` → clean
- Worker bundle purity re-verified independently on the built artifact

The known parallel-load flake (`Parse Error: Expected HTTP/, RTSP/ or ICE/`, tracked as `fleetsim-all-vtwk.13`) did not appear in any run here. It is not fixed by this PR.

### Still open after this

`fleetsim-all-mxzc.7` (generate OpenAPI/AsyncAPI from `shared-types`) gets easier now that the analytics endpoint's types are declared in `shared-types` rather than inside the simulator, but it is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
