### PR TITLE
feat(simulator): check API specs against the code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
       # this dedicated check rather than an app's unit tests.
       - name: Repo-policy checks
         run: npm run test:repo
+      # The two API specs (openapi.yaml, asyncapi.yaml) are hand-maintained, so
+      # they drift silently unless something compares them with the code. This
+      # step does: it diffs the OpenAPI paths against the routes Express
+      # registers, the AsyncAPI messages against the WS union in
+      # packages/shared-types/src/ws.ts, and both version stamps against the
+      # simulator package version.
+      - name: API spec drift check
+        run: npm run check:api-specs
       - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,11 @@ The simulator works standalone with synthetic vehicles. The adapter is only need
   - `npm run lint` (Biome lint across the whole repo) or `npm run lint:fix` (apply safe fixes)
   - `npm run format:check` (Biome format check) or `npm run format` (write)
 - Type-checking is a separate task: `npm run type-check`.
+- API specs are checked against the code: `npm run check:api-specs` diffs
+  `apps/simulator/openapi.yaml` against the registered Express routes and
+  `apps/simulator/asyncapi.yaml` against the WebSocket union in
+  `packages/shared-types/src/ws.ts`. Update the spec in the same commit as the route or
+  message type; CI fails on drift.
 - Follow existing conventions in the codebase. When in doubt, match the style of surrounding code.
 
 ## Testing

--- a/apps/simulator/README.md
+++ b/apps/simulator/README.md
@@ -330,6 +330,21 @@ Connect to `ws://localhost:5010` for real-time updates.
 
 Beyond the endpoints shown above, the API also exposes incidents (`/incidents`), geofences (`/geofences`), fleets (`/fleets`), jobs (`/jobs`), device faults (`/faults`), analytics (`/analytics/*`), traffic (`/traffic`, `/traffic-profile`), clock (`/clock`), speed limits (`/speed-limits`), recording, replay (`/replay/status`), scenarios, and state persistence (`/state/save`, `/state/restore`, `/state/snapshots`). See the OpenAPI/Scalar reference served by the app for the full set.
 
+## API Specifications
+
+Two specs describe the simulator's surface, both at the app root:
+
+- `openapi.yaml` — the REST API (OpenAPI 3.0.3). Served raw at `/api-docs.yaml` and
+  rendered by Scalar at `/api-docs`.
+- `asyncapi.yaml` — the WebSocket surface (AsyncAPI 3.0.0). Every message type, its
+  wire `type` discriminator and its payload, with payload shapes shared with
+  `openapi.yaml` wherever the same type is served over both transports.
+
+Both are hand-maintained, so `npm run check:api-specs` (from the repo root, and a
+required CI step) compares them with the code: OpenAPI paths against the routes Express
+registers, AsyncAPI messages against the WS union in `packages/shared-types/src/ws.ts`,
+and both version stamps against this package's version. Any drift fails the build.
+
 ## Docker Usage
 
 ### Build and Run

