### PR TITLE
feat(simulator): scenario-as-code with assertions, graded headlessly (fleetsim-all-mxzc.6)

### DIFF
--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -387,6 +387,45 @@ See "Scaling WebSocket Clients" below for when to enable it and load-test result
 npm test
 ```
 
+### Scenario Harness (scenario-as-code with assertions)
+
+A scenario file in `data/scenarios/` can carry an `assertions` array, which turns it into a
+regression test the simulator grades against itself. The runner is headless and drives
+simulated time in explicit steps (no wall-clock timers), so a one-hour scenario grades in
+seconds and exits non-zero when an assertion fails — suitable for CI.
+
+```bash
+npm run scenario -- dispatch-regression --vehicles 150
+npm run scenario -- ./my-scenario.json --seed 7 --max-seconds 600 --report report.json
+```
+
+Options: `--vehicles <n>` (synthetic fleet seeded before the timeline), `--step-ms <n>`
+(simulated ms per step, default 1000), `--seed <n>`, `--max-seconds <n>` (cap the simulated
+window, overriding the scenario's `duration`), `--network <path>`, `--report <path>` (write the
+full JSON report), `--json` (print the report instead of a summary). Exit codes: `0` every
+assertion held, `1` an assertion failed or a scenario action threw, `2` the scenario could not
+be run (bad arguments, unreadable or invalid file, missing network).
+
+Assertion types (all optional fields have defaults):
+
+| Type | Fields | Holds when |
+|---|---|---|
+| `all_jobs_completed` | — | every job the scenario created reached `complete` |
+| `job_completion_rate` | `atLeast` (0–1) | completed/created is at least `atLeast` (a run with no jobs scores 1) |
+| `job_failures` | `atMost` (default 0) | no more than `atMost` jobs ended `failed` |
+| `job_eta_percentile` | `percentile` (95), `leg` (`pickup`\|`dropoff`), `lessThanSeconds` | that percentile of assignment ETAs is under the threshold (fails if no job was ever assigned) |
+| `no_stranded_vehicles` | `idleSeconds` (120) | no vehicle stayed at the same position for longer than `idleSeconds` of simulated time |
+| `fleet_avg_speed` | `atLeastKph`, `atMostKph` (optional) | the fleet-mean speed is inside the band |
+
+Every assertion also accepts `label` to override the generated description. Scenarios can
+dispatch work with the `create_job` action (pickup + dropoff + `strategy`), which is what the
+job assertions grade. Assertions are evaluated only by this harness — a scenario played live
+from the UI has no exit code to fail, so `ScenarioManager` ignores them there.
+
+The run is reproducible for a fixed `--seed`: RNG is seeded, waypoint dwell and the
+pathfind-retry cooldown are measured on the simulation clock rather than wall time, and
+in-flight pathfinding is settled at each step boundary.
+
 ### Lint & format
 
 Linting and formatting are handled repo-wide by **Biome**; run from the monorepo root

--- a/apps/simulator/data/scenarios/dispatch-regression.json
+++ b/apps/simulator/data/scenarios/dispatch-regression.json
@@ -1,0 +1,130 @@
+{
+  "name": "Dispatch Regression",
+  "description": "Headless regression harness: seeds a fleet, dispatches four jobs across the Nairobi CBD with an incident on the first pickup corridor, then asserts every job was delivered, response ETAs stayed inside SLA, nothing got stranded and the fleet kept moving. Run with `npm run scenario -- dispatch-regression --vehicles 150`.",
+  "city": "nairobi",
+  "version": 1,
+  "duration": 3600,
+  "events": [
+    {
+      "at": 0,
+      "action": {
+        "type": "set_options",
+        "options": {
+          "minSpeed": 20,
+          "maxSpeed": 60
+        }
+      }
+    },
+    {
+      "at": 5,
+      "action": {
+        "type": "create_job",
+        "pickup": {
+          "lat": -1.2921,
+          "lng": 36.8219,
+          "label": "CBD"
+        },
+        "dropoff": {
+          "lat": -1.3015,
+          "lng": 36.8484,
+          "label": "South B"
+        },
+        "strategy": "nearest"
+      }
+    },
+    {
+      "at": 30,
+      "action": {
+        "type": "create_job",
+        "pickup": {
+          "lat": -1.2833,
+          "lng": 36.8172,
+          "label": "Westlands approach"
+        },
+        "dropoff": {
+          "lat": -1.3084,
+          "lng": 36.8065,
+          "label": "Nairobi West"
+        },
+        "strategy": "best_eta"
+      }
+    },
+    {
+      "at": 60,
+      "action": {
+        "type": "create_incident",
+        "position": {
+          "lat": -1.2921,
+          "lng": 36.8219
+        },
+        "incidentType": "accident",
+        "duration": 180,
+        "severity": 0.6
+      }
+    },
+    {
+      "at": 90,
+      "action": {
+        "type": "create_job",
+        "pickup": {
+          "lat": -1.2975,
+          "lng": 36.8256,
+          "label": "Upper Hill"
+        },
+        "dropoff": {
+          "lat": -1.2694,
+          "lng": 36.8544,
+          "label": "Eastleigh"
+        },
+        "strategy": "nearest"
+      }
+    },
+    {
+      "at": 240,
+      "action": {
+        "type": "clear_incidents"
+      }
+    },
+    {
+      "at": 300,
+      "action": {
+        "type": "create_job",
+        "pickup": {
+          "lat": -1.3015,
+          "lng": 36.8484,
+          "label": "South B"
+        },
+        "dropoff": {
+          "lat": -1.2921,
+          "lng": 36.8219,
+          "label": "CBD"
+        },
+        "strategy": "best_eta"
+      }
+    }
+  ],
+  "assertions": [
+    {
+      "type": "all_jobs_completed"
+    },
+    {
+      "type": "job_failures",
+      "atMost": 0
+    },
+    {
+      "type": "job_eta_percentile",
+      "percentile": 95,
+      "leg": "pickup",
+      "lessThanSeconds": 900,
+      "label": "p95 response ETA under 15 minutes"
+    },
+    {
+      "type": "no_stranded_vehicles",
+      "idleSeconds": 300
+    },
+    {
+      "type": "fleet_avg_speed",
+      "atLeastKph": 5
+    }
+  ]
+}

--- a/apps/simulator/package.json
+++ b/apps/simulator/package.json
@@ -11,6 +11,8 @@
     "start": "NODE_ENV=production node ./dist/index.js",
     "start:gateway": "NODE_ENV=production node ./dist/ws-gateway.js",
     "build:worker": "node scripts/build-worker.mjs",
+    "prescenario": "npm run build:worker",
+    "scenario": "tsx src/headless/scenario-cli.ts",
     "build": "tsc && npm run build:worker",
     "type-check": "tsc --noEmit",
     "pretest": "npm run build:worker",

--- a/apps/simulator/src/__tests__/ScenarioManager.test.ts
+++ b/apps/simulator/src/__tests__/ScenarioManager.test.ts
@@ -773,4 +773,230 @@ describe("ScenarioManager", () => {
       expect(s2.elapsed).toBe(elapsed1); // should not advance while paused
     });
   });
+
+  // ─── Manual clock (headless seam) ────────────────────────────────
+
+  describe("manual clock", () => {
+    it("should require a loaded scenario and reject a double start", () => {
+      expect(() => manager.startManual()).toThrow("No scenario loaded");
+
+      manager.loadScenario(makeScenario());
+      manager.startManual();
+      expect(() => manager.startManual()).toThrow("already running");
+    });
+
+    it("should not execute anything until advance is called", async () => {
+      manager.loadScenario(
+        makeScenario({
+          duration: 30,
+          events: [makeEvent(1, { type: "clear_incidents" })],
+        })
+      );
+      manager.startManual();
+
+      // The wall clock moving must not matter in manual mode.
+      vi.advanceTimersByTime(60_000);
+      expect(mocks.incidentManager.clearAll).not.toHaveBeenCalled();
+
+      await manager.advance(1000);
+      expect(mocks.incidentManager.clearAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("should execute every event that came due in one step, in order", async () => {
+      const seen: number[] = [];
+      manager.on("scenario:event", (payload: { at: number }) => seen.push(payload.at));
+
+      manager.loadScenario(
+        makeScenario({
+          duration: 60,
+          events: [
+            makeEvent(1, { type: "clear_incidents" }),
+            makeEvent(2, { type: "clear_incidents" }),
+            makeEvent(9, { type: "clear_incidents" }),
+          ],
+        })
+      );
+      manager.startManual();
+
+      await manager.advance(5000);
+      expect(seen).toEqual([1, 2]);
+      expect(manager.getStatus().eventsExecuted).toBe(2);
+      expect(manager.getStatus().elapsed).toBe(5);
+
+      await manager.advance(5000);
+      expect(seen).toEqual([1, 2, 9]);
+    });
+
+    it("should await async actions before returning", async () => {
+      let resolveDispatch: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        resolveDispatch = resolve;
+      });
+      (mocks.simulationController.setDirections as ReturnType<typeof vi.fn>).mockImplementation(
+        async () => {
+          await gate;
+          return [];
+        }
+      );
+
+      manager.loadScenario(
+        makeScenario({
+          duration: 60,
+          events: [
+            makeEvent(1, {
+              type: "dispatch",
+              vehicleId: "v1",
+              waypoints: [{ lat: 1, lng: 2 }],
+            }),
+          ],
+        })
+      );
+      manager.startManual();
+
+      let settled = false;
+      const advancing = manager.advance(2000).then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      resolveDispatch?.();
+      await advancing;
+      expect(settled).toBe(true);
+      expect(mocks.simulationController.setDirections).toHaveBeenCalledTimes(1);
+    });
+
+    it("should complete once the last event ran and the duration elapsed", async () => {
+      const completed = vi.fn();
+      manager.on("scenario:completed", completed);
+
+      manager.loadScenario(
+        makeScenario({
+          duration: 10,
+          events: [makeEvent(1, { type: "clear_incidents" })],
+        })
+      );
+      manager.startManual();
+
+      await manager.advance(5000);
+      expect(completed).not.toHaveBeenCalled();
+
+      await manager.advance(5000);
+      expect(completed).toHaveBeenCalledTimes(1);
+      expect(completed.mock.calls[0][0]).toMatchObject({ elapsed: 10 });
+      expect(manager.getStatus().state).toBe("idle");
+    });
+
+    it("should report a throwing action instead of abandoning the timeline", async () => {
+      const errors: Array<{ at: number; action: string; error: string }> = [];
+      manager.on("scenario:event-error", (payload) => errors.push(payload));
+      (mocks.simulationController.setDirections as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("no route")
+      );
+
+      manager.loadScenario(
+        makeScenario({
+          duration: 60,
+          events: [
+            makeEvent(1, {
+              type: "dispatch",
+              vehicleId: "v1",
+              waypoints: [{ lat: 1, lng: 2 }],
+            }),
+            makeEvent(2, { type: "clear_incidents" }),
+          ],
+        })
+      );
+      manager.startManual();
+
+      await manager.advance(3000);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({ at: 1, action: "dispatch", error: "no route" });
+      // The later event still ran.
+      expect(mocks.incidentManager.clearAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("should stop advancing while paused and pick up where it left off", async () => {
+      manager.loadScenario(
+        makeScenario({
+          duration: 60,
+          events: [makeEvent(5, { type: "clear_incidents" })],
+        })
+      );
+      manager.startManual();
+
+      await manager.advance(1000);
+      manager.pause();
+      await manager.advance(10_000);
+      expect(mocks.incidentManager.clearAll).not.toHaveBeenCalled();
+
+      manager.resume();
+      await manager.advance(4000);
+      expect(mocks.incidentManager.clearAll).toHaveBeenCalledTimes(1);
+    });
+
+    it("should ignore advance in wall-clock mode and after stop", async () => {
+      manager.loadScenario(
+        makeScenario({
+          duration: 60,
+          events: [makeEvent(1, { type: "clear_incidents" })],
+        })
+      );
+      manager.start(); // wall clock
+      await manager.advance(5000);
+      expect(mocks.incidentManager.clearAll).not.toHaveBeenCalled();
+
+      manager.stop();
+      manager.startManual();
+      manager.stop();
+      await manager.advance(5000);
+      expect(mocks.incidentManager.clearAll).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── create_job ──────────────────────────────────────────────────
+
+  describe("create_job action", () => {
+    const jobEvent = () =>
+      makeEvent(1, {
+        type: "create_job" as const,
+        pickup: { lat: -1.29, lng: 36.82 },
+        dropoff: { lat: -1.3, lng: 36.85 },
+        strategy: "nearest" as const,
+      });
+
+    it("should create the job through the JobManager", async () => {
+      const jobManager = { createJob: vi.fn().mockResolvedValue({ id: "job-1" }) };
+      const withJobs = new ScenarioManager(
+        mocks.vehicleManager,
+        mocks.incidentManager,
+        mocks.simulationController,
+        jobManager as unknown as ConstructorParameters<typeof ScenarioManager>[3]
+      );
+
+      withJobs.loadScenario(makeScenario({ duration: 10, events: [jobEvent()] }));
+      withJobs.startManual();
+      await withJobs.advance(2000);
+
+      expect(jobManager.createJob).toHaveBeenCalledWith({
+        pickup: { lat: -1.29, lng: 36.82 },
+        dropoff: { lat: -1.3, lng: 36.85 },
+        strategy: "nearest",
+        vehicleId: undefined,
+        slaSeconds: undefined,
+      });
+    });
+
+    it("should report a create_job event when no JobManager is wired", async () => {
+      const errors: Array<{ error: string }> = [];
+      manager.on("scenario:event-error", (payload) => errors.push(payload));
+
+      manager.loadScenario(makeScenario({ duration: 10, events: [jobEvent()] }));
+      manager.startManual();
+      await manager.advance(2000);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain("no JobManager");
+    });
+  });
 });

--- a/apps/simulator/src/__tests__/ScenarioRunner.test.ts
+++ b/apps/simulator/src/__tests__/ScenarioRunner.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import path from "path";
+import { ScenarioRunner } from "../headless/ScenarioRunner";
+import { scenarioSchema } from "../modules/scenario/types";
+import type { Scenario } from "../modules/scenario/types";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "integration-network.geojson");
+
+/** A pickup/dropoff pair on opposite corners of the fixture grid. */
+const PICKUP = { lat: 45.5, lng: -73.57 };
+const DROPOFF = { lat: 45.504, lng: -73.564 };
+
+/** Raw scenario input, parsed through the schema so defaults are applied. */
+function makeScenario(overrides: Record<string, unknown> = {}): Scenario {
+  return scenarioSchema.parse({
+    name: "runner-test",
+    duration: 300,
+    events: [],
+    ...overrides,
+  });
+}
+
+const jobEvent = (at: number) => ({
+  at,
+  action: {
+    type: "create_job",
+    pickup: PICKUP,
+    dropoff: DROPOFF,
+    strategy: "nearest",
+  },
+});
+
+/**
+ * Each call builds a road network and a pathfinding-worker pool, so these tests
+ * stay deliberately few and short — they are the expensive kind.
+ */
+function run(
+  scenario: Scenario,
+  opts: { vehicles?: number; seed?: number; maxSimSeconds?: number } = {}
+) {
+  return new ScenarioRunner({
+    scenario,
+    geojsonPath: FIXTURE_PATH,
+    vehicles: opts.vehicles ?? 2,
+    stepMs: 1000,
+    seed: opts.seed ?? 42,
+    maxSimSeconds: opts.maxSimSeconds,
+  }).run();
+}
+
+describe("ScenarioRunner", () => {
+  it("runs a scenario's jobs to completion and passes its assertions", async () => {
+    const report = await run(
+      makeScenario({
+        events: [jobEvent(5)],
+        assertions: [
+          { type: "all_jobs_completed" },
+          { type: "job_failures", atMost: 0 },
+          { type: "job_eta_percentile", lessThanSeconds: 900 },
+          { type: "no_stranded_vehicles", idleSeconds: 120 },
+          { type: "fleet_avg_speed", atLeastKph: 1 },
+        ],
+      })
+    );
+
+    expect(report.passed).toBe(true);
+    expect(report.assertions.every((a) => a.passed)).toBe(true);
+    expect(report.eventErrors).toEqual([]);
+    expect(report.completed).toBe(true);
+    expect(report.eventsExecuted).toBe(1);
+    expect(report.metrics.jobs).toMatchObject({ total: 1, complete: 1, failed: 0, unfinished: 0 });
+    expect(report.metrics.jobs.etaToPickupSeconds).toHaveLength(1);
+    expect(report.metrics.vehicles.count).toBe(2);
+    expect(report.metrics.vehicles.totalDistanceKm).toBeGreaterThan(0);
+    expect(report.simSeconds).toBe(300);
+    expect(report.steps).toBe(300);
+  });
+
+  it("fails the run when an assertion does not hold", async () => {
+    const report = await run(
+      makeScenario({
+        duration: 30,
+        assertions: [
+          // No fleet on this network averages 500 km/h.
+          { type: "fleet_avg_speed", atLeastKph: 500 },
+          { type: "no_stranded_vehicles", idleSeconds: 120 },
+        ],
+      })
+    );
+
+    expect(report.passed).toBe(false);
+    expect(report.assertions.map((a) => a.passed)).toEqual([false, true]);
+    expect(report.assertions[0].actual).toContain("km/h");
+  });
+
+  it("is deterministic for a fixed seed", async () => {
+    const scenario = makeScenario({
+      duration: 60,
+      events: [jobEvent(5)],
+      assertions: [{ type: "all_jobs_completed" }],
+    });
+
+    const a = await run(scenario, { seed: 7 });
+    const b = await run(scenario, { seed: 7 });
+
+    expect(b.metrics.vehicles.avgSpeedKph).toBe(a.metrics.vehicles.avgSpeedKph);
+    expect(b.metrics.vehicles.totalDistanceKm).toBe(a.metrics.vehicles.totalDistanceKm);
+    expect(b.metrics.jobs.etaToPickupSeconds).toEqual(a.metrics.jobs.etaToPickupSeconds);
+    expect(b.metrics.vehicles.maxIdleSecondsById).toEqual(a.metrics.vehicles.maxIdleSecondsById);
+    expect(b.assertions).toEqual(a.assertions);
+  });
+
+  it("caps the run at maxSimSeconds, grading nothing when a scenario has no assertions", async () => {
+    const report = await run(
+      makeScenario({ duration: 600, events: [jobEvent(5), jobEvent(500)] }),
+      {
+        maxSimSeconds: 30,
+      }
+    );
+
+    expect(report.steps).toBe(30);
+    expect(report.simSeconds).toBe(30);
+    // The 500s event never came due, so the timeline never finished.
+    expect(report.eventsExecuted).toBe(1);
+    expect(report.completed).toBe(false);
+    // Nothing to grade is not a failure.
+    expect(report.assertions).toEqual([]);
+    expect(report.scenario.assertionCount).toBe(0);
+    expect(report.passed).toBe(true);
+  });
+
+  it("records the failure reason when a job cannot be assigned", async () => {
+    const report = await run(
+      makeScenario({
+        duration: 10,
+        events: [
+          {
+            at: 1,
+            action: {
+              type: "create_job",
+              pickup: PICKUP,
+              dropoff: DROPOFF,
+              strategy: "manual",
+              vehicleId: "not-in-this-fleet",
+            },
+          },
+        ],
+        assertions: [{ type: "all_jobs_completed" }],
+      })
+    );
+
+    expect(report.passed).toBe(false);
+    expect(report.metrics.jobs.failed).toBe(1);
+    expect(report.metrics.jobs.errors.length).toBeGreaterThan(0);
+    expect(report.assertions[0].detail).toContain(report.metrics.jobs.errors[0]);
+  });
+
+  it("rejects a run that covers no steps", async () => {
+    await expect(
+      new ScenarioRunner({
+        scenario: makeScenario({ duration: 300 }),
+        geojsonPath: FIXTURE_PATH,
+        stepMs: 0,
+      }).run()
+    ).rejects.toThrow("stepMs must be > 0");
+
+    await expect(
+      new ScenarioRunner({
+        scenario: makeScenario({ duration: 300 }),
+        geojsonPath: FIXTURE_PATH,
+        stepMs: 1000,
+        maxSimSeconds: 0.5,
+      }).run()
+    ).rejects.toThrow("covers no steps");
+  });
+});

--- a/apps/simulator/src/__tests__/routes/scenarios.test.ts
+++ b/apps/simulator/src/__tests__/routes/scenarios.test.ts
@@ -5,13 +5,14 @@ import { createScenarioRoutes } from "../../routes/scenarios";
 import type { RouteContext } from "../../routes/types";
 
 // Mock logger to suppress output
-vi.mock("../../utils/logger", () => ({
-  default: {
+vi.mock("../../utils/logger", () => {
+  const stub = {
     error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
-  },
-}));
+  };
+  return { default: stub, createLogger: () => stub };
+});
 
 // Mock fs for scenario file listing and reading
 vi.mock("fs", async (importOriginal) => {

--- a/apps/simulator/src/__tests__/scenarioAssertions.test.ts
+++ b/apps/simulator/src/__tests__/scenarioAssertions.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+import { evaluateAssertions, percentile } from "../modules/scenario/assertions";
+import type { ScenarioMetrics } from "../modules/scenario/assertions";
+import { scenarioAssertionSchema } from "../modules/scenario/types";
+import type { ScenarioAssertion } from "../modules/scenario/types";
+
+function makeMetrics(overrides: Partial<ScenarioMetrics> = {}): ScenarioMetrics {
+  return {
+    simSeconds: 600,
+    jobs: {
+      total: 0,
+      complete: 0,
+      failed: 0,
+      cancelled: 0,
+      unfinished: 0,
+      slaBreached: 0,
+      etaToPickupSeconds: [],
+      etaToDropoffSeconds: [],
+      errors: [],
+      ...overrides.jobs,
+    },
+    vehicles: {
+      count: 0,
+      avgSpeedKph: 0,
+      totalDistanceKm: 0,
+      maxIdleSecondsById: {},
+      ...overrides.vehicles,
+    },
+    ...(overrides.simSeconds !== undefined ? { simSeconds: overrides.simSeconds } : {}),
+  };
+}
+
+/** Parses through the schema so defaults (percentile, leg, atMost) are applied. */
+function assertion(input: unknown): ScenarioAssertion {
+  return scenarioAssertionSchema.parse(input);
+}
+
+function evaluateOne(input: unknown, metrics: ScenarioMetrics) {
+  return evaluateAssertions([assertion(input)], metrics)[0];
+}
+
+describe("percentile", () => {
+  it("returns null for an empty sample", () => {
+    expect(percentile([], 95)).toBeNull();
+  });
+
+  it("uses nearest rank and does not mutate the input", () => {
+    const values = [50, 10, 40, 20, 30];
+    expect(percentile(values, 100)).toBe(50);
+    expect(percentile(values, 95)).toBe(50);
+    expect(percentile(values, 60)).toBe(30);
+    expect(percentile(values, 1)).toBe(10);
+    expect(values).toEqual([50, 10, 40, 20, 30]);
+  });
+
+  it("handles a single-value sample at any percentile", () => {
+    expect(percentile([7], 50)).toBe(7);
+    expect(percentile([7], 99)).toBe(7);
+  });
+});
+
+describe("evaluateAssertions", () => {
+  it("returns nothing for an empty assertion list", () => {
+    expect(evaluateAssertions([], makeMetrics())).toEqual([]);
+  });
+
+  describe("all_jobs_completed", () => {
+    it("passes when every job completed", () => {
+      const result = evaluateOne(
+        { type: "all_jobs_completed" },
+        makeMetrics({ jobs: { total: 3, complete: 3 } as ScenarioMetrics["jobs"] })
+      );
+      expect(result.passed).toBe(true);
+      expect(result.actual).toBe("3/3 jobs complete");
+    });
+
+    it("fails and names the shortfall", () => {
+      const result = evaluateOne(
+        { type: "all_jobs_completed", label: "delivered" },
+        makeMetrics({
+          jobs: {
+            total: 4,
+            complete: 1,
+            failed: 2,
+            cancelled: 0,
+            unfinished: 1,
+          } as ScenarioMetrics["jobs"],
+        })
+      );
+      expect(result.passed).toBe(false);
+      expect(result.label).toBe("delivered");
+      expect(result.detail).toContain("1 unfinished");
+      expect(result.detail).toContain("2 failed");
+    });
+  });
+
+  describe("job_completion_rate", () => {
+    it("passes at exactly the threshold", () => {
+      const result = evaluateOne(
+        { type: "job_completion_rate", atLeast: 0.5 },
+        makeMetrics({ jobs: { total: 4, complete: 2 } as ScenarioMetrics["jobs"] })
+      );
+      expect(result.passed).toBe(true);
+      expect(result.actual).toContain("0.5");
+    });
+
+    it("fails below the threshold", () => {
+      const result = evaluateOne(
+        { type: "job_completion_rate", atLeast: 0.9 },
+        makeMetrics({ jobs: { total: 4, complete: 2 } as ScenarioMetrics["jobs"] })
+      );
+      expect(result.passed).toBe(false);
+    });
+
+    it("treats a run with no jobs as a pass", () => {
+      const result = evaluateOne({ type: "job_completion_rate", atLeast: 1 }, makeMetrics());
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe("job_failures", () => {
+    it("defaults to allowing none", () => {
+      const parsed = assertion({ type: "job_failures" });
+      expect(parsed).toMatchObject({ atMost: 0 });
+
+      const result = evaluateAssertions(
+        [parsed],
+        makeMetrics({ jobs: { total: 1, failed: 1 } as ScenarioMetrics["jobs"] })
+      )[0];
+      expect(result.passed).toBe(false);
+      expect(result.actual).toBe("1 failed");
+    });
+
+    it("passes at the allowance", () => {
+      const result = evaluateOne(
+        { type: "job_failures", atMost: 2 },
+        makeMetrics({ jobs: { total: 5, failed: 2 } as ScenarioMetrics["jobs"] })
+      );
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe("job_eta_percentile", () => {
+    it("defaults to p95 on the pickup leg", () => {
+      expect(assertion({ type: "job_eta_percentile", lessThanSeconds: 100 })).toMatchObject({
+        percentile: 95,
+        leg: "pickup",
+      });
+    });
+
+    it("passes when the percentile is under the threshold", () => {
+      const result = evaluateOne(
+        { type: "job_eta_percentile", percentile: 95, leg: "pickup", lessThanSeconds: 300 },
+        makeMetrics({
+          jobs: { total: 3, etaToPickupSeconds: [100, 150, 299] } as ScenarioMetrics["jobs"],
+        })
+      );
+      expect(result.passed).toBe(true);
+      expect(result.actual).toContain("n=3");
+    });
+
+    it("fails when the percentile reaches the threshold", () => {
+      const result = evaluateOne(
+        { type: "job_eta_percentile", percentile: 95, leg: "pickup", lessThanSeconds: 300 },
+        makeMetrics({
+          jobs: { total: 2, etaToPickupSeconds: [100, 300] } as ScenarioMetrics["jobs"],
+        })
+      );
+      expect(result.passed).toBe(false);
+    });
+
+    it("reads the dropoff leg when asked", () => {
+      const result = evaluateOne(
+        { type: "job_eta_percentile", percentile: 50, leg: "dropoff", lessThanSeconds: 900 },
+        makeMetrics({
+          jobs: {
+            total: 2,
+            etaToPickupSeconds: [10_000],
+            etaToDropoffSeconds: [400, 500],
+          } as ScenarioMetrics["jobs"],
+        })
+      );
+      expect(result.passed).toBe(true);
+      expect(result.actual).toContain("400s");
+    });
+
+    it("fails when there is nothing to measure", () => {
+      const result = evaluateOne(
+        { type: "job_eta_percentile", lessThanSeconds: 900 },
+        makeMetrics()
+      );
+      expect(result.passed).toBe(false);
+      expect(result.actual).toBe("no assigned jobs to measure");
+    });
+  });
+
+  describe("no_stranded_vehicles", () => {
+    it("defaults the idle allowance to 120s", () => {
+      expect(assertion({ type: "no_stranded_vehicles" })).toMatchObject({ idleSeconds: 120 });
+    });
+
+    it("passes when every vehicle stayed inside the allowance", () => {
+      const result = evaluateOne(
+        { type: "no_stranded_vehicles", idleSeconds: 60 },
+        makeMetrics({
+          vehicles: {
+            count: 2,
+            avgSpeedKph: 30,
+            totalDistanceKm: 5,
+            maxIdleSecondsById: { a: 60, b: 12 },
+          },
+        })
+      );
+      expect(result.passed).toBe(true);
+      expect(result.actual).toContain("worst idle 60s");
+    });
+
+    it("fails and lists the worst offenders first", () => {
+      const result = evaluateOne(
+        { type: "no_stranded_vehicles", idleSeconds: 30 },
+        makeMetrics({
+          vehicles: {
+            count: 3,
+            avgSpeedKph: 1,
+            totalDistanceKm: 0.1,
+            maxIdleSecondsById: { a: 40, b: 10, c: 400 },
+          },
+        })
+      );
+      expect(result.passed).toBe(false);
+      expect(result.detail?.startsWith("c idle 400s")).toBe(true);
+      expect(result.detail).toContain("a idle 40s");
+      expect(result.detail).not.toContain("b idle");
+    });
+  });
+
+  describe("fleet_avg_speed", () => {
+    it("passes above the floor with no ceiling", () => {
+      const result = evaluateOne(
+        { type: "fleet_avg_speed", atLeastKph: 10 },
+        makeMetrics({
+          vehicles: {
+            count: 2,
+            avgSpeedKph: 22.5,
+            totalDistanceKm: 3,
+            maxIdleSecondsById: {},
+          },
+        })
+      );
+      expect(result.passed).toBe(true);
+      expect(result.expected).toBe(">= 10 km/h");
+      expect(result.actual).toBe("22.5 km/h (2 vehicles)");
+    });
+
+    it("fails below the floor", () => {
+      const result = evaluateOne(
+        { type: "fleet_avg_speed", atLeastKph: 10 },
+        makeMetrics({
+          vehicles: { count: 1, avgSpeedKph: 2, totalDistanceKm: 0, maxIdleSecondsById: {} },
+        })
+      );
+      expect(result.passed).toBe(false);
+    });
+
+    it("enforces a ceiling when one is given", () => {
+      const metrics = makeMetrics({
+        vehicles: { count: 1, avgSpeedKph: 95, totalDistanceKm: 9, maxIdleSecondsById: {} },
+      });
+      const result = evaluateOne(
+        { type: "fleet_avg_speed", atLeastKph: 5, atMostKph: 80 },
+        metrics
+      );
+      expect(result.passed).toBe(false);
+      expect(result.expected).toBe("5..80 km/h");
+    });
+  });
+
+  it("grades a mixed list independently", () => {
+    const metrics = makeMetrics({
+      jobs: {
+        total: 2,
+        complete: 1,
+        failed: 1,
+        cancelled: 0,
+        unfinished: 0,
+        slaBreached: 0,
+        etaToPickupSeconds: [120, 200],
+        etaToDropoffSeconds: [400, 500],
+        errors: [],
+      },
+      vehicles: {
+        count: 1,
+        avgSpeedKph: 25,
+        totalDistanceKm: 4,
+        maxIdleSecondsById: { a: 5 },
+      },
+    });
+
+    const results = evaluateAssertions(
+      [
+        assertion({ type: "all_jobs_completed" }),
+        assertion({ type: "job_eta_percentile", lessThanSeconds: 300 }),
+        assertion({ type: "no_stranded_vehicles", idleSeconds: 60 }),
+      ],
+      metrics
+    );
+
+    expect(results.map((r) => r.passed)).toEqual([false, true, true]);
+    expect(results.map((r) => r.type)).toEqual([
+      "all_jobs_completed",
+      "job_eta_percentile",
+      "no_stranded_vehicles",
+    ]);
+  });
+});

--- a/apps/simulator/src/__tests__/scenarioCli.test.ts
+++ b/apps/simulator/src/__tests__/scenarioCli.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  EXIT_ASSERTION_FAILURE,
+  EXIT_PASS,
+  EXIT_USAGE,
+  main,
+  parseArgs,
+  resolveScenarioPath,
+} from "../headless/scenario-cli";
+import type { ScenarioRunReport } from "../headless/ScenarioRunner";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "integration-network.geojson");
+
+const tmpFiles: string[] = [];
+
+function tmpFile(contents: string, extension = ".json"): string {
+  const file = path.join(os.tmpdir(), `scenario-cli-${process.pid}-${tmpFiles.length}${extension}`);
+  fs.writeFileSync(file, contents);
+  tmpFiles.push(file);
+  return file;
+}
+
+function tmpPath(extension = ".json"): string {
+  const file = path.join(
+    os.tmpdir(),
+    `scenario-cli-out-${process.pid}-${tmpFiles.length}${extension}`
+  );
+  tmpFiles.push(file);
+  return file;
+}
+
+/** Collects the CLI's output so a test can assert on what an operator sees. */
+function capture() {
+  const lines: string[] = [];
+  return { lines, out: (line: string) => lines.push(line) };
+}
+
+const scenarioJson = (assertions: unknown[], duration = 10) =>
+  JSON.stringify({
+    name: "cli-test",
+    duration,
+    events: [],
+    assertions,
+  });
+
+afterEach(() => {
+  for (const file of tmpFiles.splice(0)) {
+    try {
+      fs.rmSync(file);
+    } catch {
+      // never created / already gone
+    }
+  }
+});
+
+describe("parseArgs", () => {
+  it("parses every option", () => {
+    const opts = parseArgs([
+      "my-scenario.json",
+      "--vehicles",
+      "12",
+      "--step-ms",
+      "500",
+      "--seed",
+      "9",
+      "--max-seconds",
+      "60",
+      "--network",
+      "net.geojson",
+      "--report",
+      "report.json",
+      "--json",
+    ]);
+
+    expect(opts).toEqual({
+      file: "my-scenario.json",
+      vehicles: 12,
+      stepMs: 500,
+      seed: 9,
+      maxSeconds: 60,
+      network: "net.geojson",
+      report: "report.json",
+      json: true,
+    });
+  });
+
+  it("defaults json off and leaves unset options undefined", () => {
+    expect(parseArgs(["scenario.json"])).toEqual({ file: "scenario.json", json: false });
+  });
+
+  it("rejects unusable invocations", () => {
+    expect(() => parseArgs([])).toThrow("Usage");
+    expect(() => parseArgs(["--help"])).toThrow("Usage");
+    expect(() => parseArgs(["a.json", "b.json"])).toThrow("Expected one scenario file");
+    expect(() => parseArgs(["a.json", "--nope"])).toThrow("Unknown option: --nope");
+    expect(() => parseArgs(["a.json", "--seed", "abc"])).toThrow("--seed requires a number");
+    expect(() => parseArgs(["a.json", "--seed"])).toThrow("--seed requires a number");
+    expect(() => parseArgs(["a.json", "--network"])).toThrow("--network requires a value");
+  });
+});
+
+describe("resolveScenarioPath", () => {
+  it("resolves an explicit path", () => {
+    const file = tmpFile(scenarioJson([]));
+    expect(resolveScenarioPath(file)).toBe(path.resolve(file));
+  });
+
+  it("resolves a bare name against data/scenarios, with or without the extension", () => {
+    // Shipped with the repo; both spellings must land on the same file.
+    expect(resolveScenarioPath("dispatch-regression")).toBe(
+      resolveScenarioPath("dispatch-regression.json")
+    );
+  });
+
+  it("throws when nothing matches", () => {
+    expect(() => resolveScenarioPath("no-such-scenario")).toThrow("Scenario not found");
+  });
+});
+
+describe("scenario CLI", () => {
+  it("exits 0 and prints a summary when the assertions hold", async () => {
+    const file = tmpFile(scenarioJson([{ type: "no_stranded_vehicles", idleSeconds: 120 }]));
+    const { lines, out } = capture();
+
+    const code = await main([file, "--network", FIXTURE_PATH, "--vehicles", "1"], out);
+
+    expect(code).toBe(EXIT_PASS);
+    const text = lines.join("\n");
+    expect(text).toContain("Scenario: cli-test");
+    expect(text).toContain("PASS no vehicle idle for more than 120s");
+    expect(text).toContain("PASSED (1 assertions)");
+  });
+
+  it("exits 1 and reports the failing assertion", async () => {
+    const file = tmpFile(scenarioJson([{ type: "fleet_avg_speed", atLeastKph: 500 }]));
+    const { lines, out } = capture();
+
+    const code = await main([file, "--network", FIXTURE_PATH, "--vehicles", "1"], out);
+
+    expect(code).toBe(EXIT_ASSERTION_FAILURE);
+    const text = lines.join("\n");
+    expect(text).toContain("FAIL fleet average speed >= 500 km/h");
+    expect(text).toContain("FAILED (1/1 assertions");
+  });
+
+  it("writes the JSON report to a file and to stdout when asked", async () => {
+    const file = tmpFile(scenarioJson([]));
+    const reportPath = tmpPath();
+    const { lines, out } = capture();
+
+    const code = await main(
+      [file, "--network", FIXTURE_PATH, "--vehicles", "1", "--json", "--report", reportPath],
+      out
+    );
+
+    expect(code).toBe(EXIT_PASS);
+    const onDisk = JSON.parse(fs.readFileSync(reportPath, "utf-8")) as ScenarioRunReport;
+    expect(onDisk.scenario.name).toBe("cli-test");
+    expect(onDisk.passed).toBe(true);
+    // --json means the printed output IS the report.
+    expect(JSON.parse(lines.join("\n")).scenario.name).toBe("cli-test");
+  });
+
+  it("says so when a scenario has no assertions", async () => {
+    const file = tmpFile(scenarioJson([]));
+    const { lines, out } = capture();
+
+    await main([file, "--network", FIXTURE_PATH, "--vehicles", "1"], out);
+    expect(lines.join("\n")).toContain("No assertions in this scenario");
+  });
+
+  it("exits 2 on a bad invocation, a missing scenario, an invalid one, or a missing network", async () => {
+    const { lines, out } = capture();
+
+    expect(await main([], out)).toBe(EXIT_USAGE);
+    expect(lines.join("\n")).toContain("Usage");
+
+    expect(await main(["definitely-not-a-scenario"], out)).toBe(EXIT_USAGE);
+
+    const notJson = tmpFile("{ not json");
+    expect(await main([notJson], out)).toBe(EXIT_USAGE);
+
+    const wrongShape = tmpFile(JSON.stringify({ name: "no-duration", events: [] }));
+    expect(await main([wrongShape], out)).toBe(EXIT_USAGE);
+
+    const valid = tmpFile(scenarioJson([]));
+    expect(await main([valid, "--network", "/nope/network.geojson"], out)).toBe(EXIT_USAGE);
+    expect(lines.join("\n")).toContain("Road network not found");
+  });
+
+  it("exits 2 when the run itself cannot start", async () => {
+    const file = tmpFile(scenarioJson([]));
+    const { lines, out } = capture();
+
+    const code = await main([file, "--network", FIXTURE_PATH, "--step-ms", "0"], out);
+
+    expect(code).toBe(EXIT_USAGE);
+    expect(lines.join("\n")).toContain("Scenario run failed");
+  });
+});

--- a/apps/simulator/src/headless/HeadlessRunner.ts
+++ b/apps/simulator/src/headless/HeadlessRunner.ts
@@ -5,7 +5,7 @@ import { IncidentManager } from "../modules/IncidentManager";
 import { RecordingManager } from "../modules/RecordingManager";
 import { config } from "../utils/config";
 import { createLogger } from "../utils/logger";
-import { mulberry32, setAmbientRng } from "../utils/rng";
+import { installSeededRandom } from "./seededRandom";
 import type { RecordingMetadata, VehicleSnapshot } from "../types";
 
 const log = createLogger("headless");
@@ -128,6 +128,11 @@ export class HeadlessRunner {
 
       const clock = vehicleManager.clock;
       clock.setTime(simStart);
+      // Waypoint dwell must be measured in SIMULATED time here: a fast-forward
+      // finishes hours of sim time in seconds of wall time, so a wall-clock
+      // dwell would freeze every vehicle at its first stop for the rest of the
+      // generation — and for a duration that depends on machine speed.
+      vehicleManager.routeManager.setTimeSource(() => clock.now());
 
       // Load the real fleet from the configured source (ids + metadata.devices),
       // assigning each a route so it moves — same path as the live sim. The
@@ -191,22 +196,3 @@ export class HeadlessRunner {
 
 /** Re-exported for clarity; the snapshot shape written per `vehicle` event. */
 export type { VehicleSnapshot };
-
-/**
- * Installs a seeded mulberry32 stream for the duration of a run and returns a
- * restore function. A SINGLE stream backs both:
- *  - the injectable ambient Rng (`src/utils/rng.ts`), which the threaded
- *    placement/routing seams draw from, and
- *  - the global `Math.random` (legacy fallback for any spot not yet threaded),
- * so a given `seed` reproduces the same generated recording byte-for-byte.
- */
-function installSeededRandom(seed: number): () => void {
-  const stream = mulberry32(seed);
-  const restoreAmbient = setAmbientRng(stream);
-  const original = Math.random;
-  Math.random = () => stream.next();
-  return () => {
-    Math.random = original;
-    restoreAmbient();
-  };
-}

--- a/apps/simulator/src/headless/ScenarioRunner.ts
+++ b/apps/simulator/src/headless/ScenarioRunner.ts
@@ -1,0 +1,373 @@
+import { RoadNetwork } from "../modules/RoadNetwork";
+import { VehicleManager } from "../modules/VehicleManager";
+import { FleetManager } from "../modules/FleetManager";
+import { IncidentManager } from "../modules/IncidentManager";
+import { JobManager } from "../modules/JobManager";
+import { SimulationController } from "../modules/SimulationController";
+import { ScenarioManager } from "../modules/scenario/ScenarioManager";
+import { evaluateAssertions } from "../modules/scenario/assertions";
+import type { AssertionResult, ScenarioMetrics } from "../modules/scenario/assertions";
+import type { Scenario } from "../modules/scenario/types";
+import { config } from "../utils/config";
+import { createLogger } from "../utils/logger";
+import { installSeededRandom } from "./seededRandom";
+import { TERMINAL_JOB_STATUSES } from "@moveet/shared-types";
+
+const log = createLogger("scenario-runner");
+
+/** Steps processed between event-loop yields (lets worker replies land). */
+const DEFAULT_CHUNK_STEPS = 50;
+
+/** Simulated milliseconds advanced per step when the caller doesn't say. */
+const DEFAULT_STEP_MS = 1000;
+
+/** Simulated seconds between `JobManager.sweep()` calls. */
+const DEFAULT_JOB_SWEEP_SECONDS = 1;
+
+/** Wall-clock budget per step for in-flight pathfinding to settle. */
+const DEFAULT_DRAIN_MS = 2000;
+
+/**
+ * Waits for the pathfinding a step kicked off to land, so every route is applied
+ * within the step that asked for it.
+ *
+ * Two passes, each `setImmediate` then drain, because a request is not
+ * registered with the pool synchronously: the movement code calls the async
+ * pathfinder without awaiting it, so the request appears a microtask later.
+ * Draining immediately would find an empty queue and return at once, letting the
+ * route land at whatever later step the worker happened to reply on — the exact
+ * wall-clock dependence a seeded run is supposed to be free of.
+ */
+async function settlePathfinding(roadNetwork: RoadNetwork, drainMs: number): Promise<void> {
+  for (let pass = 0; pass < 2; pass++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await roadNetwork.drainPathfinding(drainMs);
+  }
+}
+
+export interface ScenarioRunnerOptions {
+  /** The parsed, validated scenario to run. */
+  scenario: Scenario;
+  /** Path to the GeoJSON road network. */
+  geojsonPath: string;
+  /**
+   * Synthetic vehicles to seed before the timeline starts. A scenario that
+   * spawns its own fleet with `spawn_vehicles` can leave this at 0.
+   */
+  vehicles?: number;
+  /** Simulated milliseconds per step. Default 1000. */
+  stepMs?: number;
+  /** RNG seed — the whole point of the harness is that this reproduces. */
+  seed?: number;
+  /** Absolute start of the simulated window. Defaults to the clock's own start. */
+  simStart?: Date;
+  /**
+   * Hard cap on simulated seconds, overriding the scenario's own `duration`.
+   * Useful to smoke-test a long scenario in CI without editing the file.
+   */
+  maxSimSeconds?: number;
+  /** Steps between event-loop yields. */
+  chunkSteps?: number;
+  /** Simulated seconds between job sweeps (SLA + pending-queue retry). */
+  jobSweepSeconds?: number;
+  /**
+   * Milliseconds to wait for in-flight pathfinding to settle at each step
+   * boundary. This is what makes a run REPRODUCIBLE: A* runs on worker threads,
+   * so without a drain a route lands at whatever step the worker happened to
+   * reply on, and the same seed produces slightly different movement each run.
+   * `0` disables the drain — faster on a large fleet, but no longer deterministic.
+   */
+  drainPathfindingMs?: number;
+}
+
+/** An action that threw while the timeline ran. */
+export interface ScenarioEventError {
+  at: number;
+  action: string;
+  error: string;
+}
+
+/** The full result of a headless scenario run — the CI artifact. */
+export interface ScenarioRunReport {
+  scenario: {
+    name: string;
+    description?: string;
+    duration: number;
+    eventCount: number;
+    assertionCount: number;
+  };
+  seed: number;
+  stepMs: number;
+  steps: number;
+  /** Simulated seconds actually covered. */
+  simSeconds: number;
+  eventsExecuted: number;
+  /** True when the timeline ran to the authored duration. */
+  completed: boolean;
+  eventErrors: ScenarioEventError[];
+  metrics: ScenarioMetrics;
+  assertions: AssertionResult[];
+  /** Every assertion held AND no action threw. This is the exit code. */
+  passed: boolean;
+  /** Wall-clock milliseconds the run took (reporting only — never simulated). */
+  wallMs: number;
+}
+
+/**
+ * Runs a scenario headlessly and grades it against its own assertions.
+ *
+ * The regression harness. It builds the real module graph — road network,
+ * VehicleManager, IncidentManager, JobManager, ScenarioManager — and drives it
+ * on an explicit `stepMs` clock with NO `setInterval` and NO wall-clock timing,
+ * exactly like {@link HeadlessRunner} does for recording generation. The
+ * scenario's events fire on simulated time (`ScenarioManager.advance`), so a
+ * 10-minute scenario grades in a second of CI time and lands its events at the
+ * simulated seconds it authored, not wherever the fast-forward happened to be.
+ *
+ * The fleet is always synthetic and seeded: a harness whose verdict depends on
+ * whatever an external source returned today is not a regression test.
+ */
+export class ScenarioRunner {
+  /** Current and longest run of stationary simulated seconds, per vehicle id. */
+  private idleStreakSeconds = new Map<string, number>();
+  private maxIdleSeconds = new Map<string, number>();
+  /** Previous sampled true position, for the movement check in {@link sampleIdle}. */
+  private lastPositions = new Map<string, [number, number]>();
+
+  constructor(private readonly opts: ScenarioRunnerOptions) {}
+
+  async run(): Promise<ScenarioRunReport> {
+    const { scenario, geojsonPath } = this.opts;
+    const stepMs = this.opts.stepMs ?? DEFAULT_STEP_MS;
+    const seed = this.opts.seed ?? 1;
+    const chunkSteps = this.opts.chunkSteps ?? DEFAULT_CHUNK_STEPS;
+    const sweepSeconds = this.opts.jobSweepSeconds ?? DEFAULT_JOB_SWEEP_SECONDS;
+    const vehicles = this.opts.vehicles ?? 0;
+    const drainMs = this.opts.drainPathfindingMs ?? DEFAULT_DRAIN_MS;
+
+    if (stepMs <= 0) throw new Error("stepMs must be > 0");
+
+    const simSecondsTarget = this.opts.maxSimSeconds ?? scenario.duration;
+    const steps = Math.floor((simSecondsTarget * 1000) / stepMs);
+    if (steps <= 0) throw new Error("The run covers no steps; raise maxSimSeconds or lower stepMs");
+
+    const wallStart = Date.now();
+    const restoreRandom = installSeededRandom(seed);
+
+    // Synthetic, deterministic fleet: an empty adapterURL makes the
+    // VehicleManager constructor seed `vehicleCount` vehicles locally.
+    const prevVehicleCount = config.vehicleCount;
+    const prevAdapterURL = config.adapterURL;
+    const prevGeojsonPath = config.geojsonPath;
+    (config as { geojsonPath: string }).geojsonPath = geojsonPath;
+    (config as { vehicleCount: number }).vehicleCount = vehicles;
+    (config as { adapterURL: string }).adapterURL = "";
+
+    let jobManager: JobManager | undefined;
+    let roadNetwork: RoadNetwork | undefined;
+
+    try {
+      roadNetwork = new RoadNetwork(geojsonPath);
+      const fleetManager = new FleetManager();
+      const vehicleManager = new VehicleManager(roadNetwork, fleetManager);
+      const clock = vehicleManager.clock;
+      if (this.opts.simStart) clock.setTime(this.opts.simStart);
+      // Dwell on simulated time, or every vehicle parks at its first stop for
+      // the rest of the (wall-clock-instant) run. See RouteManager.setTimeSource.
+      vehicleManager.routeManager.setTimeSource(() => clock.now());
+
+      const incidentManager = new IncidentManager(clock);
+      const simulationController = new SimulationController(vehicleManager, incidentManager);
+      jobManager = new JobManager(vehicleManager);
+      const scenarioManager = new ScenarioManager(
+        vehicleManager,
+        incidentManager,
+        simulationController,
+        jobManager
+      );
+
+      const eventErrors: ScenarioEventError[] = [];
+      scenarioManager.on("scenario:event-error", (payload: ScenarioEventError) => {
+        eventErrors.push({ at: payload.at, action: payload.action, error: payload.error });
+      });
+      let completed = false;
+      scenarioManager.on("scenario:completed", () => {
+        completed = true;
+      });
+
+      // The synthetic fleet asks for its first routes inside the VehicleManager
+      // constructor. Settling them before the timeline starts means step 1 sees a
+      // routed fleet in every run, instead of a fleet whose routes may or may not
+      // have landed depending on how fast the workers spun up.
+      if (drainMs > 0) await settlePathfinding(roadNetwork, drainMs);
+
+      scenarioManager.loadScenario(scenario);
+      scenarioManager.startManual();
+
+      log.info(
+        `Running scenario "${scenario.name}": ${steps} steps @ ${stepMs}ms ` +
+          `(${simSecondsTarget}s simulated), ${scenario.events.length} events, ` +
+          `${scenario.assertions?.length ?? 0} assertions, seed ${seed}`
+      );
+
+      const sweepEveryMs = sweepSeconds * 1000;
+      let sinceSweepMs = 0;
+      let step = 0;
+
+      while (step < steps) {
+        const chunkEnd = Math.min(step + chunkSteps, steps);
+        for (; step < chunkEnd; step++) {
+          // Timeline first: an event scheduled at this simulated second takes
+          // effect before the vehicles move through it.
+          await scenarioManager.advance(stepMs);
+          vehicleManager.advance(stepMs);
+          if (drainMs > 0) await settlePathfinding(roadNetwork, drainMs);
+          this.sampleIdle(vehicleManager, stepMs);
+
+          sinceSweepMs += stepMs;
+          if (sinceSweepMs >= sweepEveryMs) {
+            sinceSweepMs = 0;
+            // The 1 Hz sweep the live JobManager runs on a timer: retries the
+            // pending queue so a job that found no routable vehicle at creation
+            // still gets assigned once one frees up.
+            await jobManager.sweep();
+          }
+        }
+        if (drainMs === 0) {
+          // With draining off nothing else yields, and pathfinding-worker
+          // replies only land between macrotasks.
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+      }
+
+      const simSeconds = (steps * stepMs) / 1000;
+      const metrics = this.collectMetrics(vehicleManager, jobManager, simSeconds);
+      const assertions = evaluateAssertions(scenario.assertions ?? [], metrics);
+      const passed = assertions.every((a) => a.passed) && eventErrors.length === 0;
+
+      return {
+        scenario: {
+          name: scenario.name,
+          description: scenario.description,
+          duration: scenario.duration,
+          eventCount: scenario.events.length,
+          assertionCount: scenario.assertions?.length ?? 0,
+        },
+        seed,
+        stepMs,
+        steps,
+        simSeconds,
+        eventsExecuted: scenarioManager.getStatus().eventsExecuted,
+        completed,
+        eventErrors,
+        metrics,
+        assertions,
+        passed,
+        wallMs: Date.now() - wallStart,
+      };
+    } finally {
+      // The sweep interval is unref'd, but leaving it running would keep
+      // assigning against a dead graph in a long-lived process (the tests).
+      jobManager?.dispose();
+      // Pathfinding workers are NOT unref'd: without this a CLI run would hang
+      // after printing its verdict, and a test run would leak a thread per case.
+      await roadNetwork?.shutdownWorkers();
+      (config as { vehicleCount: number }).vehicleCount = prevVehicleCount;
+      (config as { adapterURL: string }).adapterURL = prevAdapterURL;
+      (config as { geojsonPath: string }).geojsonPath = prevGeojsonPath;
+      restoreRandom();
+    }
+  }
+
+  /**
+   * Accumulates per-vehicle stationary streaks, in simulated seconds.
+   *
+   * Movement is judged by POSITION, not by the reported speed: a dwelling or
+   * blocked vehicle can still carry a non-zero speed (the speed model floors it
+   * at `minSpeed` while `dwellUntil` holds the vehicle in place), so a
+   * speed-based check would report a parked fleet as healthy. True positions are
+   * used, so an injected GPS fault cannot fake movement either.
+   *
+   * Sampled every step rather than read at the end, because "did anything get
+   * stuck" is a question about the whole run: a vehicle that was stranded for
+   * five minutes and then freed looks perfectly healthy in a final snapshot.
+   */
+  private sampleIdle(vehicleManager: VehicleManager, stepMs: number): void {
+    const stepSeconds = stepMs / 1000;
+    for (const vehicle of vehicleManager.getTrueVehicles()) {
+      const [lat, lng] = vehicle.position;
+      const previous = this.lastPositions.get(vehicle.id);
+      const moved = previous === undefined || previous[0] !== lat || previous[1] !== lng;
+      this.lastPositions.set(vehicle.id, [lat, lng]);
+
+      const streak = moved ? 0 : (this.idleStreakSeconds.get(vehicle.id) ?? 0) + stepSeconds;
+      this.idleStreakSeconds.set(vehicle.id, streak);
+      this.maxIdleSeconds.set(
+        vehicle.id,
+        Math.max(this.maxIdleSeconds.get(vehicle.id) ?? 0, streak)
+      );
+    }
+  }
+
+  private collectMetrics(
+    vehicleManager: VehicleManager,
+    jobManager: JobManager,
+    simSeconds: number
+  ): ScenarioMetrics {
+    const jobs = jobManager.getJobs();
+    const terminal = new Set<string>(TERMINAL_JOB_STATUSES);
+
+    const etaToPickupSeconds: number[] = [];
+    const etaToDropoffSeconds: number[] = [];
+    const errors = new Set<string>();
+    let complete = 0;
+    let failed = 0;
+    let cancelled = 0;
+    let unfinished = 0;
+    let slaBreached = 0;
+
+    for (const job of jobs) {
+      if (job.error) errors.add(job.error);
+      if (job.status === "complete") complete++;
+      else if (job.status === "failed") failed++;
+      else if (job.status === "cancelled") cancelled++;
+      if (!terminal.has(job.status)) unfinished++;
+      if (job.slaBreached) slaBreached++;
+      if (job.etaToPickupSeconds !== undefined) etaToPickupSeconds.push(job.etaToPickupSeconds);
+      if (job.etaToDropoffSeconds !== undefined) etaToDropoffSeconds.push(job.etaToDropoffSeconds);
+    }
+
+    const stats = vehicleManager.analytics.getAllStats();
+    const roster = vehicleManager.getTrueVehicles();
+    let speedSum = 0;
+    let distanceSum = 0;
+    for (const vehicle of roster) {
+      const vs = stats.get(vehicle.id);
+      // A vehicle with no stats never ticked; it counts as 0 km/h rather than
+      // being dropped, so a fleet that never moved cannot average away to a pass.
+      speedSum += vs?.avgSpeed ?? 0;
+      distanceSum += vs?.distanceTraveled ?? 0;
+    }
+
+    return {
+      simSeconds,
+      jobs: {
+        total: jobs.length,
+        complete,
+        failed,
+        cancelled,
+        unfinished,
+        slaBreached,
+        etaToPickupSeconds,
+        etaToDropoffSeconds,
+        errors: [...errors],
+      },
+      vehicles: {
+        count: roster.length,
+        avgSpeedKph: roster.length === 0 ? 0 : speedSum / roster.length,
+        totalDistanceKm: distanceSum,
+        maxIdleSecondsById: Object.fromEntries(this.maxIdleSeconds),
+      },
+    };
+  }
+}

--- a/apps/simulator/src/headless/scenario-cli.ts
+++ b/apps/simulator/src/headless/scenario-cli.ts
@@ -1,0 +1,235 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { scenarioSchema } from "../modules/scenario/types";
+import type { Scenario } from "../modules/scenario/types";
+import { config } from "../utils/config";
+import { ScenarioRunner } from "./ScenarioRunner";
+import type { ScenarioRunReport } from "./ScenarioRunner";
+
+/** Where a bare scenario name (`rush-hour`) is looked up. */
+const SCENARIOS_DIR = path.resolve("data/scenarios");
+
+/** Exit codes. 1 = the scenario ran and failed; 2 = it could not be run. */
+export const EXIT_PASS = 0;
+export const EXIT_ASSERTION_FAILURE = 1;
+export const EXIT_USAGE = 2;
+
+const USAGE = `Usage: npm run scenario -- <scenario.json|name> [options]
+
+Runs a scenario headlessly on simulated time and grades it against the
+assertions in the file. Exits ${EXIT_ASSERTION_FAILURE} when an assertion fails
+(or a scenario action threw), ${EXIT_USAGE} when the scenario could not be run.
+
+Options:
+  --vehicles <n>      Synthetic vehicles seeded before the timeline (default 0)
+  --step-ms <n>       Simulated ms per step (default 1000)
+  --seed <n>          RNG seed (default 1)
+  --max-seconds <n>   Cap simulated seconds, overriding the scenario duration
+  --network <path>    GeoJSON road network (default: the configured one)
+  --report <path>     Write the full JSON report to a file
+  --json              Print the JSON report to stdout instead of a summary
+  -h, --help          Show this help
+`;
+
+interface CliOptions {
+  file: string;
+  vehicles?: number;
+  stepMs?: number;
+  seed?: number;
+  maxSeconds?: number;
+  network?: string;
+  report?: string;
+  json: boolean;
+}
+
+/** Thrown for anything the user can fix by re-running with different input. */
+class UsageError extends Error {}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const positional: string[] = [];
+  const opts: Partial<CliOptions> = { json: false };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const numeric = (name: string): number => {
+      const raw = argv[++i];
+      const value = Number(raw);
+      if (raw === undefined || !Number.isFinite(value)) {
+        throw new UsageError(`${name} requires a number`);
+      }
+      return value;
+    };
+    const text = (name: string): string => {
+      const raw = argv[++i];
+      if (raw === undefined) throw new UsageError(`${name} requires a value`);
+      return raw;
+    };
+
+    switch (arg) {
+      case "--vehicles":
+        opts.vehicles = numeric(arg);
+        break;
+      case "--step-ms":
+        opts.stepMs = numeric(arg);
+        break;
+      case "--seed":
+        opts.seed = numeric(arg);
+        break;
+      case "--max-seconds":
+        opts.maxSeconds = numeric(arg);
+        break;
+      case "--network":
+        opts.network = text(arg);
+        break;
+      case "--report":
+        opts.report = text(arg);
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "-h":
+      case "--help":
+        throw new UsageError(USAGE);
+      default:
+        if (arg.startsWith("-")) throw new UsageError(`Unknown option: ${arg}`);
+        positional.push(arg);
+    }
+  }
+
+  if (positional.length === 0) throw new UsageError(USAGE);
+  if (positional.length > 1) {
+    throw new UsageError(`Expected one scenario file, got ${positional.length}`);
+  }
+
+  return { ...opts, file: positional[0], json: opts.json ?? false };
+}
+
+/**
+ * Resolves a scenario argument to a readable path: an explicit path as given,
+ * or a bare name looked up in `data/scenarios` (with or without `.json`).
+ */
+export function resolveScenarioPath(file: string): string {
+  const candidates = [
+    file,
+    path.join(SCENARIOS_DIR, file),
+    path.join(SCENARIOS_DIR, `${file}.json`),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return path.resolve(candidate);
+  }
+  throw new UsageError(`Scenario not found: ${file} (looked in ., ${SCENARIOS_DIR})`);
+}
+
+function formatSummary(report: ScenarioRunReport): string {
+  const lines: string[] = [];
+  const { scenario, metrics } = report;
+
+  lines.push(`Scenario: ${scenario.name}`);
+  lines.push(
+    `  ${report.simSeconds}s simulated in ${report.wallMs}ms wall, ` +
+      `${report.eventsExecuted}/${scenario.eventCount} events, seed ${report.seed}`
+  );
+  lines.push(
+    `  Vehicles: ${metrics.vehicles.count}, ` +
+      `avg ${metrics.vehicles.avgSpeedKph.toFixed(1)} km/h, ` +
+      `${metrics.vehicles.totalDistanceKm.toFixed(2)} km driven`
+  );
+  lines.push(
+    `  Jobs: ${metrics.jobs.total} created, ${metrics.jobs.complete} complete, ` +
+      `${metrics.jobs.failed} failed, ${metrics.jobs.cancelled} cancelled, ` +
+      `${metrics.jobs.unfinished} unfinished`
+  );
+
+  for (const error of report.eventErrors) {
+    lines.push(`  ERROR at ${error.at}s (${error.action}): ${error.error}`);
+  }
+
+  if (report.assertions.length === 0) {
+    lines.push("  No assertions in this scenario — nothing was graded.");
+  }
+  for (const assertion of report.assertions) {
+    lines.push(`  ${assertion.passed ? "PASS" : "FAIL"} ${assertion.label}`);
+    lines.push(`       expected ${assertion.expected}, got ${assertion.actual}`);
+    if (assertion.detail) lines.push(`       ${assertion.detail}`);
+  }
+
+  const failed = report.assertions.filter((a) => !a.passed).length;
+  lines.push(
+    report.passed
+      ? `PASSED (${report.assertions.length} assertions)`
+      : `FAILED (${failed}/${report.assertions.length} assertions, ${report.eventErrors.length} action errors)`
+  );
+  return lines.join("\n");
+}
+
+/**
+ * CLI body. Returns the process exit code instead of calling `process.exit`, so
+ * the whole thing is testable in-process.
+ */
+export async function main(
+  argv: string[],
+  out: (line: string) => void = console.log
+): Promise<number> {
+  let options: CliOptions;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    out(error instanceof Error ? error.message : String(error));
+    return EXIT_USAGE;
+  }
+
+  let scenario: Scenario;
+  try {
+    const scenarioPath = resolveScenarioPath(options.file);
+    scenario = scenarioSchema.parse(JSON.parse(fs.readFileSync(scenarioPath, "utf-8")));
+  } catch (error) {
+    out(`Could not load scenario: ${error instanceof Error ? error.message : String(error)}`);
+    return EXIT_USAGE;
+  }
+
+  const geojsonPath = options.network ?? config.geojsonPath;
+  if (!fs.existsSync(geojsonPath)) {
+    out(`Road network not found: ${geojsonPath}`);
+    return EXIT_USAGE;
+  }
+
+  let report: ScenarioRunReport;
+  try {
+    report = await new ScenarioRunner({
+      scenario,
+      geojsonPath,
+      vehicles: options.vehicles,
+      stepMs: options.stepMs,
+      seed: options.seed,
+      maxSimSeconds: options.maxSeconds,
+    }).run();
+  } catch (error) {
+    out(`Scenario run failed: ${error instanceof Error ? error.message : String(error)}`);
+    return EXIT_USAGE;
+  }
+
+  if (options.report) {
+    fs.writeFileSync(options.report, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  out(options.json ? JSON.stringify(report, null, 2) : formatSummary(report));
+
+  return report.passed ? EXIT_PASS : EXIT_ASSERTION_FAILURE;
+}
+
+/**
+ * Only self-executes when run as a script, so importing this module in a test
+ * doesn't run a scenario or kill the process.
+ */
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(error);
+      process.exit(EXIT_USAGE);
+    });
+}

--- a/apps/simulator/src/headless/seededRandom.ts
+++ b/apps/simulator/src/headless/seededRandom.ts
@@ -1,0 +1,23 @@
+import { mulberry32, setAmbientRng } from "../utils/rng";
+
+/**
+ * Installs a seeded mulberry32 stream for the duration of a headless run and
+ * returns a restore function. A SINGLE stream backs both:
+ *  - the injectable ambient Rng (`src/utils/rng.ts`), which the threaded
+ *    placement/routing seams draw from, and
+ *  - the global `Math.random` (legacy fallback for any spot not yet threaded),
+ * so a given `seed` reproduces the same run.
+ *
+ * Shared by `HeadlessRunner` (recording generation) and `ScenarioRunner` (the
+ * assertion harness) — both only mean anything if they are reproducible.
+ */
+export function installSeededRandom(seed: number): () => void {
+  const stream = mulberry32(seed);
+  const restoreAmbient = setAmbientRng(stream);
+  const original = Math.random;
+  Math.random = () => stream.next();
+  return () => {
+    Math.random = original;
+    restoreAmbient();
+  };
+}

--- a/apps/simulator/src/index.ts
+++ b/apps/simulator/src/index.ts
@@ -65,9 +65,16 @@ const vehicleManager = new VehicleManager(network, fleetManager);
 const simulationController = new SimulationController(vehicleManager, incidentManager);
 const recordingManager = new RecordingManager();
 const generationManager = new GenerationManager();
-const scenarioManager = new ScenarioManager(vehicleManager, incidentManager, simulationController);
 const geoFenceManager = new GeoFenceManager();
 const jobManager = new JobManager(vehicleManager);
+// After jobManager: scenarios can create jobs (`create_job` events), so the
+// scenario layer needs the dispatch module it drives.
+const scenarioManager = new ScenarioManager(
+  vehicleManager,
+  incidentManager,
+  simulationController,
+  jobManager
+);
 
 // ─── Persistence (optional) ─────────────────────────────────────────
 

--- a/apps/simulator/src/middleware/schemas.ts
+++ b/apps/simulator/src/middleware/schemas.ts
@@ -220,7 +220,7 @@ export const fleetAssignSchema = z.object({
 
 // ─── Jobs ───────────────────────────────────────────────────────────
 
-const jobStopSchema = z.object({
+export const jobStopSchema = z.object({
   lat: z
     .number()
     .min(-90, "lat must be between -90 and 90")

--- a/apps/simulator/src/modules/JobManager.ts
+++ b/apps/simulator/src/modules/JobManager.ts
@@ -492,6 +492,15 @@ export class JobManager extends EventEmitter {
     const job = this.jobForVehicle(payload.vehicleId);
     if (!job) return;
     if (payload.reason === "waypoints" && this.ownsWaypoints(job, payload.waypoints)) return;
+    // The unit was claimed but its job route has not been set yet, so any route
+    // change arriving now belongs to what the vehicle was doing BEFORE it was
+    // claimed — typically its own random destination, whose pathfind was already
+    // in flight. Treating that as a re-dispatch re-queues a job that is about to
+    // be routed, and the assignment then finishes against a job that no longer
+    // holds the vehicle (status en_route with no vehicleId, never completing).
+    // Whatever this event says is superseded by the route this assignment is
+    // about to set, so it is safe to ignore.
+    if (this.assigning.has(job.id)) return;
 
     const state = this.runtime.get(job.id);
     if (state) this.clearDwell(state);

--- a/apps/simulator/src/modules/RouteManager.ts
+++ b/apps/simulator/src/modules/RouteManager.ts
@@ -107,12 +107,29 @@ export class RouteManager extends EventEmitter {
   private static readonly REROUTE_BATCH_SIZE = 20;
   private static readonly REROUTE_STAGGER_MS = 100;
 
+  /**
+   * Clock behind dwell deadlines (`vehicle.dwellUntil`) and the pathfind-retry
+   * cooldown — the two pieces of movement bookkeeping measured in absolute time
+   * rather than in the `deltaMs` the caller passes. Wall time by default,
+   * which is what the live sim wants. The headless runners swap in the
+   * simulation clock: a fast-forward compresses hours of simulated time into
+   * seconds of wall time, so a wall-clock dwell would park a vehicle at its
+   * first stop for the rest of the run — and make the output depend on how fast
+   * the machine ran, which is the opposite of a deterministic generation.
+   */
+  private now: () => number = Date.now;
+
   constructor(
     private network: RoadNetwork,
     private registry: VehicleRegistry,
     private traffic: TrafficManager
   ) {
     super();
+  }
+
+  /** Replaces the dwell clock. See {@link now}. */
+  setTimeSource(now: () => number): void {
+    this.now = now;
   }
 
   // ─── Route getters ────────────────────────────────────────────────
@@ -310,7 +327,7 @@ export class RouteManager extends EventEmitter {
 
       if (wpIndex < vehicle.waypoints.length - 1) {
         const dwellSeconds = waypoint?.dwellTime ?? 10 + rng() * 50;
-        vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
+        vehicle.dwellUntil = this.now() + dwellSeconds * 1000;
         vehicle.speed = 0; // Will be set by caller via options.minSpeed
 
         const nextLeg = multiRoute.legs[wpIndex + 1];
@@ -327,7 +344,7 @@ export class RouteManager extends EventEmitter {
         this.emit("route:completed", { vehicleId: vehicle.id });
         this.clearWaypointState(vehicle);
         const dwellSeconds = waypoint?.dwellTime ?? 10 + rng() * 50;
-        vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
+        vehicle.dwellUntil = this.now() + dwellSeconds * 1000;
         vehicle.speed = 0; // Will be set by caller via options.minSpeed
         this.deleteRoute(vehicle.id);
         return null;
@@ -335,7 +352,7 @@ export class RouteManager extends EventEmitter {
     }
 
     const dwellSeconds = 10 + rng() * 50;
-    vehicle.dwellUntil = Date.now() + dwellSeconds * 1000;
+    vehicle.dwellUntil = this.now() + dwellSeconds * 1000;
     vehicle.speed = 0; // Will be set by caller via options.minSpeed
     this.deleteRoute(vehicle.id);
     return null;
@@ -415,7 +432,7 @@ export class RouteManager extends EventEmitter {
    */
   updateVehicle(vehicle: Vehicle, deltaMs: number, options: StartOptions): void {
     if (vehicle.dwellUntil) {
-      if (Date.now() < vehicle.dwellUntil) return;
+      if (this.now() < vehicle.dwellUntil) return;
       vehicle.dwellUntil = undefined;
       // A dwell at an INTERMEDIATE stop already has the next leg loaded (see
       // handleRouteCompleted), so the vehicle resumes its trip. Only a dwell
@@ -431,7 +448,10 @@ export class RouteManager extends EventEmitter {
 
     if (!route || route.edges.length === 0) {
       this.updatePositionCore(vehicle, deltaMs, options);
-      const now = Date.now();
+      // Same clock as dwell: on wall time live, on simulated time headlessly,
+      // where a wall-clock cooldown would gate retries on how fast the machine
+      // ran the fast-forward instead of on simulated seconds.
+      const now = this.now();
       const lastAttempt = this.lastPathfindAttempt.get(vehicle.id) ?? 0;
       if (now - lastAttempt > RouteManager.PATHFIND_COOLDOWN) {
         this.lastPathfindAttempt.set(vehicle.id, now);

--- a/apps/simulator/src/modules/SimulationClock.ts
+++ b/apps/simulator/src/modules/SimulationClock.ts
@@ -35,6 +35,15 @@ export class SimulationClock extends EventEmitter {
     }
   }
 
+  /**
+   * Simulated time as epoch ms. The clock-equivalent of `Date.now()`, for
+   * bookkeeping that must move with simulated time rather than wall time (e.g.
+   * dwell deadlines in a headless fast-forward).
+   */
+  now(): number {
+    return this._currentTime.getTime();
+  }
+
   getHour(): number {
     return this._currentTime.getHours();
   }

--- a/apps/simulator/src/modules/scenario/ScenarioManager.ts
+++ b/apps/simulator/src/modules/scenario/ScenarioManager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import type { VehicleManager } from "../VehicleManager";
 import type { IncidentManager } from "../IncidentManager";
+import type { JobManager } from "../JobManager";
 import type { SimulationController } from "../SimulationController";
 import {
   scenarioSchema,
@@ -10,12 +11,27 @@ import {
   type ScenarioState,
   type SpawnVehiclesAction,
   type CreateIncidentAction,
+  type CreateJobAction,
   type DispatchAction,
   type SetTrafficProfileAction,
   type ClearIncidentsAction,
   type SetOptionsAction,
 } from "./types";
 import type { VehicleType } from "../../types";
+import { createLogger } from "../../utils/logger";
+
+const log = createLogger("scenario");
+
+/**
+ * Which clock drives event execution.
+ *
+ * `wall` is the operator-facing mode: `setTimeout`s fire against real time so a
+ * scenario plays out in the UI at the speed it was authored at. `manual` is the
+ * headless mode: no timers exist and the caller advances simulated time in
+ * explicit steps, exactly like {@link VehicleManager.advance}. The two never mix
+ * — `start()` selects one, `startManual()` the other.
+ */
+type ClockMode = "wall" | "manual";
 
 export class ScenarioManager extends EventEmitter {
   private scenario: Scenario | null = null;
@@ -26,11 +42,19 @@ export class ScenarioManager extends EventEmitter {
   private eventsExecuted: number = 0;
   private pendingTimer: ReturnType<typeof setTimeout> | null = null;
   private completionTimer: ReturnType<typeof setTimeout> | null = null;
+  private clockMode: ClockMode = "wall";
+  private manualElapsed = 0; // elapsed simulated ms, manual mode only
 
   constructor(
     private vehicleManager: VehicleManager,
     private incidentManager: IncidentManager,
-    private simulationController: SimulationController
+    private simulationController: SimulationController,
+    /**
+     * Optional so the live wiring order and existing callers are unaffected;
+     * a scenario carrying `create_job` events needs it (see
+     * {@link handleCreateJob}).
+     */
+    private jobManager?: JobManager
   ) {
     super();
   }
@@ -75,6 +99,7 @@ export class ScenarioManager extends EventEmitter {
 
     this.resetState();
     this.state = "running";
+    this.clockMode = "wall";
     this.startTime = Date.now();
 
     this.emit("scenario:started", {
@@ -83,6 +108,77 @@ export class ScenarioManager extends EventEmitter {
     });
 
     this.scheduleNextEvent();
+  }
+
+  /**
+   * Begins executing the scenario on a MANUAL clock: no timers are armed, and
+   * nothing happens until {@link advance} is called.
+   *
+   * This is the headless seam the regression harness runs on — the deterministic,
+   * explicit-`dt` counterpart of {@link start}, and the scenario-level mirror of
+   * {@link VehicleManager.advance}. It exists because a scenario driven by
+   * `setTimeout` cannot be fast-forwarded: a 10-minute scenario would take 10
+   * minutes of CI wall-clock, and its events would land at whatever simulated
+   * time the fast-forward happened to have reached.
+   *
+   * @throws {Error} If no scenario is loaded or one is already running.
+   */
+  startManual(): void {
+    if (!this.scenario) {
+      throw new Error("No scenario loaded");
+    }
+    if (this.state === "running") {
+      throw new Error("Scenario is already running");
+    }
+
+    this.resetState();
+    this.state = "running";
+    this.clockMode = "manual";
+
+    this.emit("scenario:started", {
+      name: this.scenario.name,
+      eventCount: this.scenario.events.length,
+    });
+  }
+
+  /**
+   * Advances the scenario by `deltaMs` of SIMULATED time, executing every event
+   * that has come due, in order. Manual mode only; a no-op otherwise.
+   *
+   * Awaits each action, so an async one (`dispatch` pathfinds, `create_job`
+   * assigns a vehicle) has finished before the next event or the caller's next
+   * simulation step runs. Emits `scenario:completed` once the last event has run
+   * AND the authored duration has elapsed, same as the timer path.
+   */
+  async advance(deltaMs: number): Promise<void> {
+    if (this.clockMode !== "manual" || this.state !== "running" || !this.scenario) return;
+
+    this.manualElapsed += deltaMs;
+    const events = this.scenario.events;
+
+    while (
+      this.eventIndex < events.length &&
+      events[this.eventIndex].at * 1000 <= this.manualElapsed
+    ) {
+      const event = events[this.eventIndex];
+      // One failing action must not abandon the rest of the timeline — but it is
+      // reported, because a harness that silently skipped a dispatch would grade
+      // a scenario that never actually ran.
+      try {
+        await this.executeEvent(event);
+      } catch (error) {
+        this.emitEventError(event, error);
+      }
+      this.eventIndex++;
+      this.eventsExecuted++;
+      // An action can stop the scenario (or a caller can, from a listener);
+      // stopping mid-step must not keep draining the timeline.
+      if (this.state !== "running") return;
+    }
+
+    if (this.eventIndex >= events.length && this.manualElapsed >= this.scenario.duration * 1000) {
+      this.handleCompleted();
+    }
   }
 
   /**
@@ -118,7 +214,9 @@ export class ScenarioManager extends EventEmitter {
       nextEventIndex: this.eventIndex,
     });
 
-    this.scheduleNextEvent();
+    // In manual mode there is no timer to re-arm: the caller's next `advance`
+    // picks the timeline back up where it left off.
+    if (this.clockMode === "wall") this.scheduleNextEvent();
   }
 
   /**
@@ -139,6 +237,8 @@ export class ScenarioManager extends EventEmitter {
     this.eventsExecuted = 0;
     this.startTime = 0;
     this.pausedAt = 0;
+    this.manualElapsed = 0;
+    this.clockMode = "wall";
 
     this.emit("scenario:stopped", {
       name,
@@ -177,6 +277,7 @@ export class ScenarioManager extends EventEmitter {
   // ─── Internal ────────────────────────────────────────────────────
 
   private elapsed(): number {
+    if (this.clockMode === "manual") return this.manualElapsed;
     if (this.state === "paused") return this.pausedAt;
     if (this.state === "running") return Date.now() - this.startTime;
     return 0;
@@ -189,6 +290,7 @@ export class ScenarioManager extends EventEmitter {
     this.eventsExecuted = 0;
     this.startTime = 0;
     this.pausedAt = 0;
+    this.manualElapsed = 0;
   }
 
   private clearTimers(): void {
@@ -221,11 +323,30 @@ export class ScenarioManager extends EventEmitter {
     this.pendingTimer = setTimeout(() => {
       this.pendingTimer = null;
       if (this.state !== "running") return;
-      this.executeEvent(event);
+      try {
+        const result = this.executeEvent(event);
+        // An async action's rejection arrives after this tick; without the catch
+        // it would surface as an unhandled rejection.
+        if (result) void result.catch((error: unknown) => this.emitEventError(event, error));
+      } catch (error) {
+        this.emitEventError(event, error);
+      }
       this.eventIndex++;
       this.eventsExecuted++;
       this.scheduleNextEvent();
     }, delay);
+  }
+
+  /** Logs and announces an action that threw, without stopping the scenario. */
+  private emitEventError(event: ScenarioEvent, error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Scenario action ${event.action.type} at ${event.at}s failed: ${message}`);
+    this.emit("scenario:event-error", {
+      index: this.eventIndex,
+      at: event.at,
+      action: event.action.type,
+      error: message,
+    });
   }
 
   private scheduleCompletion(): void {
@@ -262,7 +383,14 @@ export class ScenarioManager extends EventEmitter {
     });
   }
 
