### PR TITLE
fix(simulator): close the ephemeral-port race in supertest route tests

### DIFF
--- a/apps/simulator/src/__tests__/setup/supertestLoopback.test.ts
+++ b/apps/simulator/src/__tests__/setup/supertestLoopback.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { AddressInfo, Server } from "node:net";
+
+/**
+ * Guards the setup file next to this one (see it for the full diagnosis of
+ * fleetsim-all-vtwk.13). If the patch stops being applied — setup file dropped
+ * from vitest.config.ts, supertest internals renamed — supertest silently goes
+ * back to connecting to `127.0.0.1` on a port it allocated in the IPv6 table,
+ * and the cross-process port collision comes back as a rare "Parse Error:
+ * Expected HTTP/, RTSP/ or ICE/". That is exactly the kind of failure nobody
+ * traces twice, so assert it here where it fails loudly instead.
+ */
+describe("supertest loopback setup", () => {
+  const app = express();
+  app.get("/ping", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  it("connects on the address family the server actually bound", async () => {
+    const test = request(app).get("/ping");
+    const server = test.app as unknown as Server;
+    const address = server.address() as AddressInfo | string | null;
+    const family = address && typeof address === "object" ? address.family : "unknown";
+
+    if (family === "IPv6") {
+      expect(test.url).toMatch(/^http:\/\/\[::1\]:\d+\/ping$/);
+    } else {
+      // No IPv6 on this host: the hostless listen fell back to 0.0.0.0, so the
+      // IPv4 URL supertest builds already matches the bind.
+      expect(test.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/ping$/);
+    }
+
+    const res = await test;
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/apps/simulator/src/__tests__/setup/supertestLoopback.ts
+++ b/apps/simulator/src/__tests__/setup/supertestLoopback.ts
@@ -1,0 +1,67 @@
+/**
+ * Makes supertest connect on the same address family it listened on.
+ *
+ * Why this exists (fleetsim-all-vtwk.13):
+ *
+ * `request(app)` calls `app.listen(0)` with no host and then hard-codes its URL
+ * as `http://127.0.0.1:<port>`. Those two halves disagree about the address
+ * family. A hostless `listen(0)` binds the IPv6 wildcard `::` (dual-stack), so
+ * the kernel picks the ephemeral port out of the IPv6 table — where it cannot
+ * see sockets that some *other* local process has bound IPv4-only on
+ * `127.0.0.1`. `listen(0)` therefore happily hands back a port that is already
+ * occupied on IPv4 loopback, and supertest's IPv4 connect lands on that foreign
+ * process instead of on the test's own server.
+ *
+ * Diagnosed by dumping the raw bytes that came back on a failing connection:
+ * they were a MySQL 8.0.33 handshake greeting from an unrelated local server,
+ * not HTTP. llhttp reports that as `Parse Error: Expected HTTP/, RTSP/ or ICE/`,
+ * which is the intermittent failure this fixes. Nothing was actually crossed
+ * between vitest workers — the workers only make it frequent, because the 23
+ * supertest files draw hundreds of ephemeral ports per run in parallel and one
+ * of them eventually lands on an occupied one.
+ *
+ * Connecting to `[::1]` when the server bound IPv6 closes the hole: that port
+ * came from the IPv6 table, so the kernel guarantees no other process holds it,
+ * and the connection can only reach our own server. Every route test keeps
+ * running in parallel — no serialisation, no shared-server bookkeeping, no
+ * retries.
+ *
+ * Rewriting the *bind* to `127.0.0.1` instead would also close the race, but it
+ * breaks supertest: a host argument sends `listen()` through an asynchronous
+ * DNS lookup, and supertest reads `app.address().port` synchronously on the
+ * next line, so it sees `null`.
+ */
+import type { AddressInfo, Server } from "node:net";
+import supertest from "supertest";
+
+type ServerAddressFn = (this: unknown, app: Server, path: string) => string;
+
+interface SupertestModule {
+  Test: { prototype: { serverAddress: ServerAddressFn } };
+}
+
+const PATCHED = Symbol.for("moveet.supertestLoopback.patched");
+
+const proto = (supertest as unknown as SupertestModule).Test.prototype as {
+  serverAddress: ServerAddressFn;
+  [PATCHED]?: boolean;
+};
+
+// vitest loads setup files once per test file, but the supertest module is
+// shared across the worker, so guard against wrapping the same function twice.
+if (!proto[PATCHED]) {
+  proto[PATCHED] = true;
+
+  const original = proto.serverAddress;
+
+  proto.serverAddress = function serverAddress(this: unknown, app: Server, path: string): string {
+    const url = original.call(this, app, path);
+    const addr = app.address() as AddressInfo | string | null;
+
+    if (addr && typeof addr === "object" && addr.family === "IPv6") {
+      return url.replace("://127.0.0.1:", "://[::1]:");
+    }
+
+    return url;
+  };
+}

--- a/apps/simulator/vitest.config.ts
+++ b/apps/simulator/vitest.config.ts
@@ -4,6 +4,14 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    // Makes supertest connect on the address family it listened on. Its own
+    // `listen(0)` binds the IPv6 wildcard but its URL is hard-coded to
+    // `127.0.0.1`, so the port it is handed may already belong to an unrelated
+    // IPv4-only listener on the machine — which is why the suite intermittently
+    // failed with "Parse Error: Expected HTTP/, RTSP/ or ICE/" under parallel
+    // load. The setup file carries the full diagnosis; do not drop it as
+    // unexplained cruft. (fleetsim-all-vtwk.13)
+    setupFiles: ["./src/__tests__/setup/supertestLoopback.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
Fixes the intermittent `Parse Error: Expected HTTP/, RTSP/ or ICE/` in the simulator suite (`fleetsim-all-vtwk.13`).

## Mechanism

Not a cross-worker race at all — a cross-*process* one, and the workers only make it frequent.

`request(app)` in supertest does two things that disagree about address family:

```js
if (!addr) this._server = app.listen(0);          // no host → binds the IPv6 wildcard `::`
return protocol + '://127.0.0.1:' + port + path;  // …then connects over IPv4
```

A hostless `listen(0)` binds `::` (dual-stack), so the kernel allocates the ephemeral port from the **IPv6** table. That table does not see sockets an unrelated process has bound **IPv4-only** on `127.0.0.1`. `listen(0)` therefore hands back a port that is already occupied on IPv4 loopback, and supertest's IPv4 connect is routed to that foreign process instead of to the test's own server.

Confirmed by dumping the raw bytes that came back on a failing connection, in a standalone reproducer (no vitest, no simulator code):

```
BAD port=55526 bytes="J\x00\x00\x00\n8.0.33\x00…mysql_native_password\x00"
BAD port=51833 bytes="ENTER PASSWORD:"
```

That is a MySQL 8.0.33 handshake greeting from an unrelated local server, not HTTP. `lsof` confirms those ports:

```
dolt  28062  TCP 127.0.0.1:59471 (LISTEN)   # IPv4 only
dolt  49613  TCP 127.0.0.1:55526 (LISTEN)
dolt  96242  TCP 127.0.0.1:54184 (LISTEN)
```

llhttp reports a non-HTTP first line as `Parse Error: Expected HTTP/, RTSP/ or ICE/`. This explains every observation in the issue: the adapter's access log showed zero requests (nothing of ours was involved), a single file run in a loop never reproduced it (too few ephemeral-port draws), and the 23 supertest files under parallel load reproduce it in a few percent of runs (hundreds of draws per run, one eventually lands on an occupied port). It also makes the unreproduced `expected 401 to be 200` plausible as the same root cause — a crossed connection to a *different* foreign HTTP-speaking listener would return a valid but wrong response — though that remains unconfirmed.

## The fix, and why this one

A vitest setup file (`src/__tests__/setup/supertestLoopback.ts`, wired via `setupFiles`) wraps `supertest.Test.prototype.serverAddress` so the URL uses `[::1]` when the server actually bound IPv6. The connect then resolves against the same table the port was allocated from, where the kernel guarantees exclusivity, so the connection can only reach our own server. It falls back to the unchanged IPv4 URL on hosts without IPv6.

Weighed against the three candidates in the issue:

- **Serialised route tests via a pool option** — would hide the race by reducing concurrency, not remove it (a single worker can still draw an occupied port), and costs suite time. Rejected.
- **Shared server per suite / explicit listen+close lifecycle** — fewer draws, so rarer, but the same collision is still possible on every one of them; also a 23-file change.
- **Binding `127.0.0.1` instead of rewriting the connect** — correct in principle, but it breaks supertest: passing a host sends `listen()` through an async DNS lookup, and supertest reads `app.address().port` on the very next line, getting `null`. Tried; it failed 352 tests. It also allocates from the much tighter IPv4 loopback space (`EADDRNOTAVAIL` under churn).

The chosen fix is address-family-correct at the exact seam where the bug lives, keeps every route test parallel, and adds no retries. Both the config entry and the setup file carry the reason inline, and `supertestLoopback.test.ts` fails loudly if the patch ever stops being applied.

## Before / after

Full simulator suite (`vitest run`, 94 files, 1968 tests, parallel default pool), on macOS with the dolt servers above running:

| | runs | failed | `Parse Error` |
|---|---|---|---|
| before | 30 | 5 | 4 |
| after | 30 | 0 | 0 |

(The 5th baseline failure was `EADDRNOTAVAIL` port exhaustion caused by my own concurrent port-stress reproducer, not by the suite.)

Targeted stress of the mechanism, 8 processes × 3000 listen/connect/close cycles each (24k cycles), same machine, back to back:

- connect over IPv4, as supertest does today: **4 crossed connections** (MySQL greeting / `ENTER PASSWORD:`)
- connect over IPv6, as with this fix: **0**

Verification: `npm run format:check`, `npm run lint`, `npm run type-check`, `npm run test` all pass.

Refs `fleetsim-all-vtwk.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gke6K2iMXPyuGLDoKWBKyt
