### PR TITLE
feat(simulator): record geofence crossings so replay keeps them

### DIFF
--- a/apps/simulator/src/__tests__/RecordingReplay.test.ts
+++ b/apps/simulator/src/__tests__/RecordingReplay.test.ts
@@ -5,6 +5,8 @@ import os from "os";
 import { RecordingManager } from "../modules/RecordingManager";
 import { ReplayManager } from "../modules/ReplayManager";
 import { SimulationClock } from "../modules/SimulationClock";
+import { GeoFenceManager } from "../modules/GeoFenceManager";
+import type { GeoFence, GeoFenceEvent } from "@moveet/shared-types";
 import type { StartOptions, VehicleDTO, RecordingHeader, RecordingEvent } from "../types";
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -661,5 +663,62 @@ describe("ReplayManager", () => {
 
       vi.useRealTimers();
     });
+  });
+});
+
+// ─── Geofence crossings survive record → replay ─────────────────────
+
+describe("geofence crossings survive record → replay", () => {
+  const fence: GeoFence = {
+    id: "f1",
+    name: "Depot",
+    type: "monitoring",
+    // [lng, lat] ring around [0, 0]
+    polygon: [
+      [-1, -1],
+      [1, -1],
+      [1, 1],
+      [-1, 1],
+    ],
+    active: true,
+  };
+
+  it("re-emits recorded enter/exit events on the live geofence:event channel", async () => {
+    const filePath = tmpFile("geofence-replay.ndjson");
+
+    // ─── Live session: a vehicle drives into the fence and out again ──
+    const rm = new RecordingManager();
+    const gfm = new GeoFenceManager();
+    gfm.addZone(fence);
+
+    const liveEvents: GeoFenceEvent[] = [];
+    gfm.on("geofence:event", (event: GeoFenceEvent) => {
+      liveEvents.push(event);
+      // Exactly the wiring used in setup/eventWiring.ts
+      rm.recordEvent("geofence", event as unknown as Record<string, unknown>);
+    });
+
+    rm.startRecording(defaultOptions, 1, filePath);
+    gfm.checkVehicles([makeVehicle("v1", 0, 0)]);
+    gfm.checkVehicles([makeVehicle("v1", 10, 10)]);
+    rm.stopRecording();
+
+    expect(liveEvents.map((e) => e.event)).toEqual(["enter", "exit"]);
+
+    // ─── Replay the same file ────────────────────────────────────────
+    vi.useFakeTimers();
+    const rp = new ReplayManager();
+    await rp.loadRecording(filePath);
+
+    const replayedEvents: GeoFenceEvent[] = [];
+    rp.on("geofence:event", (data) => replayedEvents.push(data as GeoFenceEvent));
+
+    rp.startReplay(1);
+    vi.advanceTimersByTime(60_000);
+    rp.stopReplay();
+    vi.useRealTimers();
+
+    // A replayed session shows the same geofence ticks the live session did.
+    expect(replayedEvents).toEqual(liveEvents);
   });
 });