-  private executeEvent(event: ScenarioEvent): void {
+  /**
+   * Runs one event's action.
+   *
+   * Returns a promise for the async actions so the manual (headless) path can
+   * await them; the timer path deliberately does not — a wall-clock scenario
+   * must not let a slow pathfind delay the next event's `setTimeout`.
+   */
+  private executeEvent(event: ScenarioEvent): Promise<void> | void {
     this.emit("scenario:event", {
       index: this.eventIndex,
       at: event.at,
@@ -279,8 +407,7 @@ export class ScenarioManager extends EventEmitter {
         this.handleCreateIncident(action);
         break;
       case "dispatch":
-        void this.handleDispatch(action);
-        break;
+        return this.handleDispatch(action);
       case "set_traffic_profile":
         this.handleSetTrafficProfile(action);
         break;
@@ -290,6 +417,8 @@ export class ScenarioManager extends EventEmitter {
       case "set_options":
         this.handleSetOptions(action);
         break;
+      case "create_job":
+        return this.handleCreateJob(action);
     }
   }
 
@@ -396,5 +525,21 @@ export class ScenarioManager extends EventEmitter {
 
   private handleSetOptions(action: SetOptionsAction): void {
     this.vehicleManager.setOptions(action.options);
+  }
+
+  private async handleCreateJob(action: CreateJobAction): Promise<void> {
+    if (!this.jobManager) {
+      throw new Error(
+        "Scenario contains a create_job event but no JobManager is wired to the ScenarioManager"
+      );
+    }
+
+    await this.jobManager.createJob({
+      pickup: action.pickup,
+      dropoff: action.dropoff,
+      strategy: action.strategy,
+      vehicleId: action.vehicleId,
+      slaSeconds: action.slaSeconds,
+    });
   }
 }

--- a/apps/simulator/src/modules/scenario/assertions.ts
+++ b/apps/simulator/src/modules/scenario/assertions.ts
@@ -1,0 +1,217 @@
+import type { ScenarioAssertion } from "./types";
+
+/**
+ * Job-side aggregate of a scenario run. Counted from the real `JobDTO`s the
+ * `JobManager` holds when the run ends, so a status here is the same status the
+ * job board and the WS `job:updated` stream reported.
+ */
+export interface ScenarioJobMetrics {
+  total: number;
+  complete: number;
+  failed: number;
+  cancelled: number;
+  /** Jobs that were still pending/assigned/en_route/on_scene/transporting at the end. */
+  unfinished: number;
+  slaBreached: number;
+  /** Assignment ETA to the pickup, seconds — one entry per job that got assigned. */
+  etaToPickupSeconds: number[];
+  /** Assignment ETA for the whole two-leg trip, seconds. */
+  etaToDropoffSeconds: number[];
+  /**
+   * Distinct `job.error` strings seen on the run, so a failing assertion can say
+   * WHY the jobs failed instead of only that they did.
+   */
+  errors: string[];
+}
+
+/** Vehicle-side aggregate of a scenario run. */
+export interface ScenarioVehicleMetrics {
+  count: number;
+  /** Fleet mean of the per-vehicle average speed, km/h. */
+  avgSpeedKph: number;
+  totalDistanceKm: number;
+  /**
+   * Longest run of SIMULATED seconds each vehicle spent stationary, keyed by
+   * vehicle id. The stranded assertion thresholds this; the runner samples it
+   * every step, so it covers the whole run rather than just the final frame.
+   */
+  maxIdleSecondsById: Record<string, number>;
+}
+
+/** Everything the assertions are evaluated against. */
+export interface ScenarioMetrics {
+  /** Simulated seconds the run covered. */
+  simSeconds: number;
+  jobs: ScenarioJobMetrics;
+  vehicles: ScenarioVehicleMetrics;
+}
+
+/** One assertion's verdict. `passed === false` is what fails a CI run. */
+export interface AssertionResult {
+  type: ScenarioAssertion["type"];
+  /** The scenario's own label when it set one, otherwise a generated one. */
+  label: string;
+  passed: boolean;
+  /** What the assertion asked for, human-readable. */
+  expected: string;
+  /** What the run produced, human-readable. */
+  actual: string;
+  /** Extra context on a failure (offending vehicles, missing statuses). */
+  detail?: string;
+}
+
+/**
+ * Nearest-rank percentile over an unsorted sample. Returns `null` for an empty
+ * sample so callers can distinguish "no data" from "zero".
+ */
+export function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  // Nearest-rank: rank = ceil(p/100 * N), clamped into the array.
+  const rank = Math.ceil((p / 100) * sorted.length);
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+  return sorted[index];
+}
+
+/** Why the jobs didn't all land: the status split, plus any reported errors. */
+function shortfallDetail(jobs: ScenarioJobMetrics): string {
+  const split = `${jobs.unfinished} unfinished, ${jobs.failed} failed, ${jobs.cancelled} cancelled`;
+  return jobs.errors.length === 0 ? split : `${split}; ${jobs.errors.join("; ")}`;
+}
+
+function round(value: number, digits = 2): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Evaluates every assertion against the collected metrics.
+ *
+ * Pure and synchronous: the run is over by the time this is called, which is
+ * what makes a scenario's verdict reproducible from its report alone.
+ */
+export function evaluateAssertions(
+  assertions: ScenarioAssertion[],
+  metrics: ScenarioMetrics
+): AssertionResult[] {
+  return assertions.map((assertion) => evaluateAssertion(assertion, metrics));
+}
+
+function evaluateAssertion(
+  assertion: ScenarioAssertion,
+  metrics: ScenarioMetrics
+): AssertionResult {
+  const { jobs, vehicles } = metrics;
+
+  switch (assertion.type) {
+    case "all_jobs_completed": {
+      const passed = jobs.total === jobs.complete;
+      return {
+        type: assertion.type,
+        label: assertion.label ?? "all jobs completed",
+        passed,
+        expected: `${jobs.total}/${jobs.total} jobs complete`,
+        actual: `${jobs.complete}/${jobs.total} jobs complete`,
+        detail: passed ? undefined : shortfallDetail(jobs),
+      };
+    }
+
+    case "job_completion_rate": {
+      // A run that created no jobs vacuously satisfies a rate: there is no
+      // dispatch behaviour to regress. Failing it would make an assertion list
+      // reusable across scenarios impossible.
+      const rate = jobs.total === 0 ? 1 : jobs.complete / jobs.total;
+      const passed = rate >= assertion.atLeast;
+      return {
+        type: assertion.type,
+        label: assertion.label ?? `job completion rate >= ${assertion.atLeast}`,
+        passed,
+        expected: `>= ${assertion.atLeast}`,
+        actual: `${round(rate, 4)} (${jobs.complete}/${jobs.total})`,
+      };
+    }
+
+    case "job_failures": {
+      const passed = jobs.failed <= assertion.atMost;
+      return {
+        type: assertion.type,
+        label: assertion.label ?? `failed jobs <= ${assertion.atMost}`,
+        passed,
+        expected: `<= ${assertion.atMost} failed`,
+        actual: `${jobs.failed} failed`,
+        detail: passed || jobs.errors.length === 0 ? undefined : jobs.errors.join("; "),
+      };
+    }
+
+    case "job_eta_percentile": {
+      const sample =
+        assertion.leg === "pickup" ? jobs.etaToPickupSeconds : jobs.etaToDropoffSeconds;
+      const value = percentile(sample, assertion.percentile);
+      const label =
+        assertion.label ??
+        `p${assertion.percentile} ETA to ${assertion.leg} < ${assertion.lessThanSeconds}s`;
+
+      if (value === null) {
+        // No assigned job means the scenario never exercised what this asserts.
+        // Reporting that as a pass would hide a dispatch failure behind a green
+        // run, so an empty sample fails.
+        return {
+          type: assertion.type,
+          label,
+          passed: false,
+          expected: `< ${assertion.lessThanSeconds}s`,
+          actual: "no assigned jobs to measure",
+        };
+      }
+
+      return {
+        type: assertion.type,
+        label,
+        passed: value < assertion.lessThanSeconds,
+        expected: `< ${assertion.lessThanSeconds}s`,
+        actual: `${round(value)}s (n=${sample.length})`,
+      };
+    }
+
+    case "no_stranded_vehicles": {
+      const offenders = Object.entries(vehicles.maxIdleSecondsById)
+        .filter(([, idle]) => idle > assertion.idleSeconds)
+        .sort((a, b) => b[1] - a[1]);
+      const worst = Object.values(vehicles.maxIdleSecondsById).reduce(
+        (max, idle) => Math.max(max, idle),
+        0
+      );
+      return {
+        type: assertion.type,
+        label: assertion.label ?? `no vehicle idle for more than ${assertion.idleSeconds}s`,
+        passed: offenders.length === 0,
+        expected: `max idle <= ${assertion.idleSeconds}s`,
+        actual: `${offenders.length} stranded, worst idle ${round(worst)}s`,
+        detail:
+          offenders.length === 0
+            ? undefined
+            : offenders
+                .slice(0, 5)
+                .map(([id, idle]) => `${id} idle ${round(idle)}s`)
+                .join(", "),
+      };
+    }
+
+    case "fleet_avg_speed": {
+      const avg = vehicles.avgSpeedKph;
+      const aboveFloor = avg >= assertion.atLeastKph;
+      const belowCeiling = assertion.atMostKph === undefined || avg <= assertion.atMostKph;
+      const band =
+        assertion.atMostKph === undefined
+          ? `>= ${assertion.atLeastKph} km/h`
+          : `${assertion.atLeastKph}..${assertion.atMostKph} km/h`;
+      return {
+        type: assertion.type,
+        label: assertion.label ?? `fleet average speed ${band}`,
+        passed: aboveFloor && belowCeiling,
+        expected: band,
+        actual: `${round(avg)} km/h (${vehicles.count} vehicles)`,
+      };
+    }
+  }
+}

--- a/apps/simulator/src/modules/scenario/index.ts
+++ b/apps/simulator/src/modules/scenario/index.ts
@@ -1,3 +1,4 @@
 export { ScenarioManager } from "./ScenarioManager";
 export * from "./types";
+export * from "./assertions";
 export { convertRecordingToScenario, parseRecording } from "./convertRecording";

--- a/apps/simulator/src/modules/scenario/types.ts
+++ b/apps/simulator/src/modules/scenario/types.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import {
   incidentTypeEnum,
+  jobStopSchema,
+  jobStrategyEnum,
   optionsSchema,
   trafficProfileSchema,
   waypointRequestSchema,
@@ -50,6 +52,21 @@ export const setOptionsActionSchema = z.object({
   options: optionsSchema.partial(),
 });
 
+/**
+ * Creates a job (pickup + dropoff) through the real `JobManager`, so a scenario
+ * can exercise the dispatch lifecycle the assertions are written against
+ * ("every job completed", "p95 ETA to pickup under N seconds").
+ */
+export const createJobActionSchema = z.object({
+  type: z.literal("create_job"),
+  pickup: jobStopSchema,
+  dropoff: jobStopSchema,
+  strategy: jobStrategyEnum.optional(),
+  /** Required when `strategy` is `manual`. */
+  vehicleId: z.string().min(1).optional(),
+  slaSeconds: z.number().int().min(1).max(86_400).optional(),
+});
+
 // ─── Discriminated union of all actions ─────────────────────────────
 
 export const scenarioActionSchema = z.discriminatedUnion("type", [
@@ -59,6 +76,7 @@ export const scenarioActionSchema = z.discriminatedUnion("type", [
   setTrafficProfileActionSchema,
   clearIncidentsActionSchema,
   setOptionsActionSchema,
+  createJobActionSchema,
 ]);
 
 // ─── Timeline event ─────────────────────────────────────────────────
@@ -92,12 +110,82 @@ export const scenarioMetadataSchema = z.object({
 
 export const scenarioVariablesSchema = z.record(z.string(), z.union([z.string(), z.number()]));
 
+// ─── Assertions ─────────────────────────────────────────────────────
+//
+// Assertions are the pass/fail contract of a scenario: they turn a run into a
+// regression test. They are evaluated ONCE, against the metrics collected over
+// the whole run, by the headless runner (`headless/ScenarioRunner.ts`) — the
+// live, wall-clock `ScenarioManager` ignores them, because a scenario an
+// operator drives from the UI has no exit code to fail.
+
+/** Every job the scenario created reached `complete`. */
+export const allJobsCompletedAssertionSchema = z.object({
+  type: z.literal("all_jobs_completed"),
+  label: z.string().optional(),
+});
+
+/** Completed / created, as a ratio in [0, 1]. A run with no jobs scores 1. */
+export const jobCompletionRateAssertionSchema = z.object({
+  type: z.literal("job_completion_rate"),
+  atLeast: z.number().min(0).max(1),
+  label: z.string().optional(),
+});
+
+/** Cap on jobs that ended `failed` (no routable vehicle, dropped mid-trip). */
+export const jobFailuresAssertionSchema = z.object({
+  type: z.literal("job_failures"),
+  atMost: z.number().int().nonnegative().default(0),
+  label: z.string().optional(),
+});
+
+/**
+ * Percentile of the assignment ETA across jobs, in seconds. `leg: "pickup"` is
+ * the response-time question (how long until a unit arrives); `leg: "dropoff"`
+ * is the whole two-leg trip.
+ */
+export const jobEtaPercentileAssertionSchema = z.object({
+  type: z.literal("job_eta_percentile"),
+  percentile: z.number().min(1).max(100).default(95),
+  leg: z.enum(["pickup", "dropoff"]).default("pickup"),
+  lessThanSeconds: z.number().positive(),
+  label: z.string().optional(),
+});
+
+/**
+ * No vehicle sat still for longer than `idleSeconds` of SIMULATED time. This is
+ * the "nothing got stuck" check: an unroutable vehicle, a vehicle boxed in by a
+ * closure, or one whose dwell never released all show up as a long idle streak.
+ */
+export const noStrandedVehiclesAssertionSchema = z.object({
+  type: z.literal("no_stranded_vehicles"),
+  idleSeconds: z.number().positive().default(120),
+  label: z.string().optional(),
+});
+
+/** Fleet-mean speed band, km/h. Catches a network-wide gridlock regression. */
+export const fleetAvgSpeedAssertionSchema = z.object({
+  type: z.literal("fleet_avg_speed"),
+  atLeastKph: z.number().nonnegative(),
+  atMostKph: z.number().positive().optional(),
+  label: z.string().optional(),
+});
+
+export const scenarioAssertionSchema = z.discriminatedUnion("type", [
+  allJobsCompletedAssertionSchema,
+  jobCompletionRateAssertionSchema,
+  jobFailuresAssertionSchema,
+  jobEtaPercentileAssertionSchema,
+  noStrandedVehiclesAssertionSchema,
+  fleetAvgSpeedAssertionSchema,
+]);
+
 // ─── Top-level scenario schema ──────────────────────────────────────
 
 export const scenarioSchema = scenarioMetadataSchema.extend({
   version: z.literal(1).default(1),
   variables: scenarioVariablesSchema.optional(),
   events: z.array(scenarioEventSchema),
+  assertions: z.array(scenarioAssertionSchema).optional(),
 });
 
 // ─── Inferred TypeScript types ──────────────────────────────────────
@@ -108,8 +196,10 @@ export type DispatchAction = z.infer<typeof dispatchActionSchema>;
 export type SetTrafficProfileAction = z.infer<typeof setTrafficProfileActionSchema>;
 export type ClearIncidentsAction = z.infer<typeof clearIncidentsActionSchema>;
 export type SetOptionsAction = z.infer<typeof setOptionsActionSchema>;
+export type CreateJobAction = z.infer<typeof createJobActionSchema>;
 export type ScenarioAction = z.infer<typeof scenarioActionSchema>;
 export type ScenarioEvent = z.infer<typeof scenarioEventSchema>;
+export type ScenarioAssertion = z.infer<typeof scenarioAssertionSchema>;
 export type ScenarioVariables = z.infer<typeof scenarioVariablesSchema>;
 export type Scenario = z.infer<typeof scenarioSchema>;
 


### PR DESCRIPTION
Closes `fleetsim-all-mxzc.6`.

A scenario file can now carry an `assertions` array, and a headless runner grades it against the metrics of an actual run. The scenario becomes a regression test for the simulator (and for anything downstream of it) that CI can gate on.

## What you get

```bash
npm run scenario -- dispatch-regression --vehicles 150
```

```
Scenario: Dispatch Regression
  3600s simulated in 12167ms wall, 7/7 events, seed 3
  Vehicles: 150, avg 20.0 km/h, 3006.94 km driven
  Jobs: 4 created, 4 complete, 0 failed, 0 cancelled, 0 unfinished
  PASS all jobs completed
  PASS failed jobs <= 0
  PASS p95 response ETA under 15 minutes
       expected < 900s, got 497s (n=4)
  PASS no vehicle idle for more than 300s
       expected max idle <= 300s, got 0 stranded, worst idle 59s
  PASS fleet average speed >= 5 km/h
PASSED (5 assertions)
```

Exit codes: `0` every assertion held, `1` an assertion failed (or a scenario action threw), `2` the scenario could not be run at all — bad arguments, unreadable/invalid file, missing network. Flags: `--vehicles --step-ms --seed --max-seconds --network --report --json`.

## Pieces

- **Assertion schema** (`modules/scenario/types.ts`): `all_jobs_completed`, `job_completion_rate`, `job_failures`, `job_eta_percentile` (percentile + `pickup`/`dropoff` leg), `no_stranded_vehicles`, `fleet_avg_speed`. Each takes an optional `label`.
- **Evaluation** (`modules/scenario/assertions.ts`): pure, synchronous, over a `ScenarioMetrics` snapshot, so a verdict is reproducible from the report alone. An empty ETA sample fails rather than vacuously passing (no assigned job means the scenario never exercised what the assertion claims); a run with no jobs satisfies a completion *rate*, so an assertion list stays reusable across scenarios.
- **`create_job` action**: scenarios can dispatch through the real `JobManager`, which is what the job assertions grade.
- **`ScenarioManager.startManual()` / `advance(deltaMs)`**: manual-clock seam mirroring `VehicleManager.advance`. Events fire on simulated seconds, so a one-hour scenario grades in seconds and lands its events where it authored them. Async actions are awaited; an action that throws is reported as `scenario:event-error` (and fails the run) instead of being silently skipped. The wall-clock path is untouched.
- **`headless/ScenarioRunner`**: builds the real graph (RoadNetwork + VehicleManager + IncidentManager + JobManager + ScenarioManager), steps it, runs the 1 Hz job sweep on simulated time, samples per-vehicle idle streaks every step, collects metrics, grades. Always a seeded synthetic fleet — a harness whose verdict depends on whatever an external source returned today is not a regression test.
- **`headless/scenario-cli.ts`** + `npm run scenario`, and `data/scenarios/dispatch-regression.json` as a working example. `installSeededRandom` moved to `headless/seededRandom.ts`, shared with `HeadlessRunner`.

## Two fixes the harness needed

Both are pre-existing bugs that a fast-forward makes unmissable:

1. **`RouteManager` dwell/pathfind-cooldown clock** is now an injectable time source (`setTimeSource`), wall clock by default and the simulation clock in both headless runners. On wall time, a fast-forward compresses hours into seconds, so the first waypoint dwell parked every vehicle for the remainder of the run — and for a duration that depended on machine speed. `HeadlessRunner`'s generated recordings had the same defect.
2. **`JobManager` ignores `direction` events while an assignment is in flight.** A route change arriving between "vehicle claimed" and "job route set" belongs to what the vehicle was doing *before* it was claimed (typically its own random destination, pathfind already dispatched). It was being read as a mid-trip re-dispatch, which re-queued the job and left the assignment to finish against a job that no longer held the vehicle: `en_route`, no `vehicleId`, never completing.

## Determinism

A run reproduces for a fixed `--seed`: seeded RNG, sim-clock dwell/cooldown, and in-flight pathfinding settled at each step boundary (`--`, i.e. `drainPathfindingMs`, defaults to 2000ms; `0` trades reproducibility for speed on large fleets). Without the settle, A* replies landed on whatever step the worker thread happened to answer on.

## Verification

- `npm run test:ci` (simulator): 94 files / 1968 tests pass with the coverage gate, run four times to check the new integration tests do not destabilise the suite. New tests: `scenarioAssertions.test.ts` (23), `ScenarioRunner.test.ts` (6), `scenarioCli.test.ts` (12), plus manual-clock and `create_job` cases in `ScenarioManager.test.ts`.
- `npm run type-check` clean across the monorepo; Biome clean on the touched files.
- Shipped scenario verified end-to-end on the real Nairobi network: passes at `--vehicles 150`, and fails (exit 1) when the window is capped so jobs cannot land.
- README documents the harness, the flags, and the assertion table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)