--- a/apps/simulator/asyncapi.yaml
+++ b/apps/simulator/asyncapi.yaml
@@ -1,0 +1,1007 @@
+# ─── Moveet Simulator WebSocket API ─────────────────────────────────
+# AsyncAPI description of the simulator's WebSocket surface.
+# packages/shared-types/src/ws.ts is the source of truth for the message
+# union; `npm run check:api-specs` compares this document against it and
+# fails CI when a message type is added, removed or renamed on either side.
+asyncapi: 3.0.0
+info:
+  title: Moveet Simulator WebSocket API
+  version: 0.1.0 # x-release-please-version
+  description: |-
+    Real-time WebSocket surface of the Moveet vehicle fleet simulator.
+
+    Every frame is JSON: `{ "type": <message type>, "data": <payload> }` for
+    data-carrying messages, and `{ "type": <message type> }` for the
+    `connect`/`disconnect` control frames.
+
+    This document is checked against `packages/shared-types/src/ws.ts` — the
+    single source of truth for the message union — by
+    `npm run check:api-specs`, which fails CI on drift. Payload shapes are
+    shared with the REST contract in `openapi.yaml` wherever the same type is
+    served over both transports.
+  license:
+    name: MIT
+defaultContentType: application/json
+servers:
+  local:
+    host: localhost:5010
+    protocol: ws
+    description: Local development server (same port as the REST API)
+channels:
+  simulation:
+    address: /
+    title: Simulation stream
+    description: |-
+      The simulator's single WebSocket endpoint. All messages, in both
+      directions, flow over this one channel; `type` discriminates them.
+    messages:
+      vehicle:
+        $ref: "#/components/messages/vehicle"
+      vehicles:
+        $ref: "#/components/messages/vehicles"
+      status:
+        $ref: "#/components/messages/status"
+      options:
+        $ref: "#/components/messages/options"
+      heatzones:
+        $ref: "#/components/messages/heatzones"
+      direction:
+        $ref: "#/components/messages/direction"
+      reset:
+        $ref: "#/components/messages/reset"
+      fleetCreated:
+        $ref: "#/components/messages/fleetCreated"
+      fleetDeleted:
+        $ref: "#/components/messages/fleetDeleted"
+      fleetAssigned:
+        $ref: "#/components/messages/fleetAssigned"
+      jobCreated:
+        $ref: "#/components/messages/jobCreated"
+      jobUpdated:
+        $ref: "#/components/messages/jobUpdated"
+      jobSlaBreach:
+        $ref: "#/components/messages/jobSlaBreach"
+      jobDeleted:
+        $ref: "#/components/messages/jobDeleted"
+      waypointReached:
+        $ref: "#/components/messages/waypointReached"
+      routeCompleted:
+        $ref: "#/components/messages/routeCompleted"
+      incidentCreated:
+        $ref: "#/components/messages/incidentCreated"
+      incidentCleared:
+        $ref: "#/components/messages/incidentCleared"
+      vehicleRerouted:
+        $ref: "#/components/messages/vehicleRerouted"
+      replayStatus:
+        $ref: "#/components/messages/replayStatus"
+      generateProgress:
+        $ref: "#/components/messages/generateProgress"
+      generateComplete:
+        $ref: "#/components/messages/generateComplete"
+      generateError:
+        $ref: "#/components/messages/generateError"
+      clock:
+        $ref: "#/components/messages/clock"
+      traffic:
+        $ref: "#/components/messages/traffic"
+      analytics:
+        $ref: "#/components/messages/analytics"
+      geofenceEvent:
+        $ref: "#/components/messages/geofenceEvent"
+      scenarioStarted:
+        $ref: "#/components/messages/scenarioStarted"
+      scenarioEvent:
+        $ref: "#/components/messages/scenarioEvent"
+      scenarioPaused:
+        $ref: "#/components/messages/scenarioPaused"
+      scenarioResumed:
+        $ref: "#/components/messages/scenarioResumed"
+      scenarioCompleted:
+        $ref: "#/components/messages/scenarioCompleted"
+      scenarioStopped:
+        $ref: "#/components/messages/scenarioStopped"
+      faultsConfig:
+        $ref: "#/components/messages/faultsConfig"
+      connect:
+        $ref: "#/components/messages/connect"
+      disconnect:
+        $ref: "#/components/messages/disconnect"
+operations:
+  receiveSimulationEvents:
+    action: receive
+    channel:
+      $ref: "#/channels/simulation"
+    title: Simulation events
+    summary: Every message the simulator broadcasts to connected clients.
+    messages:
+      - $ref: "#/components/messages/vehicle"
+      - $ref: "#/components/messages/vehicles"
+      - $ref: "#/components/messages/status"
+      - $ref: "#/components/messages/options"
+      - $ref: "#/components/messages/heatzones"
+      - $ref: "#/components/messages/direction"
+      - $ref: "#/components/messages/reset"
+      - $ref: "#/components/messages/fleetCreated"
+      - $ref: "#/components/messages/fleetDeleted"
+      - $ref: "#/components/messages/fleetAssigned"
+      - $ref: "#/components/messages/jobCreated"
+      - $ref: "#/components/messages/jobUpdated"
+      - $ref: "#/components/messages/jobSlaBreach"
+      - $ref: "#/components/messages/jobDeleted"
+      - $ref: "#/components/messages/waypointReached"
+      - $ref: "#/components/messages/routeCompleted"
+      - $ref: "#/components/messages/incidentCreated"
+      - $ref: "#/components/messages/incidentCleared"
+      - $ref: "#/components/messages/vehicleRerouted"
+      - $ref: "#/components/messages/replayStatus"
+      - $ref: "#/components/messages/generateProgress"
+      - $ref: "#/components/messages/generateComplete"
+      - $ref: "#/components/messages/generateError"
+      - $ref: "#/components/messages/clock"
+      - $ref: "#/components/messages/traffic"
+      - $ref: "#/components/messages/analytics"
+      - $ref: "#/components/messages/geofenceEvent"
+      - $ref: "#/components/messages/scenarioStarted"
+      - $ref: "#/components/messages/scenarioEvent"
+      - $ref: "#/components/messages/scenarioPaused"
+      - $ref: "#/components/messages/scenarioResumed"
+      - $ref: "#/components/messages/scenarioCompleted"
+      - $ref: "#/components/messages/scenarioStopped"
+      - $ref: "#/components/messages/faultsConfig"
+      - $ref: "#/components/messages/connect"
+      - $ref: "#/components/messages/disconnect"
+  sendClientCommands:
+    action: send
+    channel:
+      $ref: "#/channels/simulation"
+    title: Client commands
+    summary: Messages a client may send. Unknown or malformed frames are ignored by the server.
+    messages:
+      - $ref: "#/components/messages/subscribe"
+components:
+  messages:
+    vehicle:
+      name: vehicle
+      title: Vehicle state update
+      summary: A single vehicle moved or changed state. The highest-volume channel.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: vehicle
+          data:
+            $ref: ./openapi.yaml#/components/schemas/VehicleDTO
+    vehicles:
+      name: vehicles
+      title: Vehicle batch update
+      summary: A batch of vehicle states, sent when several vehicles change within one flush window.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: vehicles
+          data:
+            type: array
+            items:
+              $ref: ./openapi.yaml#/components/schemas/VehicleDTO
+    status:
+      name: status
+      title: Simulation status
+      summary: The simulation started, stopped, or changed tick interval.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: status
+          data:
+            $ref: ./openapi.yaml#/components/schemas/SimulationStatus
+    options:
+      name: options
+      title: Simulation options
+      summary: The active simulation options changed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: options
+          data:
+            $ref: ./openapi.yaml#/components/schemas/StartOptions
+    heatzones:
+      name: heatzones
+      title: Heat zones
+      summary: The full current set of heat zones.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: heatzones
+          data:
+            type: array
+            items:
+              $ref: ./openapi.yaml#/components/schemas/HeatZoneFeature
+    direction:
+      name: direction
+      title: Vehicle direction
+      summary: A vehicle was given a new route, by dispatch, waypoints, wander or an incident reroute.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: direction
+          data:
+            $ref: "#/components/schemas/VehicleDirection"
+    reset:
+      name: reset
+      title: Simulation reset
+      summary: "The simulation was reset: a full snapshot of vehicles and their active routes."
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: reset
+          data:
+            $ref: "#/components/schemas/ResetPayload"
+    fleetCreated:
+      name: fleet:created
+      title: Fleet created
+      summary: A fleet was created.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: fleet:created
+          data:
+            $ref: ./openapi.yaml#/components/schemas/Fleet
+    fleetDeleted:
+      name: fleet:deleted
+      title: Fleet deleted
+      summary: A fleet was deleted.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: fleet:deleted
+          data:
+            $ref: "#/components/schemas/FleetDeletedPayload"
+    fleetAssigned:
+      name: fleet:assigned
+      title: Fleet assignment changed
+      summary: Vehicles were assigned to a fleet, or unassigned when `fleetId` is null.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: fleet:assigned
+          data:
+            $ref: "#/components/schemas/FleetAssignedPayload"
+    jobCreated:
+      name: job:created
+      title: Job created
+      summary: A delivery job was created.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: job:created
+          data:
+            $ref: ./openapi.yaml#/components/schemas/Job
+    jobUpdated:
+      name: job:updated
+      title: Job updated
+      summary: "Any job lifecycle transition: assignment, status change, or SLA flag flip."
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: job:updated
+          data:
+            $ref: ./openapi.yaml#/components/schemas/Job
+    jobSlaBreach:
+      name: job:sla-breach
+      title: Job SLA breached
+      summary: Fires once, the moment a job passes its SLA deadline unfinished.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: job:sla-breach
+          data:
+            $ref: ./openapi.yaml#/components/schemas/Job
+    jobDeleted:
+      name: job:deleted
+      title: Job deleted
+      summary: A job was deleted.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: job:deleted
+          data:
+            $ref: "#/components/schemas/JobDeletedPayload"
+    waypointReached:
+      name: waypoint:reached
+      title: Waypoint reached
+      summary: A vehicle reached one of the waypoints on its multi-stop route.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: waypoint:reached
+          data:
+            $ref: "#/components/schemas/WaypointReachedPayload"
+    routeCompleted:
+      name: route:completed
+      title: Route completed
+      summary: A vehicle finished its route.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: route:completed
+          data:
+            $ref: "#/components/schemas/RouteCompletedPayload"
+    incidentCreated:
+      name: incident:created
+      title: Incident created
+      summary: A road incident was created.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: incident:created
+          data:
+            $ref: ./openapi.yaml#/components/schemas/IncidentDTO
+    incidentCleared:
+      name: incident:cleared
+      title: Incident cleared
+      summary: A road incident expired or was removed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: incident:cleared
+          data:
+            $ref: "#/components/schemas/IncidentClearedPayload"
+    vehicleRerouted:
+      name: vehicle:rerouted
+      title: Vehicle rerouted
+      summary: A vehicle was rerouted around an incident, keeping the same destination.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: vehicle:rerouted
+          data:
+            $ref: "#/components/schemas/VehicleReroutedPayload"
+    replayStatus:
+      name: replay:status
+      title: Replay status
+      summary: Playback mode or position changed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: replay:status
+          data:
+            $ref: ./openapi.yaml#/components/schemas/ReplayStatus
+    generateProgress:
+      name: generate:progress
+      title: Generation progress
+      summary: Progress of a headless historical recording generation job.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: generate:progress
+          data:
+            $ref: "#/components/schemas/GenerateProgressPayload"
+    generateComplete:
+      name: generate:complete
+      title: Generation complete
+      summary: A headless generation job finished and produced a recording.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: generate:complete
+          data:
+            $ref: "#/components/schemas/GenerateCompletePayload"
+    generateError:
+      name: generate:error
+      title: Generation failed
+      summary: A headless generation job failed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: generate:error
+          data:
+            $ref: "#/components/schemas/GenerateErrorPayload"
+    clock:
+      name: clock
+      title: Simulation clock
+      summary: The simulated clock ticked or its speed multiplier changed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: clock
+          data:
+            $ref: ./openapi.yaml#/components/schemas/ClockState
+    traffic:
+      name: traffic
+      title: Traffic snapshot
+      summary: Per-edge congestion snapshot, broadcast on an interval.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: traffic
+          data:
+            type: array
+            items:
+              $ref: ./openapi.yaml#/components/schemas/TrafficEdge
+    analytics:
+      name: analytics
+      title: Analytics snapshot
+      summary: Fleet-wide analytics, broadcast on an interval.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: analytics
+          data:
+            $ref: "#/components/schemas/AnalyticsSnapshot"
+    geofenceEvent:
+      name: geofence:event
+      title: Geofence event
+      summary: A vehicle entered or exited a geofence.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: geofence:event
+          data:
+            $ref: "#/components/schemas/GeoFenceEvent"
+    scenarioStarted:
+      name: scenario:started
+      title: Scenario started
+      summary: A scenario run started.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: scenario:started
+          data:
+            $ref: "#/components/schemas/ScenarioEventPayload"
+    scenarioEvent:
+      name: scenario:event
+      title: Scenario event executed
+      summary: A scenario step was executed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: scenario:event
+          data:
+            $ref: "#/components/schemas/ScenarioEventPayload"
+    scenarioPaused:
+      name: scenario:paused
+      title: Scenario paused
+      summary: A scenario run was paused.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: scenario:paused
+          data:
+            $ref: "#/components/schemas/ScenarioEventPayload"
+    scenarioResumed:
+      name: scenario:resumed
+      title: Scenario resumed
+      summary: A paused scenario run resumed.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: scenario:resumed
+          data:
+            $ref: "#/components/schemas/ScenarioEventPayload"
+    scenarioCompleted:
+      name: scenario:completed
+      title: Scenario completed
+      summary: A scenario run ran to completion.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: scenario:completed
+          data:
+            $ref: "#/components/schemas/ScenarioEventPayload"
+    scenarioStopped:
+      name: scenario:stopped
+      title: Scenario stopped
+      summary: A scenario run was stopped before completion.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: scenario:stopped
+          data:
+            $ref: "#/components/schemas/ScenarioEventPayload"
+    faultsConfig:
+      name: faults:config
+      title: Device fault configuration
+      summary: The device fault-injection configuration changed, at startup or at runtime.
+      payload:
+        type: object
+        required:
+          - type
+          - data
+        properties:
+          type:
+            type: string
+            const: faults:config
+          data:
+            $ref: ./openapi.yaml#/components/schemas/DeviceFaultConfig
+    connect:
+      name: connect
+      title: Connected
+      summary: "Control frame: the client is connected. Carries no data."
+      payload:
+        type: object
+        required:
+          - type
+        properties:
+          type:
+            type: string
+            const: connect
+    disconnect:
+      name: disconnect
+      title: Disconnected
+      summary: "Control frame: the connection was closed. Carries no data."
+      payload:
+        type: object
+        required:
+          - type
+        properties:
+          type:
+            type: string
+            const: disconnect
+    subscribe:
+      name: subscribe
+      title: Subscribe filter
+      summary: Narrows the vehicle stream for this client. A null or absent `filter` clears filtering; an unparseable filter is rejected and the previous one kept.
+      payload:
+        type: object
+        required:
+          - type
+        properties:
+          type:
+            type: string
+            const: subscribe
+          filter:
+            oneOf:
+              - $ref: "#/components/schemas/SubscribeFilter"
+              - type: "null"
+  schemas:
+    VehicleDirection:
+      type: object
+      description: A vehicle's active route and ETA.
+      required:
+        - vehicleId
+        - route
+      properties:
+        vehicleId:
+          type: string
+        route:
+          $ref: ./openapi.yaml#/components/schemas/Route
+        eta:
+          type: number
+          description: Seconds to destination.
+        waypoints:
+          type: array
+          items:
+            $ref: ./openapi.yaml#/components/schemas/Waypoint
+        currentWaypointIndex:
+          type: integer
+        reason:
+          type: string
+          enum:
+            - dispatch
+            - waypoints
+            - random
+            - reroute
+          description: Why the route was set. Absent on a reset-time snapshot, which describes an existing route rather than a change.
+    ResetPayload:
+      type: object
+      required:
+        - vehicles
+        - directions
+      properties:
+        vehicles:
+          type: array
+          items:
+            $ref: ./openapi.yaml#/components/schemas/VehicleDTO
+        directions:
+          type: array
+          items:
+            $ref: "#/components/schemas/VehicleDirection"
+    FleetDeletedPayload:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    FleetAssignedPayload:
+      type: object
+      required:
+        - fleetId
+        - vehicleIds
+      properties:
+        fleetId:
+          oneOf:
+            - type: string
+            - type: "null"
+          description: Null when the vehicles were unassigned.
+        vehicleIds:
+          type: array
+          items:
+            type: string
+    JobDeletedPayload:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+    WaypointReachedPayload:
+      type: object
+      required:
+        - vehicleId
+        - waypointIndex
+        - remaining
+      properties:
+        vehicleId:
+          type: string
+        waypointIndex:
+          type: integer
+        waypointLabel:
+          type: string
+        remaining:
+          type: integer
+          description: Waypoints still ahead.
+    RouteCompletedPayload:
+      type: object
+      required:
+        - vehicleId
+      properties:
+        vehicleId:
+          type: string
+    IncidentClearedPayload:
+      type: object
+      required:
+        - id
+        - reason
+      properties:
+        id:
+          type: string
+        reason:
+          type: string
+    VehicleReroutedPayload:
+      type: object
+      required:
+        - vehicleId
+        - incidentId
+      properties:
+        vehicleId:
+          type: string
+        incidentId:
+          type: string
+    GenerateProgressPayload:
+      type: object
+      required:
+        - jobId
+        - step
+        - totalSteps
+        - pct
+      properties:
+        jobId:
+          type: string
+        step:
+          type: integer
+        totalSteps:
+          type: integer
+        pct:
+          type: number
+          minimum: 0
+          maximum: 100
+    GeneratedRecording:
+      type: object
+      description: Recording metadata for a headlessly generated session.
+      required:
+        - filePath
+        - duration
+        - eventCount
+        - fileSize
+        - vehicleCount
+        - startTime
+      properties:
+        id:
+          type: integer
+          description: Row id, when persistence is enabled.
+        filePath:
+          type: string
+        duration:
+          type: number
+          description: Milliseconds of simulated time.
+        eventCount:
+          type: integer
+        fileSize:
+          type: integer
+          description: Bytes.
+        vehicleCount:
+          type: integer
+        startTime:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+    GenerateCompletePayload:
+      type: object
+      required:
+        - jobId
+        - recording
+      properties:
+        jobId:
+          type: string
+        recording:
+          $ref: "#/components/schemas/GeneratedRecording"
+    GenerateErrorPayload:
+      type: object
+      required:
+        - jobId
+        - error
+      properties:
+        jobId:
+          type: string
+        error:
+          type: string
+    AnalyticsSnapshot:
+      type: object
+      required:
+        - summary
+        - fleets
+        - timestamp
+      properties:
+        summary:
+          $ref: ./openapi.yaml#/components/schemas/AnalyticsSummary
+        fleets:
+          type: array
+          items:
+            $ref: ./openapi.yaml#/components/schemas/FleetAnalytics
+        timestamp:
+          type: integer
+          description: Epoch milliseconds.
+    GeoFenceEvent:
+      type: object
+      required:
+        - type
+        - fenceId
+        - fenceName
+        - vehicleId
+        - vehicleName
+        - event
+        - timestamp
+      properties:
+        type:
+          type: string
+          const: geofence:event
+        fenceId:
+          type: string
+        fenceName:
+          type: string
+        vehicleId:
+          type: string
+        vehicleName:
+          type: string
+        event:
+          type: string
+          enum:
+            - enter
+            - exit
+        timestamp:
+          type: string
+          format: date-time
+    ScenarioEventPayload:
+      type: object
+      description: Loosely-typed payload shared by every `scenario:*` message; which fields are present depends on the lifecycle stage.
+      properties:
+        type:
+          type: string
+        index:
+          type: integer
+        at:
+          type: number
+          description: Offset in milliseconds from scenario start.
+        action:
+          type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+        name:
+          type: string
+        eventCount:
+          type: integer
+        elapsed:
+          type: number
+        eventsExecuted:
+          type: integer
+    BoundingBox:
+      type: object
+      required:
+        - minLat
+        - maxLat
+        - minLng
+        - maxLng
+      properties:
+        minLat:
+          type: number
+        maxLat:
+          type: number
+        minLng:
+          type: number
+        maxLng:
+          type: number
+    SubscribeFilter:
+      type: object
+      description: Every criterion is optional; an omitted criterion filters nothing.
+      properties:
+        fleetIds:
+          type: array
+          items:
+            type: string
+          description: Only vehicles in these fleets. Vehicles with no fleet are excluded.
+        vehicleTypes:
+          type: array
+          items:
+            $ref: ./openapi.yaml#/components/schemas/VehicleType
+        bbox:
+          $ref: "#/components/schemas/BoundingBox"