--- a/apps/simulator/src/__tests__/setup/eventWiring.test.ts
+++ b/apps/simulator/src/__tests__/setup/eventWiring.test.ts
@@ -284,6 +284,58 @@ describe("wireEvents", () => {
 
   // ─── Replay events ────────────────────────────────────────────────
 
+  describe("geofence events", () => {
+    const fence = {
+      id: "f1",
+      name: "Zone 1",
+      type: "monitoring" as const,
+      // [lng, lat] ring around [0, 0]
+      polygon: [
+        [-1, -1],
+        [1, -1],
+        [1, 1],
+        [-1, 1],
+      ] as [number, number][],
+      active: true,
+    };
+
+    function vehicleAt(lat: number, lng: number) {
+      return {
+        id: "v1",
+        name: "Vehicle v1",
+        type: "car",
+        position: [lat, lng] as [number, number],
+        speed: 10,
+        heading: 0,
+      };
+    }
+
+    it("should broadcast and record geofence enter/exit crossings", () => {
+      geoFenceManager.addZone(fence);
+
+      geoFenceManager.checkVehicles([vehicleAt(0, 0)] as unknown as Parameters<
+        GeoFenceManager["checkVehicles"]
+      >[0]);
+      geoFenceManager.checkVehicles([vehicleAt(10, 10)] as unknown as Parameters<
+        GeoFenceManager["checkVehicles"]
+      >[0]);
+
+      const broadcast = (broadcaster.broadcast as unknown as ReturnType<typeof vi.fn>).mock.calls
+        .filter(([channel]) => channel === "geofence:event")
+        .map(([, payload]) => payload as { event: string });
+      expect(broadcast.map((e) => e.event)).toEqual(["enter", "exit"]);
+
+      const recorded = (
+        recordingManager.recordEvent as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls
+        .filter(([type]) => type === "geofence")
+        .map(([, payload]) => payload as { event: string });
+      expect(recorded.map((e) => e.event)).toEqual(["enter", "exit"]);
+      // The recorded payload is the live payload, unmodified.
+      expect(recorded).toEqual(broadcast);
+    });
+  });
+
   describe("replay events", () => {
     it("should broadcast replay vehicle events as batch", () => {
       const data = { vehicles: [{ id: "v1" }, { id: "v2" }] };
@@ -312,6 +364,20 @@ describe("wireEvents", () => {
       const data = { id: "inc1" };
       simulationController.emit("replayIncident:cleared", data);
       expect(broadcaster.broadcast).toHaveBeenCalledWith("incident:cleared", data);
+    });
+
+    it("should broadcast replay geofence:event events on the live channel", () => {
+      const data = {
+        type: "geofence:event",
+        fenceId: "f1",
+        fenceName: "Zone 1",
+        vehicleId: "v1",
+        vehicleName: "Vehicle v1",
+        event: "enter",
+        timestamp: new Date().toISOString(),
+      };
+      simulationController.emit("replayGeofence:event", data);
+      expect(broadcaster.broadcast).toHaveBeenCalledWith("geofence:event", data);
     });
 
     it("should broadcast replay heatzones events", () => {

--- a/apps/simulator/src/modules/RecordingManager.ts
+++ b/apps/simulator/src/modules/RecordingManager.ts
@@ -193,8 +193,10 @@ export class KeyframeStateAccumulator {
         this.clear();
         break;
       default:
-        // spawn / waypoint / vehicle:rerouted / simulation:start / stop are
-        // transient or already reflected by the events above.
+        // spawn / waypoint / vehicle:rerouted / geofence / simulation:start /
+        // stop are transient or already reflected by the events above. A
+        // geofence crossing is an instantaneous tick with no standing state,
+        // so a keyframe carries nothing for it.
         break;
     }
   }

--- a/apps/simulator/src/modules/ReplayManager.ts
+++ b/apps/simulator/src/modules/ReplayManager.ts
@@ -53,6 +53,7 @@ type ReplayEventMap = {
   "waypoint:reached": [unknown];
   "route:completed": [unknown];
   "vehicle:rerouted": [unknown];
+  "geofence:event": [unknown];
   "simulation:start": [unknown];
   "simulation:stop": [unknown];
   "simulation:reset": [unknown];
@@ -484,6 +485,11 @@ export class ReplayManager extends EventEmitter<ReplayEventMap> {
         break;
       case "vehicle:rerouted":
         this.emit("vehicle:rerouted", event.data);
+        break;
+      case "geofence":
+        // Re-emitted on the same channel the live run uses, so a replayed
+        // session shows the same geofence ticks the live session did.
+        this.emit("geofence:event", event.data);
         break;
       case "simulation:start":
         this.emit("simulation:start", event.data);

--- a/apps/simulator/src/modules/SimulationController.ts
+++ b/apps/simulator/src/modules/SimulationController.ts
@@ -30,6 +30,7 @@ type EventEmitterMap = {
   "replayWaypoint:reached": [unknown];
   "replayRoute:completed": [unknown];
   "replayVehicle:rerouted": [unknown];
+  "replayGeofence:event": [unknown];
   "replaySimulation:start": [unknown];
   "replaySimulation:stop": [unknown];
   "replaySimulation:reset": [unknown];
@@ -479,6 +480,7 @@ export class SimulationController extends EventEmitter<EventEmitterMap> {
       ["waypoint:reached", "replayWaypoint:reached"],
       ["route:completed", "replayRoute:completed"],
       ["vehicle:rerouted", "replayVehicle:rerouted"],
+      ["geofence:event", "replayGeofence:event"],
       ["simulation:start", "replaySimulation:start"],
       ["simulation:stop", "replaySimulation:stop"],
       ["simulation:reset", "replaySimulation:reset"],

--- a/apps/simulator/src/setup/eventWiring.ts
+++ b/apps/simulator/src/setup/eventWiring.ts
@@ -16,6 +16,7 @@ import type {
   VehicleDirection,
   Heatzone,
   IncidentDTO,
+  GeoFenceEvent,
   IncidentClearedPayload,
   WaypointReachedPayload,
   RouteCompletedPayload,
@@ -167,6 +168,12 @@ export function wireEvents(ctx: EventWiringContext): {
   incidentManager.on("incident:cleared", (data) =>
     recordingManager.recordEvent("incident", { action: "cleared", ...data })
   );
+  // Geofence crossings are point-in-time ticks with no live-state to fold, but
+  // they are a headline feature: without them a recording loses geofencing
+  // entirely and cannot be used to demo or regression-test it.
+  geoFenceManager.on("geofence:event", (event: GeoFenceEvent) =>
+    recordingManager.recordEvent("geofence", event as unknown as Record<string, unknown>)
+  );
 
   // ─── Recording metadata persistence ────────────────────────────────
   if (stateStore) {
@@ -258,6 +265,9 @@ export function wireEvents(ctx: EventWiringContext): {
   );
   simulationController.on("replayVehicle:rerouted", (data) =>
     broadcaster.broadcast("vehicle:rerouted", data as VehicleReroutedPayload)
+  );
+  simulationController.on("replayGeofence:event", (data) =>
+    broadcaster.broadcast("geofence:event", data as GeoFenceEvent)
   );
   simulationController.on("replay:status", (data) => broadcaster.broadcast("replay:status", data));
 

--- a/apps/simulator/src/types/index.ts
+++ b/apps/simulator/src/types/index.ts
@@ -231,6 +231,7 @@ export type RecordingEventType =
   | "waypoint"
   | "route:completed"
   | "vehicle:rerouted"
+  | "geofence"
   | "simulation:start"
   | "simulation:stop"
   | "simulation:reset";


### PR DESCRIPTION
## What was broken

`RecordingEventType` covered direction, waypoint, route:completed, vehicle:rerouted, incident and heatzone. Geofence enter/exit crossings were broadcast live over WebSocket (`geofence:event`) but never written into a recording, so they did not exist during replay: the session timeline (fleetsim-all-ke5r.6) renders geofence ticks from a uniform client path that worked live and went silent on replay, and a recorded session could not be used to demo or regression-test geofencing at all.

## What changed (simulator only)

Geofence events now follow exactly the same round trip an incident or heatzone already takes:

- `types/index.ts` — `"geofence"` added to `RecordingEventType`.
- `setup/eventWiring.ts` — `geoFenceManager.on("geofence:event", ...)` now also calls `recordingManager.recordEvent("geofence", event)`, next to the existing live broadcast; and `replayGeofence:event` is forwarded to `broadcaster.broadcast("geofence:event", ...)` — the same channel used live.
- `modules/ReplayManager.ts` — `"geofence:event"` added to the event map and a `case "geofence"` in `emitRecordingEvent` re-emits the recorded payload unchanged.
- `modules/SimulationController.ts` — `"replayGeofence:event"` added to the emitter map and to the replay forward table.
- `modules/RecordingManager.ts` — comment only. A crossing is an instantaneous tick with no standing state, so the keyframe accumulator deliberately carries nothing for it (falls through its `default`, as `waypoint` and `vehicle:rerouted` already do).

No UI change was needed — the issue's claim holds: `apps/ui/src/Inspector/useVehicleEventCapture.ts` subscribes to `geofence:event` on one path that is identical live and on replay, so it lights up with no edit. Dispatch-tick sourcing was deliberately left alone.

## How it was verified

New tests:

- `apps/simulator/src/__tests__/RecordingReplay.test.ts` — end-to-end: a real `GeoFenceManager` produces an enter then an exit as a vehicle crosses a polygon, a real `RecordingManager` writes the NDJSON, a real `ReplayManager` loads and plays it back, and the events emitted on `geofence:event` during replay are asserted deep-equal to the live ones. Confirmed load-bearing: removing the `case "geofence"` from `ReplayManager` makes it fail.
- `apps/simulator/src/__tests__/setup/eventWiring.test.ts` — a crossing through `wireEvents` is both broadcast and recorded with the unmodified payload, and `replayGeofence:event` is rebroadcast on the live `geofence:event` channel.

Commands run from the repo root, all passing:

- `npm run format:check` — 720 files checked, clean
- `npm run lint` — exit 0 (pre-existing warnings/infos only, none in touched files)
- `npm run type-check` — 6/6 tasks successful
- `npm run test` — exit 0; simulator 1968 passed / 3 skipped, adapter 688, ui 1459, shared-types 31, network 59, server-kit 41. No failures, flaky or otherwise, in this run.

Refs `fleetsim-all-vtwk.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gke6K2iMXPyuGLDoKWBKyt