--- a/apps/simulator/openapi.yaml
+++ b/apps/simulator/openapi.yaml
@@ -5,7 +5,7 @@ info:
     REST API for the Moveet vehicle fleet simulation engine.
     Simulates vehicle movement on real road networks (OpenStreetMap) with
     A* pathfinding, heat zones, incidents, recording/replay, and fleet management.
-  version: 0.0.4
+  version: 0.1.0 # x-release-please-version
   license:
     name: MIT
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "esbuild": "0.28.2",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
-        "turbo": "^2.10.10"
+        "turbo": "^2.10.10",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=26"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "type-check": "turbo type-check",
     "test:commitlint": "node --test commitlint.config.test.mjs",
     "test:repo": "vitest run --config vitest.repo-policy.config.ts",
+    "check:api-specs": "node scripts/check-api-specs.mjs",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "prepare": "husky"
   },
@@ -41,7 +42,8 @@
     "esbuild": "0.28.2",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "turbo": "^2.10.10"
+    "turbo": "^2.10.10",
+    "yaml": "^2.9.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc,css}": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,9 @@
       "extra-files": [
         "apps/simulator/package.json",
         "apps/adapter/package.json",
-        "apps/ui/package.json"
+        "apps/ui/package.json",
+        { "type": "generic", "path": "apps/simulator/openapi.yaml" },
+        { "type": "generic", "path": "apps/simulator/asyncapi.yaml" }
       ]
     }
   }

--- a/scripts/check-api-specs.mjs
+++ b/scripts/check-api-specs.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+// ─── API specification drift check ──────────────────────────────────
+//
+// Both simulator API specs are hand-maintained, so nothing stops them from
+// silently falling behind the code. This script is the thing that stops it:
+//
+//   1. apps/simulator/openapi.yaml must describe exactly the routes the
+//      Express app registers — no undocumented route, no phantom path.
+//   2. apps/simulator/asyncapi.yaml must describe exactly the WebSocket
+//      message types declared in packages/shared-types/src/ws.ts, which is
+//      the single source of truth for the WS contract.
+//   3. Both specs must be stamped with the simulator package version.
+//
+// Any mismatch prints the offending entries and exits non-zero, so CI fails
+// on drift instead of letting the specs rot.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const simulatorDir = path.join(repoRoot, "apps", "simulator");
+const OPENAPI_PATH = path.join(simulatorDir, "openapi.yaml");
+const ASYNCAPI_PATH = path.join(simulatorDir, "asyncapi.yaml");
+const WS_TYPES_PATH = path.join(repoRoot, "packages", "shared-types", "src", "ws.ts");
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete"];
+
+/**
+ * Infrastructure routes served straight from index.ts that are deliberately
+ * absent from the OpenAPI document: the health probe, the raw spec download,
+ * the Scalar docs UI and the Prometheus scrape endpoint.
+ */
+const UNDOCUMENTED_INFRA_ROUTES = new Set(["GET /health", "GET /api-docs.yaml", "GET /metrics"]);
+
+/** Inbound (client -> server) WS message types, not part of WsMessageMap. */
+const INBOUND_WS_TYPES = new Set(["subscribe"]);
+
+const failures = [];
+
+function fail(message, entries = []) {
+  failures.push({ message, entries });
+}
+
+function readYaml(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Spec not found: ${path.relative(repoRoot, filePath)}`);
+  }
+  return YAML.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function diff(actual, expected) {
+  return {
+    missing: [...expected].filter((x) => !actual.has(x)).sort(),
+    extra: [...actual].filter((x) => !expected.has(x)).sort(),
+  };
+}
+
+// ─── REST: routes the Express app actually registers ────────────────
+
+/**
+ * Collects `METHOD /path` for every route handler registered in index.ts or
+ * any file under src/routes. Route modules are mounted with `app.use(router)`
+ * and therefore carry no path prefix, so the literal passed to `.get(...)` &c
+ * is the full path.
+ */
+function extractRoutesFromSource() {
+  const routesDir = path.join(simulatorDir, "src", "routes");
+  const files = [
+    path.join(simulatorDir, "src", "index.ts"),
+    ...fs.readdirSync(routesDir).map((f) => path.join(routesDir, f)),
+  ].filter((f) => f.endsWith(".ts"));
+
+  const routeRegex = /\.(get|post|put|patch|delete)\(\s*["'`]([^"'`]+)["'`]/g;
+  const routes = new Set();
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf-8");
+    for (const match of source.matchAll(routeRegex)) {
+      const key = `${match[1].toUpperCase()} ${match[2]}`;
+      if (!UNDOCUMENTED_INFRA_ROUTES.has(key)) routes.add(key);
+    }
+  }
+  return routes;
+}
+
+/** Collects `METHOD /path` from the OpenAPI document, in Express notation. */
+function extractRoutesFromOpenApi(spec) {
+  const routes = new Set();
+  for (const [pathStr, operations] of Object.entries(spec.paths ?? {})) {
+    for (const method of Object.keys(operations)) {
+      if (!HTTP_METHODS.includes(method)) continue;
+      routes.add(`${method.toUpperCase()} ${pathStr.replace(/\{(\w+)\}/g, ":$1")}`);
+    }
+  }
+  return routes;
+}
+
+// ─── WS: the message union declared in shared-types ─────────────────
+
+/** Returns the text between the first balanced `open`/`close` pair after `header`. */
+function sliceBlock(source, header, open = "{", close = "}") {
+  const start = source.indexOf(header);
+  if (start === -1) throw new Error(`Could not find \`${header}\` in ws.ts`);
+  const from = source.indexOf(open, start);
+  if (from === -1) throw new Error(`No \`${open}\` after \`${header}\` in ws.ts`);
+  let depth = 0;
+  for (let i = from; i < source.length; i++) {
+    if (source[i] === open) depth++;
+    else if (source[i] === close && --depth === 0) return source.slice(from + 1, i);
+  }
+  throw new Error(`Unterminated block for \`${header}\` in ws.ts`);
+}
+
+/** Property keys of the `WsMessageMap` interface — the data-carrying types. */
+function extractDataMessageTypes(source) {
+  const body = sliceBlock(source, "export interface WsMessageMap");
+  const types = new Set();
+  for (const line of body.split("\n")) {
+    const match = line.match(/^\s*"?([A-Za-z][\w:-]*)"?\s*:/);
+    if (match) types.add(match[1]);
+  }
+  return types;
+}
+
+/** The runtime `DATA_MESSAGE_TYPES` set literal, used to cross-check the map. */
+function extractRuntimeMessageTypes(source) {
+  const body = sliceBlock(source, "const DATA_MESSAGE_TYPES", "[", "]");
+  return new Set([...body.matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+/** The `WsControlMessageType` union members (`connect` / `disconnect`). */
+function extractControlMessageTypes(source) {
+  const match = source.match(/export type WsControlMessageType\s*=([^;]+);/);
+  if (!match) throw new Error("Could not find `WsControlMessageType` in ws.ts");
+  return new Set([...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+/**
+ * The wire `type` of an AsyncAPI message, read from the const-discriminated
+ * `type` property of its payload rather than from the component key, so the
+ * check is against what a client would actually see on the wire.
+ */
+function messageWireType(spec, ref) {
+  const key = ref.replace("#/components/messages/", "");
+  const message = spec.components?.messages?.[key];
+  if (!message) throw new Error(`AsyncAPI operation references unknown message: ${ref}`);
+  const wireType = message.payload?.properties?.type?.const;
+  if (typeof wireType !== "string") {
+    throw new Error(`AsyncAPI message \`${key}\` has no payload.properties.type.const`);
+  }
+  return { key, wireType, message };
+}
+
+function operationMessageTypes(spec, operationName) {
+  const operation = spec.operations?.[operationName];
+  if (!operation) throw new Error(`AsyncAPI operation \`${operationName}\` is missing`);
+  return (operation.messages ?? []).map((m) => messageWireType(spec, m.$ref));
+}
+
+// ─── Checks ─────────────────────────────────────────────────────────
+
+function checkOpenApi(openapi, expectedVersion) {
+  const sourceRoutes = extractRoutesFromSource();
+  const specRoutes = extractRoutesFromOpenApi(openapi);
+  const { missing, extra } = diff(specRoutes, sourceRoutes);
+
+  if (missing.length) fail("Routes implemented but missing from openapi.yaml", missing);
+  if (extra.length) fail("Paths in openapi.yaml with no matching Express route", extra);
+
+  if (openapi.info?.version !== expectedVersion) {
+    fail(
+      `openapi.yaml info.version is "${openapi.info?.version}" but @moveet/simulator is at "${expectedVersion}"`
+    );
+  }
+
+  for (const [pathStr, operations] of Object.entries(openapi.paths ?? {})) {
+    for (const [method, operation] of Object.entries(operations)) {
+      if (!HTTP_METHODS.includes(method)) continue;
+      if (!operation.operationId) {
+        fail(`Operation without an operationId: ${method.toUpperCase()} ${pathStr}`);
+      }
+      if (!operation.responses || !Object.keys(operation.responses).length) {
+        fail(`Operation without responses: ${method.toUpperCase()} ${pathStr}`);
+      }
+    }
+  }
+  return sourceRoutes.size;
+}
+
+/**
+ * Walks a document collecting every `$ref`, so the AsyncAPI document's own
+ * schemas and its cross-file references into openapi.yaml can be resolved.
+ */
+function collectRefs(node, acc = []) {
+  if (Array.isArray(node)) {
+    for (const item of node) collectRefs(item, acc);
+  } else if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$ref" && typeof value === "string") acc.push(value);
+      else collectRefs(value, acc);
+    }
+  }
+  return acc;
+}
+
+function resolvePointer(doc, pointer) {
+  return pointer
+    .split("/")
+    .slice(1)
+    .reduce((node, segment) => node?.[segment.replace(/~1/g, "/").replace(/~0/g, "~")], doc);
+}
+
+/** Fails for any `$ref` in the AsyncAPI document that does not resolve. */
+function checkAsyncApiRefs(asyncapi, openapi) {
+  for (const ref of new Set(collectRefs(asyncapi))) {
+    const [file, pointer] = ref.split("#");
+    if (file && file !== "./openapi.yaml") {
+      fail(`asyncapi.yaml references an unknown document: ${ref}`);
+      continue;
+    }
+    const target = file ? openapi : asyncapi;
+    if (resolvePointer(target, pointer) === undefined) {
+      fail(`Unresolvable $ref in asyncapi.yaml: ${ref}`);
+    }
+  }
+}
+
+function checkAsyncApi(asyncapi, expectedVersion) {
+  const wsSource = fs.readFileSync(WS_TYPES_PATH, "utf-8");
+  const dataTypes = extractDataMessageTypes(wsSource);
+  const runtimeTypes = extractRuntimeMessageTypes(wsSource);
+  const controlTypes = extractControlMessageTypes(wsSource);
+
+  // ws.ts internal consistency: the runtime validator set must match the
+  // compile-time map, or `isValidMessage` silently rejects valid frames.
+  const runtimeDrift = diff(runtimeTypes, dataTypes);
+  if (runtimeDrift.missing.length) {
+    fail("WsMessageMap keys absent from the DATA_MESSAGE_TYPES runtime set", runtimeDrift.missing);
+  }
+  if (runtimeDrift.extra.length) {
+    fail("DATA_MESSAGE_TYPES entries absent from WsMessageMap", runtimeDrift.extra);
+  }
+
+  const expectedOutbound = new Set([...dataTypes, ...controlTypes]);
+  const outbound = operationMessageTypes(asyncapi, "receiveSimulationEvents");
+  const outboundTypes = new Set(outbound.map((m) => m.wireType));
+  const outboundDrift = diff(outboundTypes, expectedOutbound);
+
+  if (outboundDrift.missing.length) {
+    fail("WS message types in shared-types but missing from asyncapi.yaml", outboundDrift.missing);
+  }
+  if (outboundDrift.extra.length) {
+    fail("Messages in asyncapi.yaml with no type in shared-types", outboundDrift.extra);
+  }
+
+  // Data-carrying frames must document a `data` payload; control frames must not.
+  for (const { key, wireType, message } of outbound) {
+    const hasData = Boolean(message.payload?.properties?.data);
+    if (dataTypes.has(wireType) && !hasData) {
+      fail(
+        `AsyncAPI message \`${key}\` carries data in shared-types but documents no payload.data`
+      );
+    }
+    if (controlTypes.has(wireType) && hasData) {
+      fail(`AsyncAPI message \`${key}\` is a control frame but documents a payload.data`);
+    }
+  }
+
+  const inbound = operationMessageTypes(asyncapi, "sendClientCommands");
+  const inboundDrift = diff(new Set(inbound.map((m) => m.wireType)), INBOUND_WS_TYPES);
+  if (inboundDrift.missing.length) {
+    fail("Inbound WS message types missing from asyncapi.yaml", inboundDrift.missing);
+  }
+  if (inboundDrift.extra.length) {
+    fail("Inbound messages in asyncapi.yaml the server does not handle", inboundDrift.extra);
+  }
+
+  if (asyncapi.info?.version !== expectedVersion) {
+    fail(
+      `asyncapi.yaml info.version is "${asyncapi.info?.version}" but @moveet/simulator is at "${expectedVersion}"`
+    );
+  }
+  return outboundTypes.size;
+}
+
+// ─── Entry point ────────────────────────────────────────────────────
+
+function main() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(simulatorDir, "package.json"), "utf-8"));
+  const openapi = readYaml(OPENAPI_PATH);
+  const asyncapi = readYaml(ASYNCAPI_PATH);
+
+  const routeCount = checkOpenApi(openapi, pkg.version);
+  const messageCount = checkAsyncApi(asyncapi, pkg.version);
+  checkAsyncApiRefs(asyncapi, openapi);
+
+  if (failures.length) {
+    console.error("API spec drift detected:\n");
+    for (const { message, entries } of failures) {
+      console.error(`  ✗ ${message}`);
+      for (const entry of entries) console.error(`      - ${entry}`);
+    }
+    console.error(
+      "\nUpdate apps/simulator/openapi.yaml / apps/simulator/asyncapi.yaml to match the code."
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `API specs match the code: ${routeCount} REST routes, ${messageCount} WebSocket message types.`
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`API spec check failed: ${err instanceof Error ? err.message : err}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes the spec-drift half of `fleetsim-all-mxzc.7`.

## What had drifted

- `apps/simulator/openapi.yaml` was stamped `info.version: 0.0.4` while `@moveet/simulator` had moved to `0.1.0`, and nothing bumped it on release.
- There was no spec at all for the WebSocket surface, even though `packages/shared-types/src/ws.ts` already holds the message union as a single source of truth.
- The route set itself turned out **not** to have drifted: `apps/simulator/src/__tests__/openapi.test.ts` already diffs Express routes against the spec both ways, and it is green. That check stays where it is; this PR does not weaken it.

## What the check does

`scripts/check-api-specs.mjs` (`npm run check:api-specs`) is a standalone, dependency-light checker that exits non-zero on any of:

- a route the Express app registers that `openapi.yaml` does not document (health, `/api-docs.yaml` and `/metrics` are explicitly excluded as infra);
- a path in `openapi.yaml` with no matching Express route;
- an operation with no `operationId` or no `responses`;
- a WS message type in `ws.ts` missing from `asyncapi.yaml`, or an AsyncAPI message with no counterpart in `ws.ts` — compared on the wire `type` discriminator (`payload.properties.type.const`), not on the component key;
- a `WsMessageMap` key that has drifted from the runtime `DATA_MESSAGE_TYPES` set inside `ws.ts` itself (that pair silently breaks `isValidMessage`);
- a data-carrying message documented without `data`, or a control frame documented with one;
- an inbound message the server does not actually handle (only `subscribe` is);
- an unresolvable `$ref` in `asyncapi.yaml`, including its cross-file refs into `openapi.yaml`;
- either spec's `info.version` not matching the simulator package version.

It runs as its own `API spec drift check` step in the `verify` job of `.github/workflows/ci.yml`.

## What was fixed

- `openapi.yaml` version stamped `0.1.0`.
- Both specs annotated with `x-release-please-version` and added to `release-please-config.json` `extra-files`, so the version check does not go red on every release PR.
- New `apps/simulator/asyncapi.yaml` (AsyncAPI 3.0.0) covering all 36 outbound messages — the 34 `WsMessageMap` types plus the `connect`/`disconnect` control frames — and the inbound `subscribe` filter. Payload shapes `$ref` into `openapi.yaml` wherever the same type is served over both transports, and are defined locally for the WS-only payloads (`VehicleDirection`, `ResetPayload`, the `generate:*` payloads, `ScenarioEventPayload`, `GeoFenceEvent`, `SubscribeFilter`, …), so nothing is duplicated.
- Documented in `apps/simulator/README.md` and `CONTRIBUTING.md`.

No route behaviour was changed.

## What remains

- The specs are still **hand-maintained**; this PR adds a check with teeth, not full codegen from `shared-types`. Generating 2900 lines of OpenAPI from the TS types is a larger piece of work and is deliberately not attempted here.
- The check verifies the **shape of the surface** (which routes, which messages, which payload keys exist), not that every documented request/response *schema* still matches the TypeScript type. A field renamed inside `VehicleDTO` would still pass. Structural payload equivalence would need the codegen above, or a type-to-JSON-Schema pass.
- `packages/shared-types` is still at `0.0.4` while the apps are at `0.1.0`; that is pre-existing and out of scope here, and deliberately not what the spec version is checked against (the specs describe the simulator).

## Verification

Run locally from a clean `npm ci`:

- `npm run format:check` — pass
- `npm run lint` (Biome) — pass, exit 0
- `npm run type-check` — 6/6 tasks pass
- `npm run test` — 6/6 tasks pass (one earlier run hit the known flaky supertest port race in `@moveet/simulator`; the suite passes standalone, 1965 passed / 3 skipped, and green on re-run)
- `npm run test:repo` — 12/12 pass
- `npm run check:api-specs` — `API specs match the code: 85 REST routes, 36 WebSocket message types.`

Negative test: deleting the `/vehicle-types` path from `openapi.yaml` and the `clock` message from the AsyncAPI receive operation made the check exit 1 with both reported by name; breaking one cross-file `$ref` likewise exited 1. Reverting restored a green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gke6K2iMXPyuGLDoKWBKyt
